### PR TITLE
Some semgrep rules were missing metadata.source

### DIFF
--- a/assets/semgrep_rules/client/signed-unsigned-conversion.yaml
+++ b/assets/semgrep_rules/client/signed-unsigned-conversion.yaml
@@ -15,6 +15,7 @@ rules:
         - http://www.phrack.org/issues/60/10.html#article
         - https://docs.microsoft.com/en-us/cpp/sanitizers/asan-error-examples
       confidence: MEDIUM
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/client/signed-unsigned-conversion.yaml
     message: The software uses a signed primitive and performs a cast to an unsigned
       primitive, or uses an unsigned primitive and performs a cast to a signed
       primitive, which can produce an unexpected value if the value of the

--- a/assets/semgrep_rules/services/detected-aws-access-key-id-value.yaml
+++ b/assets/semgrep_rules/services/detected-aws-access-key-id-value.yaml
@@ -31,3 +31,4 @@ rules:
       likelihood: LOW
       impact: HIGH
       license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/services/detected-aws-access-key-id-value.yaml

--- a/assets/semgrep_rules/services/missing-integrity.yaml
+++ b/assets/semgrep_rules/services/missing-integrity.yaml
@@ -15,6 +15,7 @@ rules:
     - audit
     likelihood: LOW
     impact: LOW
+    source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/services/missing-integrity.yaml
   patterns:
   - pattern-either:
     - pattern: <script $...A >...</script>

--- a/assets/semgrep_rules/services/not-using-hasownproperty-proto-access.yaml
+++ b/assets/semgrep_rules/services/not-using-hasownproperty-proto-access.yaml
@@ -16,4 +16,5 @@ rules:
       category: security
       references:
         - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/services/not-using-hasownproperty-proto-access.yaml
 


### PR DESCRIPTION
`for f in $(find . -type f -name '*.yaml'); do grep -q 'source: ' $f || echo $f; done`