### PR TITLE
brave-third-party-action-not-pinned-to-commit-sha.yaml: allowlist `slackapi`

### DIFF
--- a/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
+++ b/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
@@ -54,7 +54,9 @@ jobs:
       - uses: github/test@v1
       # ok: brave-third-party-action-not-pinned-to-commit-sha
       - uses: ruby/setup-ruby@v1
- 
+      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      - uses: slackapi/slack-github-action@v1.24.0
+      
       # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: fakerepo/comment-on-pr
         with:

--- a/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
+++ b/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
@@ -16,6 +16,7 @@ rules:
             - pattern-not-regex: ^github/
             - pattern-not-regex: ^aws-actions/
             - pattern-not-regex: ^ruby/
+            - pattern-not-regex: ^slackapi/
             - pattern-not-regex: "@[0-9a-f]{40}$"
             - pattern-not-regex: ^docker://.*@sha256:[0-9a-f]{64}$
     message: An action sourced from a third-party repository on GitHub is not pinned


### PR DESCRIPTION


Resolves: https://github.com/brave/security-action/issues/332