### PR TITLE
semgrep rules: March 2024 Update

### DIFF
--- a/assets/semgrep_rules/generated/nonfree/audit.yaml
+++ b/assets/semgrep_rules/generated/nonfree/audit.yaml
@@ -92,7 +92,7 @@ rules:
     category: security
     technology:
     - c
-    confidence: MEDIUM
+    confidence: LOW
     owasp:
     - A09:2021 - Security Logging and Monitoring Failures
     subcategory:
@@ -107,8 +107,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: 5rUOlg
-        version_id: xyTKZpQ
-        url: https://semgrep.dev/playground/r/xyTKZpQ/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
+        version_id: ExTpjpr
+        url: https://semgrep.dev/playground/r/ExTpjpr/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
         origin: community
   languages:
   - c
@@ -2716,7 +2716,9 @@ rules:
         url: https://semgrep.dev/playground/r/JdTNpAp/generic.secrets.security.detected-codeclimate.detected-codeclimate
         origin: community
 - id: generic.secrets.security.detected-etc-shadow.detected-etc-shadow
-  pattern-regex: root:[x!*]*:[0-9]*:[0-9]*
+  patterns:
+  - pattern-regex: "^(\\s*)(?P<ROOT>root:[x!*]*:[0-9]*:[0-9]*)"
+  - focus-metavariable: "$ROOT"
   languages:
   - regex
   message: linux shadow file detected
@@ -2746,8 +2748,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: JDUP6p
-        version_id: 5PTdA0e
-        url: https://semgrep.dev/playground/r/5PTdA0e/generic.secrets.security.detected-etc-shadow.detected-etc-shadow
+        version_id: PkTWJ2o
+        url: https://semgrep.dev/playground/r/PkTWJ2o/generic.secrets.security.detected-etc-shadow.detected-etc-shadow
         origin: community
 - id: generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token
   pattern-either:
@@ -4404,16 +4406,20 @@ rules:
     semgrep.dev:
       rule:
         rule_id: 5rUOWQ
-        version_id: l4T4vA3
-        url: https://semgrep.dev/playground/r/l4T4vA3/go.jwt-go.security.jwt-none-alg.jwt-go-none-algorithm
+        version_id: 0bT59Rk
+        url: https://semgrep.dev/playground/r/0bT59Rk/go.jwt-go.security.jwt-none-alg.jwt-go-none-algorithm
         origin: community
   languages:
   - go
   severity: ERROR
   patterns:
-  - pattern-inside: |
-      import "github.com/dgrijalva/jwt-go"
-      ...
+  - pattern-either:
+    - pattern-inside: |
+        import "github.com/golang-jwt/jwt"
+        ...
+    - pattern-inside: |
+        import "github.com/dgrijalva/jwt-go"
+        ...
   - pattern-either:
     - pattern: 'jwt.SigningMethodNone
 
@@ -4939,8 +4945,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: ZqU5bD
-        version_id: kbTdxBw
-        url: https://semgrep.dev/playground/r/kbTdxBw/go.lang.security.audit.database.string-formatted-query.string-formatted-query
+        version_id: JdT3NAn
+        url: https://semgrep.dev/playground/r/JdT3NAn/go.lang.security.audit.database.string-formatted-query.string-formatted-query
         origin: community
   patterns:
   - metavariable-regex:
@@ -4970,120 +4976,57 @@ rules:
     - pattern: $OBJ.Query(fmt.$P("...", ...))
     - pattern: $OBJ.QueryContext($CTX, fmt.$P("...", ...))
     - pattern: $OBJ.QueryRow(fmt.$P("...", ...))
