### PR TITLE
no-backticks-in-js-handlers.yaml: fixes

### DIFF
--- a/assets/semgrep_rules/web/no-backticks-in-js-handlers.yaml
+++ b/assets/semgrep_rules/web/no-backticks-in-js-handlers.yaml
@@ -1,5 +1,8 @@
 rules:
   - id: no-backticks-in-js-handlers
+    metadata:
+      author: Andrea Brancaleoni @ Brave
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/web/no-backticks-in-js-handlers.yaml
     patterns:
       - pattern-either:
         - pattern-inside: $HANDLER="..."
@@ -8,10 +11,10 @@ rules:
       - pattern-regex: '`{{[^}]+}}`'
       - metavariable-regex:
           metavariable: $HANDLER
-          regex: on(abort|auxclick|beforeinput|beforematch|beforetoggle|cancel|canplay|canplaythrough|change|click|close|contextlost|contextmenu|contextrestored|copy|cuechange|cut|dblclick|drag|dragend|dragenter|dragleave|dragover|dragstart|drop|durationchange|emptied|ended|formdata|input|invalid|keydown|keypress|keyup|loadeddata|loadedmetadata|loadstart|mousedown|mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|paste|pause|play|playing|progress|ratechange|reset|securitypolicyviolation|seeked|seeking|select|slotchange|stalled|submit|suspend|timeupdate|toggle|volumechange|waiting|webkitAnimationEnd|webkitAnimationIteration|webkitAnimationStart|webkitTransitionEnd|wheel)
+          regex: (?i)on[a-z]{3,40}
     message: |
-      Backtick in JS handler may cause XSS since they are typically not auto escaped in variables.
+      Backtick in JS handler may cause XSS since they are typically not auto-escaped in variables.
 
-      Consider using single or double apices, instead of backticks.
+      Consider using single or double quotes instead of backticks.
     languages: [generic]
     severity: WARNING


### PR DESCRIPTION
- better wording
- comprehensive regex matching