### PR TITLE
fix mismatched-memory-management-cpp

### DIFF
--- a/assets/semgrep_rules/client/mismatched-memory-management-cpp.cpp
+++ b/assets/semgrep_rules/client/mismatched-memory-management-cpp.cpp
@@ -1,4 +1,73 @@
+// ok: raptor-mismatched-memory-management-cpp
+Blah& operator=(const Blah&) = delete;
+
 void RedeemOptedOutConfirmation::Destroy() {
   // ok: raptor-mismatched-memory-management-cpp
   delete this;
+}
+
+void bad1()
+{
+	BarObj *ptr = new BarObj()
+
+	// ruleid: raptor-mismatched-memory-management-cpp
+	free(ptr);
+}
+
+void good1()
+{
+	BarObj *ptr = new BarObj()
+
+	// ok: raptor-mismatched-memory-management-cpp
+	delete ptr;
+}
+
+class A {
+	void bad2();
+	void good2();
+};
+
+void A::bad2()
+{
+	int *ptr;
+	ptr = (int*)malloc(sizeof(int));
+
+	// ruleid: raptor-mismatched-memory-management-cpp
+	delete ptr;
+}
+
+void A::good2()
+{
+	int *ptr;
+	ptr = (int*)malloc(sizeof(int));
+
+	// ok: raptor-mismatched-memory-management-cpp
+	free(ptr);
+}
+
+class B {
+	void bad3(bool);
+	void good3();
+};
+
+void B::bad3(bool heap) {
+	int localArray[2] = { 11,22 };
+	int *p = localArray;
+
+	if (heap) {
+		p = new int[2];
+	}
+
+	// ruleid: raptor-mismatched-memory-management-cpp
+	delete[] p;
+}
+
+void B::good3() {
+	int localArray[2] = { 11,22 };
+	int *p = localArray;
+
+	p = new (std::nothrow) int[2];
+
+	// ok: raptor-mismatched-memory-management-cpp
+	delete[] p;
 }

--- a/assets/semgrep_rules/client/mismatched-memory-management-cpp.yaml
+++ b/assets/semgrep_rules/client/mismatched-memory-management-cpp.yaml
@@ -12,6 +12,7 @@ rules:
       # are not covered.
       # NOTE: overloaded operators, VirtualAlloc()/VirtualFree(),
       # mmap()/munmap() are not covered.
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/client/mismatched-memory-management-cpp.yaml
     message: >-
       The software attempts to return a memory resource to the system, but
       it calls a release function that is not compatible with the function
@@ -69,6 +70,9 @@ rules:
             ...
             delete[]($PTR);
         - pattern-not: delete[](this);
+        - metavariable-regex:
+            metavariable: $PTR
+            regex: .
       # delete
       - patterns:
         - pattern: delete($PTR);
@@ -77,6 +81,9 @@ rules:
             ...
             delete($PTR);
         - pattern-not: delete(this);
+        - metavariable-regex:
+            metavariable: $PTR
+            regex: .
       - patterns:
         - pattern: delete($PTR);
         - pattern-inside: |
@@ -84,3 +91,6 @@ rules:
             ...
             delete($PTR);
         - pattern-not: delete(this);
+        - metavariable-regex:
+            metavariable: $PTR
+            regex: .


### PR DESCRIPTION
C++ was matching 'delete;'.

This is for removing the default implementation inherited from a base class rather than a memory error.

Prevent this particular false positive.

Closes #342 