### PR TITLE
semgrep rules: January 2024 Update

### DIFF
--- a/assets/semgrep_rules/generated/nonfree/audit.yaml
+++ b/assets/semgrep_rules/generated/nonfree/audit.yaml
@@ -375,104 +375,6 @@ rules:
   languages:
   - c
   severity: WARNING
-- id: contrib.nodejsscan.crypto_node.node_md5
-  message: The MD5 hashing algorithm is considered to be weak. If this is used in
-    any sensitive operation such as password hashing, or is used to ensure data integrity
-    (collision sensitive) then you should use a stronger hashing algorithm. For passwords,
-    consider using `Argon2id`, `scrypt`, or `bcrypt`. For data integrity, consider
-    using `SHA-256`
-  severity: WARNING
-  metadata:
-    likelihood: LOW
-    impact: MEDIUM
-    confidence: LOW
-    category: security
-    cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
-    owasp:
-    - A03:2017 - Sensitive Data Exposure
-    - A02:2021 - Cryptographic Failures
-    references:
-    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
-    subcategory:
-    - audit
-    technology:
-    - node.js
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Cryptographic Issues
-    source: https://semgrep.dev/r/contrib.nodejsscan.crypto_node.node_md5
-    shortlink: https://sg.run/dKBX
-    semgrep.dev:
-      rule:
-        rule_id: GdU75E
-        version_id: 7ZTgoEl
-        url: https://semgrep.dev/playground/r/7ZTgoEl/contrib.nodejsscan.crypto_node.node_md5
-        origin: community
-  languages:
-  - javascript
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern-either:
-      - pattern: '"md5"
-
-          '
-      - pattern: '"MD5"
-
-          '
-  pattern-sinks:
-  - patterns:
-    - pattern-inside: "$CRYPTO.createHash(...)\n"
-- id: contrib.nodejsscan.crypto_node.node_sha1
-  message: The SHA1 hashing algorithm is considered to be weak. If this is used in
-    any sensitive operation such as password hashing, or is used to ensure data integrity
-    (collision sensitive) then you should use a stronger hashing algorithm. For passwords,
-    consider using `Argon2id`, `scrypt`, or `bcrypt`. For data integrity, consider
-    using `SHA-256`
-  severity: WARNING
-  metadata:
-    likelihood: LOW
-    impact: MEDIUM
-    confidence: LOW
-    category: security
-    cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
-    owasp:
-    - A03:2017 - Sensitive Data Exposure
-    - A02:2021 - Cryptographic Failures
-    references:
-    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
-    subcategory:
-    - audit
-    technology:
-    - node.js
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Cryptographic Issues
-    source: https://semgrep.dev/r/contrib.nodejsscan.crypto_node.node_sha1
-    shortlink: https://sg.run/ZvEx
-    semgrep.dev:
-      rule:
-        rule_id: ReUgYx
-        version_id: LjTqQkn
-        url: https://semgrep.dev/playground/r/LjTqQkn/contrib.nodejsscan.crypto_node.node_sha1
-        origin: community
-  languages:
-  - javascript
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern-either:
-      - pattern: '"SHA1"
-
-          '
-      - pattern: '"sha1"
-
-          '
-  pattern-sinks:
-  - patterns:
-    - pattern-inside: "$CRYPTO.createHash(...)\n"
 - id: csharp.dotnet.security.mvc-missing-antiforgery.mvc-missing-antiforgery
   message: "$METHOD is a state-changing MVC method that does not validate the antiforgery
     token or do strict content-type checking. State-changing controller methods should
@@ -9905,17 +9807,17 @@ rules:
       - pattern-not: java.lang.Short
 - id: java.servlets.security.cookie-issecure-false.cookie-issecure-false
   patterns:
-  - pattern: "$COOKIE = new Cookie(...);\n"
+  - pattern: "$COOKIE = new Cookie($...ARGS);"
   - pattern-not-inside: |
       $COOKIE = new Cookie(...);
       ...
-      $COOKIE.setSecure(true);
+      $COOKIE.setSecure(...);
   message: 'Default session middleware settings: `setSecure` not set to true. This
     ensures that the cookie is sent only over HTTPS to prevent cross-site scripting
     attacks.'
-  fix-regex:
-    regex: setSecure\(false\)
-    replacement: setSecure(true)
+  fix: |
+    $COOKIE = new Cookie($...ARGS);
+    $COOKIE.setSecure(true);
   metadata:
     vulnerability: Insecure Transport
     owasp:
@@ -9924,11 +9826,12 @@ rules:
     cwe:
     - 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
-    - https://tomcat.apache.org/tomcat-5.5-doc/servletapi/
+    - https://docs.oracle.com/javaee/6/api/javax/servlet/http/Cookie.html#setSecure(boolean)
+    - https://owasp.org/www-community/controls/SecureCookieAttribute
     category: security
     technology:
-    - servlet
-    - tomcat
+    - java
+    - cookie
     subcategory:
     - audit
     likelihood: LOW
@@ -9942,8 +9845,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: kxUkn9
-        version_id: gET3xdQ
-        url: https://semgrep.dev/playground/r/gET3xdQ/java.servlets.security.cookie-issecure-false.cookie-issecure-false
+        version_id: xyTvPr0
+        url: https://semgrep.dev/playground/r/xyTvPr0/java.servlets.security.cookie-issecure-false.cookie-issecure-false
         origin: community
   languages:
   - java
