### PR TITLE
Blocklist: almost always a false positive

### DIFF
--- a/assets/semgrep_rules/blocklist.txt
+++ b/assets/semgrep_rules/blocklist.txt
@@ -1,3 +1,4 @@
 https://semgrep.dev/r/python.flask.security.xss.audit.template-unescaped-with-safe.template-unescaped-with-safe
 https://semgrep.dev/r/python.flask.security.xss.audit.template-href-var.template-href-var
 https://semgrep.dev/r/generic.html-templates.security.var-in-href.var-in-href
+https://semgrep.dev/r/generic.nginx.security.missing-internal.missing-internal


### PR DESCRIPTION
This location block contains a 'proxy_pass' directive but does not contain the 'internal' directive. The 'internal' directive restricts access to this location to internal requests. Without 'internal', an attacker could use your server for server-side request forgeries (SSRF). Include the 'internal' directive in this block to limit exposure.