### PR TITLE
Reporter errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,6 @@ runs:
               prnumber: context.issue.number
             }
             const result = await github.graphql(query, variables);
-            console.log(JSON.stringify(result));
             const threads = result.repository.pullRequest.reviewThreads;
             const deletableComments = threads.nodes.filter(
               reviewThread => (
@@ -221,7 +220,6 @@ runs:
               prnumber: context.issue.number
             }
             const result = await github.graphql(query, variables);
-            console.log(JSON.stringify(result));
             const threads = result.repository.pullRequest.reviewThreads;
             var commentsNumber = threads.nodes.filter(
               reviewThread => (

--- a/assets/reviewdog.sh
+++ b/assets/reviewdog.sh
@@ -14,9 +14,18 @@ if [ -n "${GITHUB_BASE_REF+set}" ]; then
     done
 
     for runner in $RUNNERS; do
-        cat $runner.log | reviewdog -reporter=github-pr-review -efm='%f:%l: %m'
+        cat $runner.log | reviewdog -reporter=github-pr-review -efm='%f:%l: %m' \
+          || cat $runner.log >> reviewdog.fail.log
         cat $runner.log >> reviewdog.log
     done
+
+    if [[ -f "reviewdog.fail.log" ]]; then
+        set +x
+        echo -e '\033[0;31mThis action encountered an error while reporting the following findings via the Github API:'
+        cat reviewdog.fail.log | sed 's/^/\x1B[0;34m/'
+        echo -e '\033[0;31mThe failure of this action should not prevent you from merging your PR. Please report this failure to the maintainers of https://github.com/brave/security-action \033[0m'
+        exit 1
+    fi
 else
     find $SCRIPTPATH/../t3sts/ | sed "s|$SCRIPTPATH/../||g" | tr '\n' '\0' > $SCRIPTPATH/all_changed_files.txt
     GITHUB_BASE_REF=initial-commit reviewdog  -runners=semgrep,safesvg -conf="$SCRIPTPATH/reviewdog/reviewdog.yml"  -diff="git diff origin/$GITHUB_BASE_REF" -reporter=local -tee


### PR DESCRIPTION
Sometimes there are issues with Github API / reviewdog. We should try to report as much as we can and then fail and explain that the action's failure can be ignored.

e.g. npm-audit can have issues because when package-lock.json diff is massive, Github does not allow comments on the diff.