### PR TITLE
Add iOS Javascript injection rules

### DIFF
--- a/assets/semgrep_rules/client/brave-execute-script-ios.swift
+++ b/assets/semgrep_rules/client/brave-execute-script-ios.swift
@@ -1,0 +1,25 @@
+import WebKit
+
+let webView = WKWebView(frame: .zero)
+// ruleid: brave-execute-script-ios
+webView.evaluateJavaScript("document.title") { (result, error) in
+    if let result = result {
+        print("Title: \(result)")
+    } else if let error = error {
+        print("Evaluate error: \(error.localizedDescription)")
+    }
+}
+// ruleid: brave-execute-script-ios
+try await webView.evaluateSafeJavaScriptThrowing(
+    functionName: "localStorage.setItem",
+    args: ["storageKey", "receipt"],
+    contentWorld: .defaultClient
+)
+// ruleid: brave-execute-script-ios
+webView.evaluateSafeJavaScript(
+          functionName: "alert(123)",
+          contentWorld: .page
+        )
+// ruleid: brave-execute-script-ios
+let userScript = WKUserScript(source: "document.title = 'Test';", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+webView.configuration.userContentController.addUserScript(userScript)

--- a/assets/semgrep_rules/client/brave-execute-script-ios.yaml
+++ b/assets/semgrep_rules/client/brave-execute-script-ios.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: brave-execute-script-ios
+    metadata:
+      author: Artem Chaikin
+      references:
+        - https://github.com/brave/brave-browser/wiki/Security-reviews
+      source: https://github.com/brave/security-action/blob/main/assets/semgrep_rules/client/brave-execute-script-ios.yaml
+      assignees: stoletheminerals
+    message: |
+      $FUNC usages should be vet by the security-team.
+
+      References:
+      - https://github.com/brave/brave-browser/wiki/Security-reviews (point 13)
+    severity: INFO
+    languages:
+      - swift
+    patterns:
+      - pattern-either:
+          - pattern: $OBJ.$FUNC(...)
+          - pattern: $FUNC(...)
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: ^(WKUserScript|evaluateSafeJavaScriptThrowing|evaluateSafeJavaScript|evaluateJavaScript)$


### PR DESCRIPTION
Adds a Javascript injection rules for Swift, similar to https://github.com/brave/security-action/blob/main/assets/semgrep_rules/client/brave-execute-script.yaml