### PR TITLE
Fix for npm-audit when package.json in root

### DIFF
--- a/assets/npm-audit.py
+++ b/assets/npm-audit.py
@@ -14,7 +14,7 @@ def main():
     for lock_path in changed_lock_files:
         with open(lock_path) as lock_file:
             lock_file_lines = lock_file.readlines()
-        cwd = path.split(lock_path)[0]
+        cwd = path.split(lock_path)[0] or '.'
         stdout = subprocess.run(
             ["npm", "audit", "--package-lock-only", "--json"],
             cwd=cwd,


### PR DESCRIPTION
```
>>> os.path.split("package.json")
('', 'package.json')
>>> os.path.split("x/y/package.json")
('x/y', 'package.json')
```

https://github.com/brave/brave-core-crx-packager/actions/runs/5339275564/jobs/9677773649