@@ -14837,6 +14740,101 @@ rules:
   - metavariable-comparison:
       metavariable: "$BITS"
       comparison: "$BITS < 2048"
+- id: ocaml.lang.security.hashtable-dos.ocamllint-hashtable-dos
+  patterns:
+  - pattern: Hashtbl.create $Y
+  - pattern-not: Hashtbl.create $Y ~random:true
+  message: Creating a Hashtbl without the optional random number parameter makes it
+    prone to DoS attacks when attackers are able to fill the table with malicious
+    content. Hashtbl.randomize or the R flag in the OCAMLRUNPARAM are other ways to
+    randomize it.
+  languages:
+  - ocaml
+  severity: WARNING
+  metadata:
+    category: security
+    references:
+    - https://v2.ocaml.org/api/Hashtbl.html
+    technology:
+    - ocaml
+    cwe: 'CWE-399: Resource Management Errors (4.12)'
+    confidence: LOW
+    likelihood: LOW
+    impact: LOW
+    subcategory:
+    - audit
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/ocaml.lang.security.hashtable-dos.ocamllint-hashtable-dos
+    shortlink: https://sg.run/OrPrk
+    semgrep.dev:
+      rule:
+        rule_id: qNU2j21
+        version_id: jQTlK0B
+        url: https://semgrep.dev/playground/r/jQTlK0B/ocaml.lang.security.hashtable-dos.ocamllint-hashtable-dos
+        origin: community
+- id: ocaml.lang.security.unsafe.ocamllint-unsafe
+  pattern-either:
+  - pattern: "$X.unsafe_get"
+  - pattern: "$X.unsafe_set"
+  - pattern: "$X.unsafe_to_string"
+  - pattern: "$X.unsafe_of_string"
+  - pattern: "$X.unsafe_blit"
+  - pattern: "$X.unsafe_blit_string"
+  - pattern: "$X.unsafe_fill"
+  - pattern: "$X.unsafe_to_string"
+  - pattern: "$X.unsafe_getenv"
+  - pattern: "$X.unsafe_environment"
+  - pattern: "$X.unsafe_chr"
+  - pattern: "$X.unsafe_of_int"
+  - pattern: "$X.unsafe_output"
+  - pattern: "$X.unsafe_output_string"
+  - pattern: "$X.unsafe_read"
+  - pattern: "$X.unsafe_recv"
+  - pattern: "$X.unsafe_recvfrom"
+  - pattern: "$X.unsafe_send"
+  - pattern: "$X.unsafe_sendto"
+  - pattern: "$X.unsafe_set"
+  - pattern: "$X.unsafe_set_int16"
+  - pattern: "$X.unsafe_set_int32"
+  - pattern: "$X.unsafe_set_int64"
+  - pattern: "$X.unsafe_set_int8"
+  - pattern: "$X.unsafe_set_uint16_ne"
+  - pattern: "$X.unsafe_set_uint8"
+  - pattern: "$X.unsafe_single_write"
+  - pattern: "$X.unsafe_string"
+  - pattern: "$X.unsafe_sub"
+  - pattern: "$X.unsafe_write"
+  message: Unsafe functions do not perform boundary checks or have other side effects,
+    use with care.
+  languages:
+  - ocaml
+  severity: WARNING
+  metadata:
+    category: security
+    references:
+    - https://v2.ocaml.org/api/Bigarray.Array1.html#VALunsafe_get
+    - https://v2.ocaml.org/api/Bytes.html#VALunsafe_to_string
+    technology:
+    - ocaml
+    cwe: 'CWE-242: Use of Inherently Dangerous Function (4.12)'
+    confidence: MEDIUM
+    likelihood: MEDIUM
+    impact: MEDIUM
+    subcategory:
+    - audit
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/ocaml.lang.security.unsafe.ocamllint-unsafe
+    shortlink: https://sg.run/d8K80
+    semgrep.dev:
+      rule:
+        rule_id: 6JUvjv6
+        version_id: LjT7Zeo
+        url: https://semgrep.dev/playground/r/LjT7Zeo/ocaml.lang.security.unsafe.ocamllint-unsafe
+        origin: community
 - id: php.doctrine.security.audit.doctrine-dbal-dangerous-query.doctrine-dbal-dangerous-query
   languages:
   - php
@@ -16339,8 +16337,10 @@ rules:
       airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
 - id: python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
   pattern: cryptography.hazmat.primitives.ciphers.modes.ECB(...)
-  message: Detected ECB cipher mode which is considered insecure. The algorithm can
-    potentially leak information about the plaintext. Use CBC mode instead.
+  message: ECB (Electronic Code Book) is the simplest mode of operation for block
+    ciphers.  Each block of data is encrypted in the same way.  This means identical
+    plaintext blocks will always result in identical ciphertext blocks, which can
+    leave significant patterns in the output. Use a different, more secure mode instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L101
     cwe:
@@ -16350,6 +16350,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     bandit-code: B305
     references:
+    - https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#insecure-modes
     - https://crypto.stackexchange.com/questions/20941/why-shouldnt-i-use-ecb-encryption
     category: security
     technology:
