### PR TITLE
Add Android Resolve Intent rule

### DIFF
--- a/assets/semgrep_rules/client/android-resolve-intent.java
+++ b/assets/semgrep_rules/client/android-resolve-intent.java
@@ -1,0 +1,39 @@
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageItemInfo;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ActivityInfo
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        PackageManager pm = getPackageManager();
+        // ruleid: android-resolve-intent
+        ResolveInfo resolveInfo = pm.resolveService(intent, 0);
+        // ruleid: android-resolve-intent
+        resolveInfo = pm.resolveContentProvider(intent, 0);
+        // ruleid: android-resolve-intent
+        resolveInfo = pm.resolveActivity(intent, 0);
+        // ruleid: android-resolve-intent
+        ComponentName componentName = intent.resolveActivity(pm);
+        // ruleid: android-resolve-intent
+        ActivityInfo activityInfo = intent.resolveActivityInfo(pm);
+        // ruleid: android-resolve-intent
+        List<ResolveInfo> resolveInfoList = pm.queryBroadcastReceivers(intent,0);
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentActivities(intent,0);
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentActivityOptions(null,null,intent,0);
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentServices(intent,0);
+        // ruleid: android-resolve-intent
+        List<ProviderInfo> providerInfoList = pm.queryIntentContentProviders(intent,0);
+    }
+}

--- a/assets/semgrep_rules/client/android-resolve-intent.kt
+++ b/assets/semgrep_rules/client/android-resolve-intent.kt
@@ -1,0 +1,38 @@
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageItemInfo
+import android.content.pm.ResolveInfo
+import android.content.pm.ActivityInfo
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"))
+        val pm = packageManager
+        // ruleid: android-resolve-intent
+        val resolveInfo = pm.resolveService(intent, 0)
+        // ruleid: android-resolve-intent
+        resolveInfo = pm.resolveContentProvider(intent, 0) 
+        // ruleid: android-resolve-intent
+        resolveInfo = pm.resolveActivity(intent, 0)
+        // ruleid: android-resolve-intent
+        val componentName = intent.resolveActivity(pm)
+        // ruleid: android-resolve-intent
+        val activityInfo = intent.resolveActivityInfo(pm)
+        // ruleid: android-resolve-intent
+        val resolveInfoList = pm.queryBroadcastReceivers(intent, 0)
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentActivities(intent, 0)
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentActivityOptions(null, null, intent, 0)
+        // ruleid: android-resolve-intent
+        resolveInfoList = pm.queryIntentServices(intent, 0)
+        // ruleid: android-resolve-intent
+        val providerInfoList = pm.queryIntentContentProviders(intent, 0)
+    }
+}

--- a/assets/semgrep_rules/client/android-resolve-intent.yaml
+++ b/assets/semgrep_rules/client/android-resolve-intent.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: android-resolve-intent
+    patterns:
+      - pattern-either:
+          - pattern: ....resolveService(...,...)
+          - pattern: ....resolveContentProvider(...,...)
+          - pattern: ....resolveActivity(...,...)
+          - pattern: ....resolveActivity(...)
+          - pattern: ....resolveActivityInfo(...,...)
+          - pattern: ....queryBroadcastReceivers(...,...)
+          - pattern: ....queryIntentActivities(...,...)
+          - pattern: ....queryIntentActivityOptions(...,...,...,...)
+          - pattern: ....queryIntentServices(...,...)
+          - pattern: ....queryIntentContentProviders(...,...)
+    metadata:
+      author: Artem Chaikin
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/client/android-resolve-intent.yaml
+      assignees: stoletheminerals
+    message: Implicit intents in resolveComponent and queryComponent methods for component launch may pose security risks, as other installed apps can register similar components with higher priority. Instead, it is recommended to use hardcoded package names for third-party components launch or getApplicationContext().getPackageName() for local component launch.
+    languages: [java, kotlin]
+    severity: WARNING


### PR DESCRIPTION
Adds a few patterns for Java and Kotlin to detect component resolving using implicit intents. I checked the rule on Semgrep Playground and it works for both Java and Kotlin. It says that Kotlin support is in beta, not sure what does it mean for us. If it doesn't work correctly I can remove it as the only Kotlin component we have is Android Playlist.