### PR TITLE
Add more auth-related keywords

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
       login
       policy
       authentication
+      authorization
+      authn
+      authz
+      oauth
       secure
       insecure
       safebrowsing


### PR DESCRIPTION
Those would have been covered by "auth", but we [removed that](https://github.com/brave/security-action/pull/546) given the false positives with "author".