@@ -16359,6 +16360,8 @@ rules:
     likelihood: LOW
     impact: LOW
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::mode::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -16367,8 +16370,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: DbUp5g
-        version_id: X0TQxbJ
-        url: https://semgrep.dev/playground/r/X0TQxbJ/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
+        version_id: 0bTyOx2
+        url: https://semgrep.dev/playground/r/0bTyOx2/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
         origin: community
   severity: WARNING
   languages:
@@ -16407,6 +16410,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::key-length::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -16415,8 +16420,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: qNUjZ3
-        version_id: yeTR2Jb
-        url: https://semgrep.dev/playground/r/yeTR2Jb/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
+        version_id: YDTNPqv
+        url: https://semgrep.dev/playground/r/YDTNPqv/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
         origin: community
   languages:
   - python
@@ -16441,6 +16446,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
     references:
+    - https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/
     - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
     category: security
     technology:
@@ -16450,6 +16456,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::key-length::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -16458,8 +16466,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: lBU9jn
-        version_id: rxTyLZR
-        url: https://semgrep.dev/playground/r/rxTyLZR/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+        version_id: JdT5g1p
+        url: https://semgrep.dev/playground/r/JdT5g1p/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
         origin: community
   languages:
   - python
@@ -30717,62 +30725,6 @@ rules:
         rule_id: eqUvZ9
         version_id: K3TvG8r
         url: https://semgrep.dev/playground/r/K3TvG8r/yaml.docker-compose.security.exposing-docker-socket-volume.exposing-docker-socket-volume
-        origin: community
-  languages:
-  - yaml
-  severity: WARNING
-- id: yaml.docker-compose.security.no-new-privileges.no-new-privileges
-  patterns:
-  - pattern-inside: |
-      version: ...
-      ...
-      services:
-        ...
-  - pattern: |
-      $SERVICE:
-        ...
-        image: ...
-  - pattern-not: |
-      $SERVICE:
-        ...
-        image: ...
-        ...
-        security_opt:
-          - ...
-          - no-new-privileges:true
-          - ...
-  - focus-metavariable: "$SERVICE"
-  message: Service '$SERVICE' allows for privilege escalation via setuid or setgid
-    binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
-  metadata:
-    cwe:
-    - 'CWE-732: Incorrect Permission Assignment for Critical Resource'
-    owasp:
-    - A05:2021 - Security Misconfiguration
-    - A06:2017 - Security Misconfiguration
-    references:
-    - https://raesene.github.io/blog/2019/06/01/docker-capabilities-and-no-new-privs/
-    - https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
-    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4-add-no-new-privileges-flag
-    category: security
-    technology:
-    - docker-compose
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: HIGH
-    confidence: LOW
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Improper Authorization
-    source: https://semgrep.dev/r/yaml.docker-compose.security.no-new-privileges.no-new-privileges
-    shortlink: https://sg.run/0n8q
-    semgrep.dev:
-      rule:
-        rule_id: qNUoWr
-        version_id: qkT2BLp
-        url: https://semgrep.dev/playground/r/qkT2BLp/yaml.docker-compose.security.no-new-privileges.no-new-privileges
         origin: community
   languages:
   - yaml

--- a/assets/semgrep_rules/generated/nonfree/security_noaudit_novuln.yaml
+++ b/assets/semgrep_rules/generated/nonfree/security_noaudit_novuln.yaml
@@ -1,40 +1,5 @@
 ---
 rules:
-- id: contrib.dlint.dlint-equivalent.insecure-xml-use
-  message: Insecure XML parsing functionality, prefer 'defusedxml'
-  languages:
-  - python
-  severity: WARNING
-  metadata:
-    source_rule_url: https://github.com/dlint-py/dlint/blob/master/docs/linters/DUO107.md
-    category: security
-    technology:
-    - python
-    references:
-    - https://github.com/dlint-py/dlint/blob/master/docs/linters/DUO107.md
-    owasp:
-    - A09:2017 - Using Components with Known Vulnerabilities
-    - A06:2021 - Vulnerable and Outdated Components
-    cwe:
-    - 'CWE-611: Improper Restriction of XML External Entity Reference'
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - XML Injection
-    source: https://semgrep.dev/r/contrib.dlint.dlint-equivalent.insecure-xml-use
-    shortlink: https://sg.run/5QOW
-    semgrep.dev:
-      rule:
-        rule_id: zdUkvA
-        version_id: DkT6nYQ
-        url: https://semgrep.dev/playground/r/DkT6nYQ/contrib.dlint.dlint-equivalent.insecure-xml-use
-        origin: community
-  pattern-either:
-  - patterns:
-    - pattern: xml.$ANYTHING
-    - pattern-not: xml.sax.saxutils
-    - pattern-not: xml.etree.ElementTree.Element
-    - pattern-not: xml.etree.ElementTree.SubElement
-  - pattern: xmlrpclib.$ANYTHING
 - id: go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
   message: "`MinVersion` is missing from this TLS configuration.  By default, TLS
     1.2 is currently used as the minimum when acting as a client, and TLS 1.0 when
@@ -153,6 +118,15 @@ rules:
 - id: python.django.security.django-no-csrf-token.django-no-csrf-token
   patterns:
   - pattern: "<form...>...</form>"
