### PR TITLE
[[fallthrough]];

### DIFF
--- a/assets/semgrep_rules/client/brave-missing-break-in-switch.yaml
+++ b/assets/semgrep_rules/client/brave-missing-break-in-switch.yaml
@@ -53,3 +53,5 @@ rules:
           switch ($VAR) { case $VAL1: NOTREACHED_NORETURN(); case $VAL2: ... }
       - pattern-not: |
           switch ($VAR) { case $VAL1: ... NOTREACHED_NORETURN(); case $VAL2: ... }
+      # [[fallthrough]];
+      - pattern-not-regex: '\[\[fallthrough\]\];'


### PR DESCRIPTION
Not fully supported by semgrep, so cannot test fully. This is because semgrep's C/C++ support isn't great.

Fixes #368

If this causes further issues, we should remove the rule.