### PR TITLE
Add "safebrowsing" as a hotword

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
       crypto
       login
       policy
+      safebrowsing
   debug:
     description: enables debug output for this action
     required: false


### PR DESCRIPTION
Ideally we should have "safe browsing" too, but that's not supported at the moment.