+  - pattern-either:
+    - pattern: '<form ... method="$METHOD" ...>...</form>
+
+        '
+    - pattern: "<form ... method='$METHOD' ...>...</form>\n"
+    - pattern: "<form ... method=$METHOD ...>...</form>\n"
+  - metavariable-regex:
+      metavariable: "$METHOD"
+      regex: "(?i)(post|put|delete|patch)"
   - pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
   message: Manually-created forms in django templates should specify a csrf_token
     to prevent CSRF attacks
@@ -179,8 +153,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: PeUyYG
-        version_id: K3TvKZG
-        url: https://semgrep.dev/playground/r/K3TvKZG/python.django.security.django-no-csrf-token.django-no-csrf-token
+        version_id: 9lTez9q
+        url: https://semgrep.dev/playground/r/9lTez9q/python.django.security.django-no-csrf-token.django-no-csrf-token
         origin: community
   paths:
     include:

--- a/assets/semgrep_rules/generated/nonfree/vulns.yaml
+++ b/assets/semgrep_rules/generated/nonfree/vulns.yaml
@@ -400,78 +400,6 @@ rules:
   - metavariable-regex:
       metavariable: "$ALGO"
       regex: (((org\.apache\.commons\.codec\.digest\.)?MessageDigestAlgorithms/)?"?(SHA-1|SHA1)"?)
-- id: contrib.owasp.java.xxe.documentbuilderfactory.owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
-  message: DocumentBuilderFactory being instantiated without calling the setFeature
-    functions that are generally used for disabling entity processing, which can allow
-    for XXE vulnerabilities
-  metadata:
-    cwe: 'CWE-611: Improper Restriction of XML External Entity Reference'
-    owasp: A04:2017 - XML External Entities (XXE)
-    source-rule-url: https://cheatsheetseries.owasp.org//cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-    category: security
-    technology:
-    - java
-    - xml
-    cwe2022-top25: true
-    cwe2021-top25: true
-    references:
-    - https://www.programcreek.com/java-api-examples/?api=javax.xml.parsers.DocumentBuilderFactory
-    likelihood: LOW
-    impact: HIGH
-    subcategory:
-    - vuln
-    confidence: HIGH
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - XML Injection
-    source: https://semgrep.dev/r/contrib.owasp.java.xxe.documentbuilderfactory.owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
-    shortlink: https://sg.run/gLbR
-    semgrep.dev:
-      rule:
-        rule_id: 0oU5Dw
-        version_id: 3ZTkQWk
-        url: https://semgrep.dev/playground/r/3ZTkQWk/contrib.owasp.java.xxe.documentbuilderfactory.owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
-        origin: community
-  severity: ERROR
-  patterns:
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          DocumentBuilderFactory $DBF =  ... ;
-          ...
-      - pattern-inside: |
-          DocumentBuilder $DB = $DBF.newDocumentBuilder();
-          ...
-      - pattern: "$DB.parse(...);\n"
-    - patterns:
-      - pattern-inside: |
-          (DocumentBuilder $DB) = (DocumentBuilderFactory $DBF).newDocumentBuilder();
-          ...
-      - pattern: "(DocumentBuilder $DB).parse(...);\n"
-    - pattern: DocumentBuilder $DB = DocumentBuilderFactory. ... .newInstance(). ...
-        .newDocumentBuilder();
-  - pattern-not:
-      patterns:
-      - pattern-inside: |
-          DocumentBuilderFactory $DBF =  ... ;
-          ...
-      - pattern-inside: |
-          $DBF. ... .setXIncludeAware(true);
-          ...
-      - pattern-inside: |
-          $DBF. ... .setNamespaceAware(true);
-          ...
-      - pattern-inside: |
-          $DBF. ... .setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-          ...
-      - pattern-inside: |
-          $DBF. ... .setFeature("http://xml.org/sax/features/external-general-entities", false);
-          ...
-      - pattern-inside: |
-          $DBF. ... .setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-          ...
-  languages:
-  - java
 - id: csharp.dotnet.security.audit.ldap-injection.ldap-injection
   message: LDAP queries are constructed dynamically on user-controlled input. This
     vulnerability in code could lead to an arbitrary LDAP query execution.
@@ -4394,6 +4322,47 @@ rules:
         origin: community
   patterns:
   - pattern-regex: "(?i)[a-z0-9]{14}\\.atlasv1\\.[a-z0-9\\-_=]{60,70}"
+- id: generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
+  message: A gitleaks hashicorp-tf-password was detected which attempts to identify
+    hard-coded credentials. It is not recommended to store credentials in source-code,
+    as this risks secrets being leaked and used by either an internal or external
+    malicious adversary. It is recommended to use environment variables to securely
+    provide credentials or retrieve credentials from a secure vault or HSM (Hardware
+    Security Module).
+  languages:
+  - regex
+  severity: INFO
+  metadata:
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    cwe2021-top25: true
+    cwe2022-top25: true
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+    source-rule-url: https://github.com/zricethezav/gitleaks/tree/master/cmd/generate/config/rules
+    subcategory:
+    - vuln
+    technology:
+    - gitleaks
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Hard-coded Secrets
+    source: https://semgrep.dev/r/generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
+    shortlink: https://sg.run/bw7lv
+    semgrep.dev:
+      rule:
+        rule_id: BYUXNWY
+        version_id: kbTgNPD
+        url: https://semgrep.dev/playground/r/kbTgNPD/generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
+        origin: community
+  patterns:
+  - pattern-regex: (?i)(?:administrator_login_password|password)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)
 - id: generic.secrets.gitleaks.heroku-api-key.heroku-api-key
   message: A gitleaks heroku-api-key was detected which attempts to identify hard-coded
     credentials. It is not recommended to store credentials in source-code, as this