-    - pattern: $OBJ.QueryRow($CTX, fmt.$P("...", ...))
+    - pattern: $OBJ.QueryRow($CTX, fmt.$U("...", ...))
     - pattern: $OBJ.QueryRowContext($CTX, fmt.$P("...", ...))
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.Exec($QUERY, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.Query($QUERY, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.ExecContext($CTX, $QUERY, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryContext($CTX, $QUERY, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRow($QUERY)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRow($CTX, $QUERY)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $QUERY = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRowContext($CTX, $QUERY, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.Exec($OTHER, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.Query($OTHER, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.ExecContext($CTX, $OTHER, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryContext($CTX, $OTHER, ...)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRow($OTHER)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRow($CTX, $OTHER)
-    - pattern: |
-        $QUERY = "..."
-        ...
-        $OTHER = $FXN(..., $QUERY, ...)
-        ...
-        $OBJ.QueryRowContext($CTX, $OTHER, ...)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.Exec($QUERY, ...)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.Query($QUERY, ...)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.ExecContext($CTX, $QUERY, ...)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.QueryContext($CTX, $QUERY, ...)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.QueryRow($QUERY)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.QueryRow($CTX, $QUERY)
-    - pattern: |
-        $QUERY = $X + ...
-        ...
-        $OBJ.QueryRowContext($CTX, $QUERY, ...)
+    - patterns:
+      - pattern-either:
+        - pattern: $QUERY = fmt.Fprintf($F, "$SQLSTR", ...)
+        - pattern: $QUERY = fmt.Sprintf("$SQLSTR", ...)
+        - pattern: $QUERY = fmt.Printf("$SQLSTR", ...)
+        - pattern: "$QUERY = $X + ..."
+      - pattern-either:
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.Query($QUERY, ...)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.ExecContext($CTX, $QUERY, ...)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.Exec($QUERY, ...)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.QueryRow($CTX, $QUERY)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.QueryRow($QUERY)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.QueryContext($CTX, $QUERY)
+                ...
+            }
+        - pattern-inside: |
+            func $FUNC(...) {
+                ...
+                $OBJ.QueryRowContext($CTX, $QUERY, ...)
+                ...
+            }
 - id: go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
   message: Detected a network listener listening on 0.0.0.0 or an empty string. This
     could unexpectedly expose the server publicly as it binds to all available interfaces.
@@ -6026,10 +5969,8 @@ rules:
   - pattern: ioutil.WriteFile("=~//tmp/.*$/", ...)
   - pattern: os.Create("=~//tmp/.*$/", ...)
 - id: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
-  message: Detected a possible denial-of-service via a zip bomb attack. By limiting
-    the max bytes read, you can mitigate this attack. `io.CopyN()` can specify a size.
-    Refer to https://bomb.codes/ to learn more about this attack and other ways to
-    mitigate it.
+  message: 'Detected a possible denial-of-service via a zip bomb attack. By limiting
+    the max bytes read, you can mitigate this attack. `io.CopyN()` can specify a size. '
   severity: WARNING
   languages:
   - go
@@ -6076,7 +6017,6 @@ rules:
     - 'CWE-400: Uncontrolled Resource Consumption'
     source-rule-url: https://github.com/securego/gosec
     references:
-    - https://bomb.codes/
     - https://golang.org/pkg/io/#CopyN
     - https://github.com/securego/gosec/blob/master/rules/decompression-bomb.go
     category: security
@@ -6096,8 +6036,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: oqUeqn
-        version_id: 6xTvJlY
-        url: https://semgrep.dev/playground/r/6xTvJlY/go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
+        version_id: JdT3NG6
+        url: https://semgrep.dev/playground/r/JdT3NG6/go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
         origin: community
 - id: go.lang.security.zip.path-traversal-inside-zip-extraction
   message: File traversal when extracting zip archive
@@ -6832,8 +6772,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: L1Uyvp
-        version_id: GxTv63G
-        url: https://semgrep.dev/playground/r/GxTv63G/java.lang.security.audit.cookie-missing-secure-flag.cookie-missing-secure-flag
+        version_id: qkTbbZp
+        url: https://semgrep.dev/playground/r/qkTbbZp/java.lang.security.audit.cookie-missing-secure-flag.cookie-missing-secure-flag
         origin: community
   message: A cookie was detected without setting the 'secure' flag. The 'secure' flag
     for cookies prevents the client from transmitting the cookie over insecure channels
@@ -12224,89 +12164,6 @@ rules:
       $OTHERFUNC(..., <... $UNK ...>, ...);
   - pattern: $OTHERFUNC(..., <... "=~/.*<script.*/" ...>, ...)
   - pattern: "$UNK"
-- id: javascript.lang.security.audit.vm-injection.vm-runincontext-context-injection
-  message: Make sure that unverified user data can not reach vm.runInContext.
-  severity: WARNING
-  languages:
-  - javascript
-  - typescript
-  metadata:
-    owasp:
-    - A03:2021 - Injection
-    cwe:
-    - 'CWE-94: Improper Control of Generation of Code (''Code Injection'')'
-    category: security
-    technology:
-    - javascript
-    references:
-    - https://nodejs.org/dist/latest-v16.x/docs/api/vm.html
-    cwe2022-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: LOW
-    confidence: LOW
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Code Injection
-    source: https://semgrep.dev/r/javascript.lang.security.audit.vm-injection.vm-runincontext-context-injection
-    shortlink: https://sg.run/9oey
-    semgrep.dev:
-      rule:
-        rule_id: eqU8KW
-        version_id: GxTv6Eg
-        url: https://semgrep.dev/playground/r/GxTv6Eg/javascript.lang.security.audit.vm-injection.vm-runincontext-context-injection
-        origin: community
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern-inside: function ... (..., $ARG,...) {...}
-    - focus-metavariable: "$ARG"
-  pattern-sinks:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          $VM = require('vm')
-          ...
-      - pattern-inside: |
-          import * as $VM from 'vm'
-          ...
-      - pattern-inside: |
-          import $VM from 'vm'
-          ...
-    - pattern-either:
-      - pattern: "$VM.runInContext($CODE,$INPUT,...)"
-      - pattern: "$VM.runInContext($INPUT,...)"
-      - pattern: "$VM.runInNewContext($CODE,$INPUT,...)"
-      - pattern: "$VM.runInNewContext($INPUT,...)"
-      - pattern: "$VM.runInThisContext($INPUT,...)"
-      - pattern: "$VM.compileFunction($INPUT,...)"
-      - pattern: "$VM.compileFunction($CODE,$PARAMS,{parsingContext: $INPUT},...)\n"
-      - pattern: |
-          $OPTS = {parsingContext: $INPUT};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...)
-      - pattern: new $VM.Script($INPUT,...)
-      - pattern: new $VM.SourceTextModule($INPUT,...)
-    - focus-metavariable: "$INPUT"
-  - patterns:
-    - pattern-either:
-      - pattern: vm.runInContext($CODE,$INPUT,...)
-      - pattern: vm.runInContext($INPUT,...)
-      - pattern: vm.runInNewContext($CODE,$INPUT,...)
-      - pattern: vm.runInNewContext($INPUT,...)
-      - pattern: vm.runInThisContext($INPUT,...)
-      - pattern: vm.compileFunction($INPUT,...)
-      - pattern: 'vm.compileFunction($CODE,$PARAMS,{parsingContext: $INPUT},...)
-
-          '
-      - pattern: |
-          $OPTS = {parsingContext: $INPUT};
-          ...
-          vm.compileFunction($CODE,$PARAMS,$OPTS,...)
-      - pattern: new vm.Script($INPUT,...)
-      - pattern: new vm.SourceTextModule($INPUT,...)
-    - focus-metavariable: "$INPUT"
 - id: javascript.lang.security.detect-buffer-noassert.detect-buffer-noassert
   message: Detected usage of noassert in Buffer API, which allows the offset the be
     beyond the end of the buffer. This could result in writing or reading beyond the
@@ -14993,6 +14850,67 @@ rules:
   languages:
   - php
   severity: ERROR
+- id: php.lang.security.base-convert-loses-precision.base-convert-loses-precision
+  message: The function base_convert uses 64-bit numbers internally, and does not
+    correctly convert large numbers. It is not suitable for random tokens such as
+    those used for session tokens or CSRF tokens.
+  metadata:
+    references:
+    - https://www.php.net/base_convert
+    - https://www.sjoerdlangkemper.nl/2017/03/15/dont-use-base-convert-on-random-tokens/
+    category: security
+    technology:
+    - php
+    cwe:
+    - 'CWE-190: Integer Overflow or Wraparound'
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/php.lang.security.base-convert-loses-precision.base-convert-loses-precision
+    shortlink: https://sg.run/kxpGo
+    semgrep.dev:
+      rule:
+        rule_id: 7KUgBAk
+        version_id: 1QTKbNw
+        url: https://semgrep.dev/playground/r/1QTKbNw/php.lang.security.base-convert-loses-precision.base-convert-loses-precision
+        origin: community
+  languages:
+  - php
+  severity: WARNING
+  mode: taint
+  pattern-sources:
+  - pattern: hash(...)
+  - pattern: hash_hmac(...)
+  - pattern: sha1(...)
+  - pattern: md5(...)
+  - patterns:
+    - pattern: random_bytes($N)
+    - metavariable-comparison:
+        metavariable: "$N"
+        comparison: "$N > 7"
+  - patterns:
+    - pattern: openssl_random_pseudo_bytes($N)
+    - metavariable-comparison:
+        metavariable: "$N"
+        comparison: "$N > 7"
+  - patterns:
+    - pattern: "$OBJ->get_random_bytes($N)"
+    - metavariable-comparison:
+        metavariable: "$N"
+        comparison: "$N > 7"
+  pattern-sinks:
+  - pattern: base_convert(...)
+  pattern-sanitizers:
+  - patterns:
+    - pattern: substr(..., $LENGTH)
+    - metavariable-comparison:
+        metavariable: "$LENGTH"
+        comparison: "$LENGTH <= 7"
 - id: php.lang.security.eval-use.eval-use
   patterns:
   - pattern: eval(...);
@@ -28346,6 +28264,20 @@ rules:
             })
             ...
           }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
+                ...
+              ]
+              ...
+            })
+            ...
+          }
       - pattern: 'Action = $ACTION
 
           '
