### PR TITLE
Contents:read is required to clone private repos

### DIFF
--- a/.github/workflows/full-loop.yml
+++ b/.github/workflows/full-loop.yml
@@ -7,8 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 permissions:
-  # Clear all permissions as none are required just to clone repo
-  contents: none
+  contents: read
 jobs:
   full-loop:
     name: full-loop

--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 permissions:
+  contents: read
   pull-requests: write
 jobs:
   loop:

--- a/.github/workflows/semgrep-self-test.yml
+++ b/.github/workflows/semgrep-self-test.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 permissions:
-  # Clear all permissions as none are required just to clone repo
+  # This is a public repo, no permissions required to clone
   contents: none
 jobs:
   semgrep-self-test:

--- a/assets/org.yml
+++ b/assets/org.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master, staging, development, devel, dev]
 permissions:
+  contents: read
   pull-requests: write
 jobs:
   security:
@@ -15,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: brave/security-action@main


### PR DESCRIPTION
It was quite surprising that it was working with contents:none. But it was only working in security-action because it's public!!

Private repos need more permissions in the GITHUB_TOKEN.