@@ -19072,8 +19041,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: WAUon7
-        version_id: K3TvjWe
-        url: https://semgrep.dev/playground/r/K3TvjWe/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
+        version_id: e1TgQKG
+        url: https://semgrep.dev/playground/r/e1TgQKG/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
         origin: community
   languages:
   - javascript
@@ -19082,24 +19051,16 @@ rules:
   mode: taint
   pattern-sources:
   - patterns:
+    - pattern: "$X = '...' \n"
+    - pattern: "$X = '$Y' \n"
+  - patterns:
     - pattern-either:
-      - patterns:
-        - pattern-inside: "$VALUE = '$Y' \n...\n"
-        - pattern: "$VALUE"
-      - patterns:
-        - pattern-either:
-          - pattern-inside: "$JWT.sign($VALUE, $Y,...)"
-          - pattern-inside: "$JWT.verify($VALUE, $Y,...)"
-        - focus-metavariable: "$Y"
-        - pattern: "'...'\n"
-      - patterns:
-        - pattern-inside: |
-            $SECRET = "$Y"
-            ...
-            class $FUNC {
-              ...
-            }
-        - pattern: "$SECRET"
+      - pattern-inside: '$JWT.sign($DATA,"...",...);
+
+          '
+      - pattern-inside: '$JWT.verify($DATA,"...",...);
+
+          '
   pattern-sinks:
   - patterns:
     - pattern-either:
@@ -20805,6 +20766,7 @@ rules:
   - pattern: "$_POST"
   pattern-sinks:
   - pattern: echo ...;
+  - pattern: print(...);
   pattern-sanitizers:
   - pattern: isset(...)
   - pattern: empty(...)
@@ -20841,8 +20803,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: BYUyyg
-        version_id: 0bTLlzv
-        url: https://semgrep.dev/playground/r/0bTLlzv/php.lang.security.injection.echoed-request.echoed-request
+        version_id: 8KT4RlJ
+        url: https://semgrep.dev/playground/r/8KT4RlJ/php.lang.security.injection.echoed-request.echoed-request
         origin: community
 - id: php.lang.security.injection.tainted-filename.tainted-filename
   severity: WARNING
@@ -21201,8 +21163,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: qNUXdL
-        version_id: l4T4v0Q
-        url: https://semgrep.dev/playground/r/l4T4v0Q/php.lang.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: RGTevOe
+        url: https://semgrep.dev/playground/r/RGTevOe/php.lang.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -21227,20 +21189,19 @@ rules:
           metavariable: "$SQLSTR"
           regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*"
     - patterns:
-      - pattern: '"...{$EXPR}..."
-
-          '
-      - pattern-regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*\n"
-    - patterns:
       - pattern: '"...$EXPR..."
 
           '
-      - pattern-regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*\n"
+      - metavariable-regex:
+          metavariable: "$EXPR"
+          regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*"
     - patterns:
-      - pattern: '"...".$EXPR
+      - pattern: '"$SQLSTR".$EXPR
 
           '
-      - pattern-regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*\n"
+      - metavariable-regex:
+          metavariable: "$SQLSTR"
+          regex: ".*\\b(?i)(select|delete|insert|create|update|alter|drop)\\b.*"
 - id: php.lang.security.injection.tainted-url-host.tainted-url-host
   languages:
   - php
@@ -22501,8 +22462,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: j2Uv2K
-        version_id: qkT2xZx
-        url: https://semgrep.dev/playground/r/qkT2xZx/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions1.disallow-old-tls-versions1
+        version_id: d6TqD0o
+        url: https://semgrep.dev/playground/r/d6TqD0o/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions1.disallow-old-tls-versions1
         origin: community
   languages:
   - java
@@ -22524,6 +22485,14 @@ rules:
   - pattern-not: 'new SSLConnectionSocketFactory(..., new String[] {"TLSv1.2"}, ...);
 
       '
+  - pattern-not-inside: "(SSLConnectionSocketFactory $SF) = new SSLConnectionSocketFactory(...);
+      ... (TlsConfig $TLSCONFIG) = TlsConfig.custom(). ... .setSupportedProtocols(TLS.V_1_2).
+      ... .build(); ... HttpClientConnectionManager cm = $CM.create(). ... .setSSLSocketFactory($SF).
+      ... .setDefaultTlsConfig($TLSCONFIG). ... .build();\n"
+  - pattern-not-inside: "(SSLConnectionSocketFactory $SF) = new SSLConnectionSocketFactory(...);
+      ... (TlsConfig $TLSCONFIG) = TlsConfig.custom(). ... .setSupportedProtocols(TLS.V_1_3).
+      ... .build(); ... HttpClientConnectionManager cm = $CM.create(). ... .setSSLSocketFactory($SF).
+      ... .setDefaultTlsConfig($TLSCONFIG). ... .build();\n"
 - id: problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions2.disallow-old-tls-versions2
   message: Detects setting client protocols to insecure versions of TLS and SSL. These
     protocols are deprecated due to POODLE, man in the middle attacks, and other vulnerabilities.