@@ -28369,6 +28301,16 @@ rules:
           data aws_iam_policy_document "..." {
             ...
             statement {
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -28532,8 +28474,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: kxUwK2
-        version_id: YDTpnEX
-        url: https://semgrep.dev/playground/r/YDTpnEX/terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
+        version_id: qkTjezP
+        url: https://semgrep.dev/playground/r/qkTjezP/terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
         origin: community
   languages:
   - hcl
@@ -28550,6 +28492,20 @@ rules:
               Statement = [
                 ...,
                 {... Resource = "*" ...},
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -28581,6 +28537,16 @@ rules:
             statement {
               ...
               resources = ["*"]
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -28648,8 +28614,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: wdUj1k
-        version_id: 6xTvQRb
-        url: https://semgrep.dev/playground/r/6xTvQRb/terraform.lang.security.iam.no-iam-data-exfiltration.no-iam-data-exfiltration
+        version_id: l4T92wK
+        url: https://semgrep.dev/playground/r/l4T92wK/terraform.lang.security.iam.no-iam-data-exfiltration.no-iam-data-exfiltration
         origin: community
   languages:
   - hcl
@@ -28664,6 +28630,20 @@ rules:
             policy = jsonencode({
               ...
               Statement = [
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -28691,6 +28671,16 @@ rules:
           data aws_iam_policy_document "..." {
             ...
             statement {
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -28763,8 +28753,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: x8UxLq
-        version_id: o5Tg9Lg
-        url: https://semgrep.dev/playground/r/o5Tg9Lg/terraform.lang.security.iam.no-iam-priv-esc-funcs.no-iam-priv-esc-funcs
+        version_id: YDTROjB
+        url: https://semgrep.dev/playground/r/YDTROjB/terraform.lang.security.iam.no-iam-priv-esc-funcs.no-iam-priv-esc-funcs
         origin: community
   languages:
   - hcl
@@ -28781,6 +28771,20 @@ rules:
               Statement = [
                 ...,
                 {... Resource = $RESOURCE ...},
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -28812,6 +28816,16 @@ rules:
             statement {
               ...
               resources = $RESOURCE
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -28867,8 +28881,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: OrU6jO
-        version_id: zyTKDBj
-        url: https://semgrep.dev/playground/r/zyTKDBj/terraform.lang.security.iam.no-iam-priv-esc-other-users.no-iam-priv-esc-other-users
+        version_id: JdTyeAb
+        url: https://semgrep.dev/playground/r/JdTyeAb/terraform.lang.security.iam.no-iam-priv-esc-other-users.no-iam-priv-esc-other-users
         origin: community
   languages:
   - hcl
@@ -28883,6 +28897,20 @@ rules:
             policy = jsonencode({
               ...
               Statement = [
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -28912,6 +28940,16 @@ rules:
           data aws_iam_policy_document "..." {
             ...
             statement {
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -29005,8 +29043,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: eqUzR3
-        version_id: pZT1L26
-        url: https://semgrep.dev/playground/r/pZT1L26/terraform.lang.security.iam.no-iam-priv-esc-roles.no-iam-priv-esc-roles
+        version_id: 5PTO30W
+        url: https://semgrep.dev/playground/r/5PTO30W/terraform.lang.security.iam.no-iam-priv-esc-roles.no-iam-priv-esc-roles
         origin: community
   languages:
   - hcl
@@ -29021,6 +29059,20 @@ rules:
             policy = jsonencode({
               ...
               Statement = [
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -29050,6 +29102,16 @@ rules:
           data aws_iam_policy_document "..." {
             ...
             statement {
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -30140,8 +30202,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: v8U9r0
-        version_id: 2KTz3Rb
-        url: https://semgrep.dev/playground/r/2KTz3Rb/terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
+        version_id: GxT7J51
+        url: https://semgrep.dev/playground/r/GxT7J51/terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
         origin: community
   languages:
   - hcl
@@ -30156,6 +30218,20 @@ rules:
             policy = jsonencode({
               ...
               Statement = [
+                ...
+              ]
+              ...
+            })
+            ...
+          }
+      - pattern-not-inside: |
+          resource $TYPE "..." {
+            ...
+            policy = jsonencode({
+              ...
+              Statement = [
+                ...,
+                {... Effect = "Deny" ...},
                 ...
               ]
               ...
@@ -30185,6 +30261,16 @@ rules:
           data aws_iam_policy_document "..." {
             ...
             statement {
+              ...
+            }
+            ...
+          }
+      - pattern-not-inside: |
+          data aws_iam_policy_document "..." {
+            ...
+            statement {
+              ...
+              effect = "Deny"
               ...
             }
             ...
@@ -30221,8 +30307,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: d8Uew3
-        version_id: X0TQ2YZ
-        url: https://semgrep.dev/playground/r/X0TQ2YZ/terraform.lang.security.iam.no-iam-star-actions.no-iam-star-actions
+        version_id: RGTgrYj
+        url: https://semgrep.dev/playground/r/RGTgrYj/terraform.lang.security.iam.no-iam-star-actions.no-iam-star-actions
         origin: community
   languages:
   - hcl

--- a/assets/semgrep_rules/generated/nonfree/others.yaml
+++ b/assets/semgrep_rules/generated/nonfree/others.yaml
@@ -171,48 +171,6 @@ rules:
         version_id: gET3x7z
         url: https://semgrep.dev/playground/r/gET3x7z/ocaml.lang.portability.slash-tmp.not-portable-tmp-string
         origin: community
-- id: python.flask.best-practice.use-jsonify.use-jsonify
-  patterns:
-  - pattern: "$JSONDUMPS"
-  - pattern-either:
-    - pattern-inside: 'return json.dumps($...VAR)
-
-        '
-    - pattern-inside: |
-        $DATA = json.dumps($...VAR)
-        ...
-        return $DATA
-  - pattern-inside: |
-      @app.route(...)
-      def $X():
-        ...
-  - metavariable-pattern:
-      metavariable: "$JSONDUMPS"
-      pattern: json.dumps($...VAR)
-  - focus-metavariable: "$JSONDUMPS"
-  fix: 'flask.jsonify($...VAR)
-
-    '
-  message: flask.jsonify() is a Flask helper method which handles the correct  settings
-    for returning JSON from Flask routes
-  languages:
-  - python
-  severity: ERROR
-  metadata:
-    category: best-practice
-    technology:
-    - flask
-    references:
-    - https://flask.palletsprojects.com/en/2.2.x/api/#flask.json.jsonify
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    source: https://semgrep.dev/r/python.flask.best-practice.use-jsonify.use-jsonify
-    shortlink: https://sg.run/XBlb
-    semgrep.dev:
-      rule:
-        rule_id: NbUkx6
-        version_id: 0bTLlv0
-        url: https://semgrep.dev/playground/r/0bTLlv0/python.flask.best-practice.use-jsonify.use-jsonify
-        origin: community
 - id: python.flask.caching.query-string.flask-cache-query-string
   patterns:
   - pattern-either:
@@ -265,34 +223,6 @@ rules:
         rule_id: kxUko3
         version_id: K3Tvjl9
         url: https://semgrep.dev/playground/r/K3Tvjl9/python.flask.caching.query-string.flask-cache-query-string
-        origin: community
-- id: python.flask.correctness.access-request-in-wrong-handler.avoid-accessing-request-in-wrong-handler
-  patterns:
-  - pattern-inside: |
-      @app.route(..., method="GET")
-      def $X(...):
-        ...
-  - pattern-either:
-    - pattern: "$Y = flask.request.json\n"
-    - pattern: "$Y = flask.request.form\n"
-    - pattern: "$Y = flask.request.data\n"
-  message: Accessing request object inside a route handle for HTTP GET command will
-    throw due to missing request body.
-  languages:
-  - python
-  severity: WARNING
-  metadata:
-    category: correctness
-    technology:
-    - flask
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    source: https://semgrep.dev/r/python.flask.correctness.access-request-in-wrong-handler.avoid-accessing-request-in-wrong-handler
-    shortlink: https://sg.run/1ZYv
-    semgrep.dev:
-      rule:
-        rule_id: wdUJe5
-        version_id: qkT2xNz
-        url: https://semgrep.dev/playground/r/qkT2xNz/python.flask.correctness.access-request-in-wrong-handler.avoid-accessing-request-in-wrong-handler
         origin: community
 - id: python.lang.compatibility.python36.python36-compatibility-Popen1
   pattern: subprocess.Popen(errors=$X, ...)

--- a/assets/semgrep_rules/generated/nonfree/vulns.yaml
+++ b/assets/semgrep_rules/generated/nonfree/vulns.yaml
@@ -78,7 +78,7 @@ rules:
     category: security
     technology:
     - c
-    confidence: MEDIUM
+    confidence: LOW
     subcategory:
     - vuln
     likelihood: LOW
@@ -91,8 +91,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: JDUyw8
-        version_id: kbTdxL3
-        url: https://semgrep.dev/playground/r/kbTdxL3/c.lang.security.double-free.double-free
+        version_id: ZRT7Q7O
+        url: https://semgrep.dev/playground/r/ZRT7Q7O/c.lang.security.double-free.double-free
         origin: community
   languages:
   - c
@@ -121,7 +121,7 @@ rules:
     category: security
     technology:
     - c
-    confidence: MEDIUM
+    confidence: LOW
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:
@@ -136,8 +136,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: WAU9Dz
-        version_id: w8T9nD5
-        url: https://semgrep.dev/playground/r/w8T9nD5/c.lang.security.function-use-after-free.function-use-after-free
+        version_id: nWT8x8G
+        url: https://semgrep.dev/playground/r/nWT8x8G/c.lang.security.function-use-after-free.function-use-after-free
         origin: community
   languages:
   - c
@@ -155,7 +155,7 @@ rules:
     category: security
     technology:
     - c
-    confidence: MEDIUM
+    confidence: LOW
     subcategory:
     - vuln
     likelihood: MEDIUM
@@ -168,8 +168,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: ReUgWx
-        version_id: vdTYN8J
-        url: https://semgrep.dev/playground/r/vdTYN8J/c.lang.security.insecure-use-printf-fn.insecure-use-printf-fn
+        version_id: 7ZT1g1b
+        url: https://semgrep.dev/playground/r/7ZT1g1b/c.lang.security.insecure-use-printf-fn.insecure-use-printf-fn
         origin: community
   languages:
   - c
@@ -214,7 +214,7 @@ rules:
     category: security
     technology:
     - c
-    confidence: MEDIUM
+    confidence: LOW
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:
@@ -229,8 +229,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: KxUb9l
-        version_id: LjTqQAn
-        url: https://semgrep.dev/playground/r/LjTqQAn/c.lang.security.use-after-free.use-after-free
+        version_id: LjT2q2X
+        url: https://semgrep.dev/playground/r/LjT2q2X/c.lang.security.use-after-free.use-after-free
         origin: community
   languages:
   - c
@@ -327,7 +327,6 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
     - 'CWE-328: Use of Weak Hash'
     author: Gabriel Marquet <gab.marquet@gmail.com>
     category: security
@@ -338,15 +337,14 @@ rules:
     impact: HIGH
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
-    - Cryptographic Issues
     - Insecure Hashing Algorithm
     source: https://semgrep.dev/r/clojure.lang.security.use-of-md5.use-of-md5
     shortlink: https://sg.run/BgPx
     semgrep.dev:
       rule:
         rule_id: nJU1ep
-        version_id: 5PTdeYo
-        url: https://semgrep.dev/playground/r/5PTdeYo/clojure.lang.security.use-of-md5.use-of-md5
+        version_id: 2KTQz3r
+        url: https://semgrep.dev/playground/r/2KTQz3r/clojure.lang.security.use-of-md5.use-of-md5
         origin: community
   pattern-either:
   - pattern: (MessageDigest/getInstance "MD5")
@@ -7517,11 +7515,11 @@ rules:
     semgrep.dev:
       rule:
         rule_id: KxUAY4
-        version_id: pZT1yg8
-        url: https://semgrep.dev/playground/r/pZT1yg8/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
+        version_id: jQT6gyn
+        url: https://semgrep.dev/playground/r/jQT6gyn/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
         origin: community
   patterns:
-  - pattern-regex: (?i)\b((sk|pk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)
+  - pattern-regex: (?i)\b((sk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)
 - id: generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id
   message: A gitleaks sumologic-access-id was detected which attempts to identify
     hard-coded credentials. It is not recommended to store credentials in source-code,
@@ -9028,7 +9026,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    - 'CWE-328: Use of Weak Hash'
     source-rule-url: https://github.com/securego/gosec#available-rules
     category: security
     technology:
@@ -9042,14 +9040,14 @@ rules:
     impact: MEDIUM
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
-    - Cryptographic Issues
+    - Insecure Hashing Algorithm
     source: https://semgrep.dev/r/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
     shortlink: https://sg.run/2xB5
     semgrep.dev:
       rule:
         rule_id: x8Un6q
-        version_id: 2KTzro0
-        url: https://semgrep.dev/playground/r/2KTzro0/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
+        version_id: 1QTbO72
+        url: https://semgrep.dev/playground/r/1QTbO72/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
         origin: community
   patterns:
   - pattern-inside: |
@@ -9113,7 +9111,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    - 'CWE-328: Use of Weak Hash'
     source-rule-url: https://github.com/securego/gosec#available-rules
     category: security
     technology:
@@ -9127,14 +9125,14 @@ rules:
     confidence: MEDIUM
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
-    - Cryptographic Issues
+    - Insecure Hashing Algorithm
     source: https://semgrep.dev/r/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
     shortlink: https://sg.run/XBYA
     semgrep.dev:
       rule:
         rule_id: OrU31O
-        version_id: X0TQx0B
-        url: https://semgrep.dev/playground/r/X0TQx0B/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
+        version_id: 9lTod53
+        url: https://semgrep.dev/playground/r/9lTod53/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
         origin: community
   patterns:
   - pattern-inside: |
@@ -20522,7 +20520,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     cwe:
-    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    - 'CWE-328: Use of Weak Hash'
     source-rule-url: https://find-sec-bugs.github.io/bugs.htm#WEAK_MESSAGE_DIGEST_MD5
     category: security
     technology:
@@ -20536,14 +20534,14 @@ rules:
     impact: MEDIUM
     confidence: MEDIUM
     vulnerability_class:
-    - Cryptographic Issues
+    - Insecure Hashing Algorithm
     source: https://semgrep.dev/r/kotlin.lang.security.use-of-md5.use-of-md5
     shortlink: https://sg.run/4eQx
     semgrep.dev:
       rule:
         rule_id: qNUXPj
-        version_id: l4T4vRQ
-        url: https://semgrep.dev/playground/r/l4T4vRQ/kotlin.lang.security.use-of-md5.use-of-md5
+        version_id: yeTBRZG
+        url: https://semgrep.dev/playground/r/yeTBRZG/kotlin.lang.security.use-of-md5.use-of-md5
         origin: community
   pattern-either:
   - pattern: '$VAR = $MD.getInstance("MD5")

--- a/assets/semgrep_rules/generated/oss/audit.yaml
+++ b/assets/semgrep_rules/generated/oss/audit.yaml
@@ -1070,7 +1070,7 @@ rules:
     - pattern: "$FUN(...)"
     - metavariable-regex:
         metavariable: "$FUN"
-        regex: "^\\w*fork\\s*$|^\\w*clone\\s*$"
+        regex: "^\\w*fork\\s*$"
   - patterns:
     - pattern: "$FUN(...)"
     - metavariable-regex:
@@ -2549,9 +2549,11 @@ rules:
     semgrep.dev:
       rule:
         rule_id: lBU4JeW
-        version_id: gET647o
-        url: https://semgrep.dev/playground/r/gET647o/trailofbits.generic.tar-insecure-flags.tar-insecure-flags
+        version_id: 6xT5vWg
+        url: https://semgrep.dev/playground/r/6xT5vWg/trailofbits.generic.tar-insecure-flags.tar-insecure-flags
         origin: community
+  options:
+    generic_ellipsis_max_span: 0
   pattern-either:
   - pattern: 'tar ... -P '
   - pattern: tar ... --absolute-paths
@@ -2646,8 +2648,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: kxU6Xb
-        version_id: 7ZTDO6X
-        url: https://semgrep.dev/playground/r/7ZTDO6X/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
+        version_id: A8Tr9vQ
+        url: https://semgrep.dev/playground/r/A8Tr9vQ/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
         origin: community
   patterns:
   - pattern: |
@@ -2671,6 +2673,24 @@ rules:
         $X = ...
         ...
         <... $X.$Y ...>
+      }
+  - pattern-not: |
+      ..., $X, ..., $ERR = ...
+      if $ERR != nil {
+        ...
+        if $X != nil {
+          <... $X.$Y ...>
+        }
+        ...
+      }
+  - pattern-not: |
+      ..., $X, ..., $ERR := ...
+      if $ERR != nil {
+        ...
+        if  $X != nil && <... $X.$Y ...> {
+          ...
+        }
+        ...
       }
 - id: trailofbits.go.iterate-over-empty-map.iterate-over-empty-map
   message: Iteration over a possibly empty map `$C`. This is likely a bug or redundant
@@ -4056,45 +4076,3 @@ rules:
   - metavariable-regex:
       metavariable: "$VALUE"
       regex: "(?i)^(http|ftp)://.*"
-- id: trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
-  message: Service port is exposed on all interfaces
-  languages:
-  - yaml
-  severity: WARNING
-  metadata:
-    category: security
-    cwe: 'CWE-1327: Binding to an Unrestricted IP Address'
-    subcategory:
-    - audit
-    technology:
-    - docker
-    - compose
-    confidence: LOW
-    likelihood: LOW
-    impact: LOW
-    references:
-    - https://docs.docker.com/compose/compose-file/compose-file-v3/#ports
-    license: AGPL-3.0 license
-    vulnerability_class:
-    - Other
-    source: https://semgrep.dev/r/trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
-    shortlink: https://sg.run/gxAyK
-    semgrep.dev:
-      rule:
-        rule_id: j2UgnLW
-        version_id: A8TkY2z
-        url: https://semgrep.dev/playground/r/A8TkY2z/trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
-        origin: community
-  patterns:
-  - pattern-inside: |
-      services:
-        ...
-  - pattern: |
-      ports:
-        - ...
-        - "$PORT"
-        - ...
-  - focus-metavariable: "$PORT"
-  - metavariable-regex:
-      metavariable: "$PORT"
-      regex: "^(?!127.\\d{1,3}.\\d{1,3}.\\d{1,3}:).+"

--- a/assets/semgrep_rules/generated/oss/vulns.yaml
+++ b/assets/semgrep_rules/generated/oss/vulns.yaml
@@ -328,8 +328,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: 8GUzNK
-        version_id: 3ZTkBPJ
-        url: https://semgrep.dev/playground/r/3ZTkBPJ/trailofbits.go.missing-runlock-on-rwmutex.missing-runlock-on-rwmutex
+        version_id: BjTDX4z
+        url: https://semgrep.dev/playground/r/BjTDX4z/trailofbits.go.missing-runlock-on-rwmutex.missing-runlock-on-rwmutex
         origin: community
   patterns:
   - pattern-either:
@@ -345,6 +345,12 @@ rules:
       defer $T.RUnlock()
       ...
   - pattern-not-inside: "$FOO(..., ..., func(...) { \n    ... \n})\n"
+  - pattern-not-inside: |
+      return func(...) {
+          ...
+          $T.RUnlock()
+          ...
+      }
 - id: trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
   message: Missing mutex unlock before returning from a function.  This could result
     in panics resulting from double lock operations
@@ -373,8 +379,8 @@ rules:
     semgrep.dev:
       rule:
         rule_id: L1U5Gz
-        version_id: 44TRzkv
-        url: https://semgrep.dev/playground/r/44TRzkv/trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
+        version_id: DkT96BG
+        url: https://semgrep.dev/playground/r/DkT96BG/trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
         origin: community
   patterns:
   - pattern-either:
@@ -390,6 +396,12 @@ rules:
       defer $T.Unlock()
       ...
   - pattern-not-inside: "$FOO(..., ..., func(...) { \n    ... \n})\n"
+  - pattern-not-inside: |
+      return func(...) {
+          ...
+          $T.Unlock()
+          ...
+      }
 - id: trailofbits.go.nil-check-after-call.nil-check-after-call
   message: Potential `$FOO` nil dereference when `$BAR` is called
   languages:

--- a/assets/semgrep_rules/update-ruleset.rb
+++ b/assets/semgrep_rules/update-ruleset.rb
@@ -8,6 +8,8 @@ require 'pp'
 SEMGREP_VERSION = `semgrep --version`.strip
 RULESETS = [
 	'r/c.lang.security.insecure-use-memset.insecure-use-memset',
+	'r/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string',
+	'r/c.lang.security.function-use-after-free.function-use-after-free',
 
 	'p/default',
 	'p/xss',
@@ -55,7 +57,7 @@ RULESETS = [
 	'p/wordpress',
 	'p/react-best-practices',
 	'p/trailofbits',
-    'p/rust',
+	'p/rust',
 	'p/c',
 	'p/swift',
 ]


### PR DESCRIPTION
```
@ nonfree.audit (+1, -2)
+ php.lang.security.base-convert-loses-precision.base-convert-loses-precision
- c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
- javascript.lang.security.audit.vm-injection.vm-runincontext-context-injection
@ nonfree.others (+0, -2)
- python.flask.best-practice.use-jsonify.use-jsonify
- python.flask.correctness.access-request-in-wrong-handler.avoid-accessing-request-in-wrong-handler
@ nonfree.security_noaudit_novuln (+0, -0)
@ nonfree.vulns (+0, -1)
- c.lang.security.function-use-after-free.function-use-after-free
@ oss.audit (+0, -1)
- trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
@ oss.others (+0, -0)
@ oss.security_noaudit_novuln (+0, -0)
@ oss.vulns (+0, -0)
```