@@ -24677,8 +24646,6 @@ rules:
     - https://cwe.mitre.org/data/definitions/327.html
     - https://cwe.mitre.org/data/definitions/310.html
     category: security
-    technology:
-    - python
     subcategory:
     - vuln
     likelihood: MEDIUM
@@ -24686,6 +24653,13 @@ rules:
     confidence: MEDIUM
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     owasp: A6:2017 misconfiguration
+    functional-categories:
+    - crypto::search::key-length::pycrypto
+    - crypto::search::key-length::pycryptodome
+    technology:
+    - python
+    - pycrypto
+    - pycryptodome
     vulnerability_class:
     - Cryptographic Issues
     source: https://semgrep.dev/r/python.cryptography.security.empty-aes-key.empty-aes-key
@@ -24693,13 +24667,14 @@ rules:
     semgrep.dev:
       rule:
         rule_id: OrUADK
-        version_id: o5Tgl0L
-        url: https://semgrep.dev/playground/r/o5Tgl0L/python.cryptography.security.empty-aes-key.empty-aes-key
+        version_id: A8TkYjr
+        url: https://semgrep.dev/playground/r/A8TkYjr/python.cryptography.security.empty-aes-key.empty-aes-key
         origin: community
 - id: python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
   pattern: cryptography.hazmat.primitives.ciphers.algorithms.ARC4(...)
-  message: Detected ARC4 cipher algorithm which is considered insecure. The algorithm
-    is considered weak and has been deprecated. Use AES instead.
+  message: ARC4 (Alleged RC4) is a stream cipher with serious weaknesses in its initial
+    stream output.  Its use is strongly discouraged. ARC4 does not use mode constructions.
+    Use a strong symmetric cipher such as EAS instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
     cwe:
@@ -24709,7 +24684,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     bandit-code: B304
     references:
-    - https://tools.ietf.org/html/rfc5469
+    - https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#weak-ciphers
     category: security
     technology:
     - cryptography
@@ -24718,6 +24693,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::symmetric-algorithm::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24726,16 +24703,17 @@ rules:
     semgrep.dev:
       rule:
         rule_id: KxU8gK
-        version_id: zyTK8pN
-        url: https://semgrep.dev/playground/r/zyTK8pN/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
+        version_id: BjTxYWN
+        url: https://semgrep.dev/playground/r/BjTxYWN/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
         origin: community
   severity: WARNING
   languages:
   - python
 - id: python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
   pattern: cryptography.hazmat.primitives.ciphers.algorithms.Blowfish(...)
-  message: Detected Blowfish cipher algorithm which is considered insecure. The algorithm
-    is considered weak and has been deprecated. Use AES instead.
+  message: Blowfish is a block cipher developed by Bruce Schneier. It is known to
+    be susceptible to attacks when using weak keys.  The author has recommended that
+    users of Blowfish move to newer algorithms such as AES.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
     cwe:
@@ -24745,6 +24723,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     bandit-code: B304
     references:
+    - https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#weak-ciphers
     - https://tools.ietf.org/html/rfc5469
     category: security
     technology:
@@ -24754,6 +24733,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::symmetric-algorithm::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24762,16 +24743,19 @@ rules:
     semgrep.dev:
       rule:
         rule_id: qNULvO
-        version_id: pZT1yKA
-        url: https://semgrep.dev/playground/r/pZT1yKA/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
+        version_id: DkTq8dW
+        url: https://semgrep.dev/playground/r/DkTq8dW/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
         origin: community
   severity: WARNING
   languages:
   - python
 - id: python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
   pattern: cryptography.hazmat.primitives.ciphers.algorithms.IDEA(...)
-  message: Detected IDEA cipher algorithm which is considered insecure. The algorithm
-    is considered weak and has been deprecated. Use AES instead.
+  message: IDEA (International Data Encryption Algorithm) is a block cipher created
+    in 1991.  It is an optional component of the OpenPGP standard. This cipher is
+    susceptible to attacks when using weak keys.  It is recommended that you do not
+    use this cipher for new applications. Use a strong symmetric cipher such as EAS
+    instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
     cwe:
@@ -24782,6 +24766,7 @@ rules:
     bandit-code: B304
     references:
     - https://tools.ietf.org/html/rfc5469
+    - https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.IDEA
     category: security
     technology:
     - cryptography
@@ -24790,6 +24775,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::symmetric-algorithm::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24798,8 +24785,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: BYUNPg
-        version_id: 2KTzrgw
-        url: https://semgrep.dev/playground/r/2KTzrgw/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
+        version_id: WrTOxzP
+        url: https://semgrep.dev/playground/r/WrTOxzP/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
         origin: community
   severity: WARNING
   languages:
@@ -24818,6 +24805,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     bandit-code: B303
     references:
+    - https://cryptography.io/en/latest/hazmat/primitives/cryptographic-hashes/#md5
     - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
     - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
     - http://2012.sharcs.org/slides/stevens.pdf
@@ -24830,6 +24818,8 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::symmetric-algorithm::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24838,8 +24828,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: lBUopp
-        version_id: jQTgYbL
-        url: https://semgrep.dev/playground/r/jQTgYbL/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+        version_id: K3Tny25
+        url: https://semgrep.dev/playground/r/K3Tny25/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
         origin: community
   severity: WARNING
   languages:
@@ -24868,6 +24858,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     bandit-code: B303
     references:
+    - https://cryptography.io/en/latest/hazmat/primitives/cryptographic-hashes/#sha-1
     - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
     - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
     - http://2012.sharcs.org/slides/stevens.pdf
@@ -24880,6 +24871,8 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::symmetric-algorithm::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24888,8 +24881,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: 0oU5dN
-        version_id: 1QTOY9n
-        url: https://semgrep.dev/playground/r/1QTOY9n/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+        version_id: qkT5qYQ
+        url: https://semgrep.dev/playground/r/qkT5qYQ/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
         origin: community
   severity: WARNING
   languages:
@@ -24914,6 +24907,8 @@ rules:
     - A02:2021 - Cryptographic Failures
     source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
     references:
+    - https://www.cosic.esat.kuleuven.be/ecrypt/ecrypt2/documents/D.SPA.20.pdf
+    - https://cryptography.io/en/latest/hazmat/primitives/asymmetric/dsa/
     - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
     category: security
     technology:
@@ -24923,6 +24918,8 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    functional-categories:
+    - crypto::search::key-length::cryptography
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -24931,8 +24928,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: KxUb0x
-        version_id: 9lTdWg8
-        url: https://semgrep.dev/playground/r/9lTdWg8/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+        version_id: l4TlPQX
+        url: https://semgrep.dev/playground/r/l4TlPQX/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
         origin: community
   languages:
   - python
@@ -30520,8 +30517,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: yyUn6Z
-        version_id: BjTXrEG
-        url: https://semgrep.dev/playground/r/BjTXrEG/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
+        version_id: yeT3XWe
+        url: https://semgrep.dev/playground/r/yeT3XWe/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
         origin: community
   languages:
   - python
@@ -30538,6 +30535,9 @@ rules:
         def $F(..., $VAR=$EMPTY, ...):
           ...
           $MODEL.set_password($VAR)
+  - metavariable-pattern:
+      metavariable: "$EMPTY"
+      pattern: '""'
   - focus-metavariable: "$EMPTY"
   fix: 'None
 

--- a/assets/semgrep_rules/generated/oss/audit.yaml
+++ b/assets/semgrep_rules/generated/oss/audit.yaml
@@ -432,6 +432,8 @@ rules:
   metadata:
     author: Marco Ivaldi <raptor@0xdeadbeef.info>
     references:
+    - https://cwe.mitre.org/data/definitions/787
+    - https://cwe.mitre.org/data/definitions/193
     - https://g.co/kgs/PCHQjJ
     confidence: HIGH
     license: MIT
@@ -490,6 +492,7 @@ rules:
         - pattern: strncpy
         - pattern: stpncpy
         - pattern: strlcpy
+        - pattern: strscpy
     - pattern-either:
       - pattern-inside: |
           $TYPE $SRC[$LEN];
@@ -505,6 +508,7 @@ rules:
         - pattern: strncpy
         - pattern: stpncpy
         - pattern: strlcpy
+        - pattern: strscpy
 - id: raptor-insecure-api-access-stat-lstat
   metadata:
     author: Marco Ivaldi <raptor@0xdeadbeef.info>
@@ -1641,6 +1645,7 @@ rules:
   - pattern: stpncpy($DST, $SRC, (int $LEN))
   - pattern: strncat($DST, $SRC, (int $LEN))
   - pattern: strlcpy($DST, $SRC, (int $LEN))
+  - pattern: strscpy($DST, $SRC, (int $LEN))
   - pattern: strlcat($DST, $SRC, (int $LEN))
   - pattern: snprintf($BUF, (int $LEN), ...)
   - pattern: vsnprintf($BUF, (int $LEN), ...)
@@ -1935,6 +1940,7 @@ rules:
     - https://cwe.mitre.org/data/definitions/252
     - https://lwn.net/Articles/451985/
     - https://www.usenix.org/legacy/events/sec02/full_papers/chen/chen.pdf
+    - https://www.openwall.com/lists/oss-security/2023/12/30/4
     confidence: MEDIUM
     license: MIT
     category: security
@@ -2209,6 +2215,7 @@ rules:
         - pattern: stpcpy
         - pattern: stpncpy
         - pattern: strlcpy
+        - pattern: strscpy
         - pattern: wcscpy
         - pattern: wcsncpy
         - pattern: wcpcpy
@@ -2294,8 +2301,8 @@ rules:
         - pattern: recv
         - pattern: recvfrom
 - id: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
-  message: 'Variable `$X` is likely modified and later used on error. In some cases
-    this could result  in panics due to a nil dereference  '
+  message: Variable `$X` is likely modified and later used on error. In some cases
+    this could result  in panics due to a nil dereference
   languages:
   - go
   severity: WARNING
@@ -2320,8 +2327,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: kxU6Xb
-        version_id: DkT6Gbr
-        url: https://semgrep.dev/playground/r/DkT6Gbr/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
+        version_id: 7ZTDO6X
+        url: https://semgrep.dev/playground/r/7ZTDO6X/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
         origin: community
   patterns:
   - pattern: |
@@ -2578,8 +2585,8 @@ rules:
     - pattern: "{..., cors: $CORS_ORIGIN, ...}\n"
     - focus-metavariable: "$CORS_ORIGIN"
 - id: trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
-  message: 'If possible, it is better to rely on automatic pinning in PyTorch to avoid
-    undefined behavior and for efficiency '
+  message: If possible, it is better to rely on automatic pinning in PyTorch to avoid
+    undefined behavior and for efficiency
   languages:
   - python
   severity: WARNING
@@ -2604,8 +2611,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: WAUN1Z
-        version_id: 2KTz44E
-        url: https://semgrep.dev/playground/r/2KTz44E/trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
+        version_id: 8KT4boW
+        url: https://semgrep.dev/playground/r/8KT4boW/trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
         origin: community
   pattern-either:
   - patterns:
@@ -2679,9 +2686,9 @@ rules:
   - pattern: numpy.f2py.compile(...)
   - pattern-not: numpy.f2py.compile("...", ...)
 - id: trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
-  message: 'Using the NumPy RNG inside of a PyTorch dataset can lead to a number of
+  message: Using the NumPy RNG inside of a PyTorch dataset can lead to a number of
     issues with loading data, including identical augmentations. Instead, use the
-    random number generators built into Python and PyTorch '
+    random number generators built into Python and PyTorch
   languages:
   - python
   severity: WARNING
@@ -2707,8 +2714,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: KxURLn
-        version_id: 9lTdOOL
-        url: https://semgrep.dev/playground/r/9lTdOOL/trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
+        version_id: gET6q8p
+        url: https://semgrep.dev/playground/r/gET6q8p/trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
         origin: community
   patterns:
   - pattern: |

--- a/assets/semgrep_rules/generated/oss/vulns.yaml
+++ b/assets/semgrep_rules/generated/oss/vulns.yaml
@@ -892,10 +892,10 @@ rules:
           ...
         }
 - id: trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
-  message: 'The Apollo GraphQL uses the ''schemaDirectives'' option. This works in
-    ApolloServer v2, but does nothing in version >=3. Depending on what the directives
-    are used for, this can expose authenticated endpoints, disable rate limiting,
-    and more. See the references on how to create custom directives in v3 and v4. '
+  message: The Apollo GraphQL uses the 'schemaDirectives' option. This works in ApolloServer
+    v2, but does nothing in version >=3. Depending on what the directives are used
+    for, this can expose authenticated endpoints, disable rate limiting, and more.
+    See the references on how to create custom directives in v3 and v4.
   languages:
   - js
   - ts
@@ -922,11 +922,13 @@ rules:
     semgrep.dev:
       rule:
         rule_id: OrU1Oz
-        version_id: 0bTLEEw
-        url: https://semgrep.dev/playground/r/0bTLEEw/trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
+        version_id: LjT70dp
+        url: https://semgrep.dev/playground/r/LjT70dp/trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
         origin: community
   pattern-either:
-  - pattern: 'new ApolloServer({..., schemaDirectives: ..., ...})'
+  - pattern: 'new ApolloServer({..., schemaDirectives: ..., ...})
+
+      '
 - id: trailofbits.javascript.apollo-graphql.use-of-graphql-upload.use-of-graphql-upload
   languages:
   - js
@@ -1350,8 +1352,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: lBUWjy
-        version_id: NdT3AAp
-        url: https://semgrep.dev/playground/r/NdT3AAp/trailofbits.python.pickles-in-numpy.pickles-in-numpy
+        version_id: QkT8J3R
+        url: https://semgrep.dev/playground/r/QkT8J3R/trailofbits.python.pickles-in-numpy.pickles-in-numpy
         origin: community
   patterns:
   - pattern: numpy.load(..., allow_pickle=$VALUE, ...)
@@ -1367,7 +1369,9 @@ rules:
       - pattern-not: 'None
 
           '
-      - pattern-not: '""'
+      - pattern-not: '""
+
+          '
 - id: trailofbits.python.pickles-in-pandas.pickles-in-pandas
   message: Functions reliant on pickle can result in arbitrary code execution. Consider
     using fickling or switching to a safer serialization method


### PR DESCRIPTION
```
@ nonfree.audit (+2, -3)
+ ocaml.lang.security.hashtable-dos.ocamllint-hashtable-dos
+ ocaml.lang.security.unsafe.ocamllint-unsafe
- contrib.nodejsscan.crypto_node.node_md5
- contrib.nodejsscan.crypto_node.node_sha1
- yaml.docker-compose.security.no-new-privileges.no-new-privileges
@ nonfree.others (+0, -0)
@ nonfree.security_noaudit_novuln (+0, -1)
- contrib.dlint.dlint-equivalent.insecure-xml-use
@ nonfree.vulns (+1, -1)
+ generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
- contrib.owasp.java.xxe.documentbuilderfactory.owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
@ oss.audit (+0, -0)
@ oss.others (+0, -0)
@ oss.security_noaudit_novuln (+0, -0)
@ oss.vulns (+0, -0)
```