### PR TITLE
security rules: June 2024 Update

### DIFF
--- a/assets/semgrep_rules/generated/nonfree/audit.yaml
+++ b/assets/semgrep_rules/generated/nonfree/audit.yaml
@@ -33,6 +33,8 @@ rules:
     shortlink: https://sg.run/KXz6
     semgrep.dev:
       rule:
+        r_id: 14555
+        rv_id: 108995
         rule_id: qNUXrw
         version_id: pZT1yLp
         url: https://semgrep.dev/playground/r/pZT1yLp/bash.curl.security.curl-pipe-bash.curl-pipe-bash
@@ -78,6 +80,8 @@ rules:
     shortlink: https://sg.run/Q9pq
     semgrep.dev:
       rule:
+        r_id: 14842
+        rv_id: 109000
         rule_id: WAUy9q
         version_id: 9lTdW5W
         url: https://semgrep.dev/playground/r/9lTdW5W/bash.lang.security.ifs-tampering.ifs-tampering
@@ -106,6 +110,8 @@ rules:
     shortlink: https://sg.run/vzwn
     semgrep.dev:
       rule:
+        r_id: 8833
+        rv_id: 257629
         rule_id: 5rUOlg
         version_id: ExTpjpr
         url: https://semgrep.dev/playground/r/ExTpjpr/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
@@ -138,6 +144,8 @@ rules:
     shortlink: https://sg.run/dKqX
     semgrep.dev:
       rule:
+        r_id: 8834
+        rv_id: 109008
         rule_id: GdU7OE
         version_id: O9TNOdZ
         url: https://semgrep.dev/playground/r/O9TNOdZ/c.lang.security.insecure-use-gets-fn.insecure-use-gets-fn
@@ -184,6 +192,8 @@ rules:
     shortlink: https://sg.run/l9GE
     semgrep.dev:
       rule:
+        r_id: 18213
+        rv_id: 109009
         rule_id: d8UK7D
         version_id: e1T013E
         url: https://semgrep.dev/playground/r/e1T013E/c.lang.security.insecure-use-memset.insecure-use-memset
@@ -213,6 +223,8 @@ rules:
     shortlink: https://sg.run/nd1g
     semgrep.dev:
       rule:
+        r_id: 8836
+        rv_id: 109011
         rule_id: AbUzPd
         version_id: d6TrAvO
         url: https://semgrep.dev/playground/r/d6TrAvO/c.lang.security.insecure-use-scanf-fn.insecure-use-scanf-fn
@@ -248,6 +260,8 @@ rules:
     shortlink: https://sg.run/EkRP
     semgrep.dev:
       rule:
+        r_id: 8837
+        rv_id: 109012
         rule_id: BYUNjA
         version_id: ZRTQNpR
         url: https://semgrep.dev/playground/r/ZRTQNpR/c.lang.security.insecure-use-strcat-fn.insecure-use-strcat-fn
@@ -286,6 +300,8 @@ rules:
     shortlink: https://sg.run/7oNk
     semgrep.dev:
       rule:
+        r_id: 8838
+        rv_id: 109013
         rule_id: DbUpo5
         version_id: nWTxPoA
         url: https://semgrep.dev/playground/r/nWTxPoA/c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn
@@ -319,6 +335,8 @@ rules:
     shortlink: https://sg.run/LwqG
     semgrep.dev:
       rule:
+        r_id: 8839
+        rv_id: 109014
         rule_id: WAUo5v
         version_id: ExTjNA3
         url: https://semgrep.dev/playground/r/ExTjNA3/c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn
@@ -368,6 +386,8 @@ rules:
     shortlink: https://sg.run/8yNj
     semgrep.dev:
       rule:
+        r_id: 8840
+        rv_id: 109015
         rule_id: 0oU5k4
         version_id: 7ZTgonl
         url: https://semgrep.dev/playground/r/7ZTgonl/c.lang.security.random-fd-exhaustion.random-fd-exhaustion
@@ -407,6 +427,8 @@ rules:
     shortlink: https://sg.run/Y0Jy
     semgrep.dev:
       rule:
+        r_id: 18214
+        rv_id: 109180
         rule_id: ZqUlxE
         version_id: YDTp2kw
         url: https://semgrep.dev/playground/r/YDTp2kw/csharp.dotnet.security.mvc-missing-antiforgery.mvc-missing-antiforgery
@@ -463,6 +485,8 @@ rules:
     shortlink: https://sg.run/yPWx
     semgrep.dev:
       rule:
+        r_id: 17324
+        rv_id: 109181
         rule_id: 0oUrvj
         version_id: JdTNpGG
         url: https://semgrep.dev/playground/r/JdTNpGG/csharp.dotnet.security.net-webconfig-debug.net-webconfig-debug
@@ -506,6 +530,8 @@ rules:
     shortlink: https://sg.run/6bP1
     semgrep.dev:
       rule:
+        r_id: 18215
+        rv_id: 109182
         rule_id: nJUyJq
         version_id: 5PTdArE
         url: https://semgrep.dev/playground/r/5PTdArE/csharp.dotnet.security.net-webconfig-trace-enabled.net-webconfig-trace-enabled
@@ -553,6 +579,8 @@ rules:
     shortlink: https://sg.run/z1jd
     semgrep.dev:
       rule:
+        r_id: 18217
+        rv_id: 109188
         rule_id: 7KUxPg
         version_id: WrTWQG5
         url: https://semgrep.dev/playground/r/WrTWQG5/csharp.dotnet.security.web-config-insecure-cookie-settings.web-config-insecure-cookie-settings
@@ -621,6 +649,8 @@ rules:
     shortlink: https://sg.run/KA0d
     semgrep.dev:
       rule:
+        r_id: 28955
+        rv_id: 109193
         rule_id: bwU5kK
         version_id: YDTp2k5
         url: https://semgrep.dev/playground/r/YDTp2k5/csharp.lang.security.ad.jwt-tokenvalidationparameters-no-expiry-validation.jwt-tokenvalidationparameters-no-expiry-validation
@@ -658,6 +688,8 @@ rules:
     shortlink: https://sg.run/Ze6p
     semgrep.dev:
       rule:
+        r_id: 11479
+        rv_id: 255672
         rule_id: 9AUOjg
         version_id: 3ZTpYly
         url: https://semgrep.dev/playground/r/3ZTpYly/csharp.lang.security.injections.os-command.os-command-injection
@@ -759,6 +791,8 @@ rules:
     shortlink: https://sg.run/yXjP
     semgrep.dev:
       rule:
+        r_id: 18224
+        rv_id: 109201
         rule_id: PeUxb0
         version_id: 1QTOY3v
         url: https://semgrep.dev/playground/r/1QTOY3v/csharp.lang.security.insecure-deserialization.data-contract-resolver.data-contract-resolver
@@ -798,6 +832,8 @@ rules:
     shortlink: https://sg.run/nqnd
     semgrep.dev:
       rule:
+        r_id: 11136
+        rv_id: 109202
         rule_id: NbUAwk
         version_id: 9lTdWqB
         url: https://semgrep.dev/playground/r/9lTdWqB/csharp.lang.security.insecure-deserialization.fast-json.insecure-fastjson-deserialization
@@ -843,6 +879,8 @@ rules:
     shortlink: https://sg.run/rere
     semgrep.dev:
       rule:
+        r_id: 18225
+        rv_id: 109204
         rule_id: JDUlKl
         version_id: rxTyLl5
         url: https://semgrep.dev/playground/r/rxTyLl5/csharp.lang.security.insecure-deserialization.insecure-typefilterlevel-full.insecure-typefilterlevel-full
@@ -899,6 +937,8 @@ rules:
     shortlink: https://sg.run/0nJq
     semgrep.dev:
       rule:
+        r_id: 11198
+        rv_id: 109205
         rule_id: PeUkrK
         version_id: bZTb1QG
         url: https://semgrep.dev/playground/r/bZTb1QG/csharp.lang.security.insecure-deserialization.javascript-serializer.insecure-javascriptserializer-deserialization
@@ -964,6 +1004,8 @@ rules:
     shortlink: https://sg.run/8n2g
     semgrep.dev:
       rule:
+        r_id: 11140
+        rv_id: 109208
         rule_id: OrUGgl
         version_id: w8T9n51
         url: https://semgrep.dev/playground/r/w8T9n51/csharp.lang.security.insecure-deserialization.newtonsoft.insecure-newtonsoft-deserialization
@@ -997,6 +1039,8 @@ rules:
     shortlink: https://sg.run/b4eW
     semgrep.dev:
       rule:
+        r_id: 18226
+        rv_id: 109210
         rule_id: 5rUyEN
         version_id: O9TNOBk
         url: https://semgrep.dev/playground/r/O9TNOBk/csharp.lang.security.memory.memory-marshal-create-span.memory-marshal-create-span
@@ -1033,6 +1077,8 @@ rules:
     shortlink: https://sg.run/NgRy
     semgrep.dev:
       rule:
+        r_id: 18227
+        rv_id: 109213
         rule_id: GdUDBP
         version_id: d6TrALz
         url: https://semgrep.dev/playground/r/d6TrALz/csharp.lang.security.regular-expression-dos.regular-expression-dos-infinite-timeout.regular-expression-dos-infinite-timeout
@@ -1081,6 +1127,8 @@ rules:
     shortlink: https://sg.run/RPyY
     semgrep.dev:
       rule:
+        r_id: 12005
+        rv_id: 109214
         rule_id: 4bU2gd
         version_id: ZRTQNWg
         url: https://semgrep.dev/playground/r/ZRTQNWg/csharp.lang.security.regular-expression-dos.regular-expression-dos.regular-expression-dos
@@ -1177,6 +1225,8 @@ rules:
     shortlink: https://sg.run/d2Xd
     semgrep.dev:
       rule:
+        r_id: 15078
+        rv_id: 113530
         rule_id: x8UxeP
         version_id: DkT6Rg2
         url: https://semgrep.dev/playground/r/DkT6Rg2/csharp.lang.security.sqli.csharp-sqli.csharp-sqli
@@ -1212,6 +1262,8 @@ rules:
     shortlink: https://sg.run/4eB9
     semgrep.dev:
       rule:
+        r_id: 13700
+        rv_id: 109216
         rule_id: 10UdbE
         version_id: ExTjN6q
         url: https://semgrep.dev/playground/r/ExTjN6q/csharp.lang.security.ssrf.http-client.ssrf
@@ -1287,6 +1339,8 @@ rules:
     shortlink: https://sg.run/Pb9v
     semgrep.dev:
       rule:
+        r_id: 13701
+        rv_id: 109217
         rule_id: 9AURoq
         version_id: 7ZTgoPx
         url: https://semgrep.dev/playground/r/7ZTgoPx/csharp.lang.security.ssrf.rest-client.ssrf
@@ -1340,6 +1394,8 @@ rules:
     shortlink: https://sg.run/JxqP
     semgrep.dev:
       rule:
+        r_id: 13702
+        rv_id: 109218
         rule_id: yyUPBe
         version_id: LjTqQBz
         url: https://semgrep.dev/playground/r/LjTqQBz/csharp.lang.security.ssrf.web-client.ssrf
@@ -1434,6 +1490,8 @@ rules:
     shortlink: https://sg.run/5DWj
     semgrep.dev:
       rule:
+        r_id: 13703
+        rv_id: 109219
         rule_id: r6UwoG
         version_id: 8KTQ9nK
         url: https://semgrep.dev/playground/r/8KTQ9nK/csharp.lang.security.ssrf.web-request.ssrf
@@ -1505,6 +1563,8 @@ rules:
     shortlink: https://sg.run/XvkA
     semgrep.dev:
       rule:
+        r_id: 26720
+        rv_id: 109220
         rule_id: lBU6Dv
         version_id: gET3x0x
         url: https://semgrep.dev/playground/r/gET3x0x/csharp.lang.security.stacktrace-disclosure.stacktrace-disclosure
@@ -1548,6 +1608,8 @@ rules:
     shortlink: https://sg.run/P86E
     semgrep.dev:
       rule:
+        r_id: 13489
+        rv_id: 109224
         rule_id: lBUzPw
         version_id: PkTJ1be
         url: https://semgrep.dev/playground/r/PkTJ1be/csharp.razor.security.html-raw-json.html-raw-json
@@ -1598,6 +1660,8 @@ rules:
     shortlink: https://sg.run/5Z43
     semgrep.dev:
       rule:
+        r_id: 20147
+        rv_id: 675962
         rule_id: ReU2n5
         version_id: kbTw78l
         url: https://semgrep.dev/playground/r/kbTw78l/dockerfile.security.last-user-is-root.last-user-is-root
@@ -1642,6 +1706,8 @@ rules:
     shortlink: https://sg.run/k281
     semgrep.dev:
       rule:
+        r_id: 47272
+        rv_id: 109256
         rule_id: ReUW9E
         version_id: vdTYNBn
         url: https://semgrep.dev/playground/r/vdTYNBn/dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
@@ -1686,6 +1752,8 @@ rules:
     shortlink: https://sg.run/Gbvn
     semgrep.dev:
       rule:
+        r_id: 20148
+        rv_id: 109257
         rule_id: AbUN06
         version_id: d6TrApz
         url: https://semgrep.dev/playground/r/d6TrApz/dockerfile.security.missing-user.missing-user
@@ -1720,6 +1788,8 @@ rules:
     shortlink: https://sg.run/80Q7
     semgrep.dev:
       rule:
+        r_id: 66384
+        rv_id: 109258
         rule_id: kxUlx1
         version_id: ZRTQNXg
         url: https://semgrep.dev/playground/r/ZRTQNXg/dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile
@@ -1751,6 +1821,8 @@ rules:
     shortlink: https://sg.run/4l9l
     semgrep.dev:
       rule:
+        r_id: 16200
+        rv_id: 109325
         rule_id: gxUJrJ
         version_id: PkTJ1nv
         url: https://semgrep.dev/playground/r/PkTJ1nv/generic.ci.security.bash-reverse-shell.bash_reverse_shell
@@ -1825,6 +1897,8 @@ rules:
     shortlink: https://sg.run/ZvNL
     semgrep.dev:
       rule:
+        r_id: 9035
+        rv_id: 109343
         rule_id: 5rUOjq
         version_id: 2KTzrAQ
         url: https://semgrep.dev/playground/r/2KTzrAQ/generic.nginx.security.alias-path-traversal.alias-path-traversal
@@ -1866,6 +1940,8 @@ rules:
     shortlink: https://sg.run/ndpb
     semgrep.dev:
       rule:
+        r_id: 9036
+        rv_id: 109344
         rule_id: GdU7yl
         version_id: X0TQxo8
         url: https://semgrep.dev/playground/r/X0TQxo8/generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
@@ -1909,6 +1985,8 @@ rules:
     shortlink: https://sg.run/EkAo
     semgrep.dev:
       rule:
+        r_id: 9037
+        rv_id: 109345
         rule_id: ReUg7n
         version_id: jQTgYLq
         url: https://semgrep.dev/playground/r/jQTgYLq/generic.nginx.security.dynamic-proxy-scheme.dynamic-proxy-scheme
@@ -1958,6 +2036,8 @@ rules:
     shortlink: https://sg.run/7oj4
     semgrep.dev:
       rule:
+        r_id: 9038
+        rv_id: 109346
         rule_id: AbUz8p
         version_id: 1QTOY0e
         url: https://semgrep.dev/playground/r/1QTOY0e/generic.nginx.security.header-injection.header-injection
@@ -2014,6 +2094,8 @@ rules:
     shortlink: https://sg.run/Lwl7
     semgrep.dev:
       rule:
+        r_id: 9039
+        rv_id: 109347
         rule_id: BYUN58
         version_id: 9lTdWER
         url: https://semgrep.dev/playground/r/9lTdWER/generic.nginx.security.header-redefinition.header-redefinition
@@ -2061,6 +2143,8 @@ rules:
     shortlink: https://sg.run/8y14
     semgrep.dev:
       rule:
+        r_id: 9040
+        rv_id: 109348
         rule_id: DbUpJe
         version_id: yeTR2QA
         url: https://semgrep.dev/playground/r/yeTR2QA/generic.nginx.security.insecure-redirect.insecure-redirect
@@ -2108,6 +2192,8 @@ rules:
     shortlink: https://sg.run/gLKy
     semgrep.dev:
       rule:
+        r_id: 9041
+        rv_id: 109349
         rule_id: WAUo9k
         version_id: rxTyLbD
         url: https://semgrep.dev/playground/r/rxTyLbD/generic.nginx.security.insecure-ssl-version.insecure-ssl-version
@@ -2153,6 +2239,8 @@ rules:
     shortlink: https://sg.run/3xzl
     semgrep.dev:
       rule:
+        r_id: 9043
+        rv_id: 109351
         rule_id: KxUbeA
         version_id: NdT3d5q
         url: https://semgrep.dev/playground/r/NdT3d5q/generic.nginx.security.missing-ssl-version.missing-ssl-version
@@ -2220,6 +2308,8 @@ rules:
     shortlink: https://sg.run/ploZ
     semgrep.dev:
       rule:
+        r_id: 10562
+        rv_id: 109352
         rule_id: 6JUq0Z
         version_id: kbTdxrx
         url: https://semgrep.dev/playground/r/kbTdxrx/generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
@@ -2264,6 +2354,8 @@ rules:
     shortlink: https://sg.run/4x3Z
     semgrep.dev:
       rule:
+        r_id: 9044
+        rv_id: 109353
         rule_id: qNUjGg
         version_id: w8T9n4D
         url: https://semgrep.dev/playground/r/w8T9n4D/generic.nginx.security.request-host-used.request-host-used
@@ -2300,6 +2392,8 @@ rules:
     shortlink: https://sg.run/PJzE
     semgrep.dev:
       rule:
+        r_id: 9045
+        rv_id: 109519
         rule_id: lBU9bw
         version_id: ExTjNPp
         url: https://semgrep.dev/playground/r/ExTjNPp/generic.secrets.security.detected-amazon-mws-auth-token.detected-amazon-mws-auth-token
@@ -2357,6 +2451,8 @@ rules:
     shortlink: https://sg.run/J9KZ
     semgrep.dev:
       rule:
+        r_id: 9046
+        rv_id: 109520
         rule_id: YGUR5K
         version_id: 7ZTgoqQ
         url: https://semgrep.dev/playground/r/7ZTgoqQ/generic.secrets.security.detected-artifactory-password.detected-artifactory-password
@@ -2410,6 +2506,8 @@ rules:
     shortlink: https://sg.run/5Q2l
     semgrep.dev:
       rule:
+        r_id: 9047
+        rv_id: 109521
         rule_id: 6JUj3l
         version_id: LjTqQD4
         url: https://semgrep.dev/playground/r/LjTqQD4/generic.secrets.security.detected-artifactory-token.detected-artifactory-token
@@ -2480,6 +2578,8 @@ rules:
     shortlink: https://sg.run/Ro22
     semgrep.dev:
       rule:
+        r_id: 9049
+        rv_id: 253873
         rule_id: zdUkdd
         version_id: pZTk9GY
         url: https://semgrep.dev/playground/r/pZTk9GY/generic.secrets.security.detected-aws-account-id.detected-aws-account-id
@@ -2516,6 +2616,8 @@ rules:
     shortlink: https://sg.run/AvJ6
     semgrep.dev:
       rule:
+        r_id: 9050
+        rv_id: 109524
         rule_id: pKUOoZ
         version_id: QkTW0ln
         url: https://semgrep.dev/playground/r/QkTW0ln/generic.secrets.security.detected-aws-appsync-graphql-key.detected-aws-appsync-graphql-key
@@ -2554,6 +2656,8 @@ rules:
     shortlink: https://sg.run/Bk39
     semgrep.dev:
       rule:
+        r_id: 9051
+        rv_id: 109525
         rule_id: 2ZUbe8
         version_id: 3ZTkQD3
         url: https://semgrep.dev/playground/r/3ZTkQD3/generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key
@@ -2595,6 +2699,8 @@ rules:
     shortlink: https://sg.run/DoRW
     semgrep.dev:
       rule:
+        r_id: 9052
+        rv_id: 109526
         rule_id: X5U8Er
         version_id: 44TRlWe
         url: https://semgrep.dev/playground/r/44TRlWe/generic.secrets.security.detected-aws-session-token.detected-aws-session-token
@@ -2630,6 +2736,8 @@ rules:
     shortlink: https://sg.run/3A8G
     semgrep.dev:
       rule:
+        r_id: 10043
+        rv_id: 109527
         rule_id: PeUk0Q
         version_id: PkTJ1qQ
         url: https://semgrep.dev/playground/r/PkTJ1qQ/generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
@@ -2666,6 +2774,8 @@ rules:
     shortlink: https://sg.run/W8yz
     semgrep.dev:
       rule:
+        r_id: 9053
+        rv_id: 109528
         rule_id: j2UvW7
         version_id: JdTNpAp
         url: https://semgrep.dev/playground/r/JdTNpAp/generic.secrets.security.detected-codeclimate.detected-codeclimate
@@ -2702,6 +2812,8 @@ rules:
     shortlink: https://sg.run/4ylL
     semgrep.dev:
       rule:
+        r_id: 10044
+        rv_id: 258243
         rule_id: JDUP6p
         version_id: PkTWJ2o
         url: https://semgrep.dev/playground/r/PkTWJ2o/generic.secrets.security.detected-etc-shadow.detected-etc-shadow
@@ -2741,6 +2853,8 @@ rules:
     shortlink: https://sg.run/0QYJ
     semgrep.dev:
       rule:
+        r_id: 9054
+        rv_id: 109530
         rule_id: 10UKBL
         version_id: GxTv65k
         url: https://semgrep.dev/playground/r/GxTv65k/generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token
@@ -2777,6 +2891,8 @@ rules:
     shortlink: https://sg.run/Klq6
     semgrep.dev:
       rule:
+        r_id: 9055
+        rv_id: 109531
         rule_id: 9AU127
         version_id: RGTDkYp
         url: https://semgrep.dev/playground/r/RGTDkYp/generic.secrets.security.detected-facebook-oauth.detected-facebook-oauth
@@ -2816,6 +2932,8 @@ rules:
     shortlink: https://sg.run/qxj8
     semgrep.dev:
       rule:
+        r_id: 9056
+        rv_id: 109532
         rule_id: yyUn8p
         version_id: A8T951E
         url: https://semgrep.dev/playground/r/A8T951E/generic.secrets.security.detected-generic-api-key.detected-generic-api-key
@@ -2855,499 +2973,11 @@ rules:
     shortlink: https://sg.run/l2o5
     semgrep.dev:
       rule:
+        r_id: 9057
+        rv_id: 109533
         rule_id: r6Urqe
         version_id: BjTXrOJ
         url: https://semgrep.dev/playground/r/BjTXrOJ/generic.secrets.security.detected-generic-secret.detected-generic-secret
-        origin: community
-- id: generic.secrets.security.detected-github-token.detected-github-token
-  patterns:
-  - pattern-either:
-    - pattern: "$VAR = $SECRET\n"
-    - pattern: "$VAR: $SECRET\n"
-    - pattern: "$VAR = '$SECRET'\n"
-    - pattern: "$VAR: '$SECRET'\n"
-    - pattern: "'$VAR' = '$SECRET'\n"
-    - pattern: "'$VAR': '$SECRET'\n"
-    - pattern: '"[hH][tT][tT][pP][sS]?://.*$SECRET.*"
-
-        '
-  - metavariable-regex:
-      metavariable: "$SECRET"
-      regex: gh[pousr]_[A-Za-z0-9_]{36,251}
-  - metavariable-analysis:
-      analyzer: entropy
-      metavariable: "$SECRET"
-  languages:
-  - generic
-  message: GitHub Token detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
-    category: security
-    technology:
-    - secrets
-    - github
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-github-token.detected-github-token
-    shortlink: https://sg.run/PpOv
-    semgrep.dev:
-      rule:
-        rule_id: eqUv7b
-        version_id: DkT6n47
-        url: https://semgrep.dev/playground/r/DkT6n47/generic.secrets.security.detected-github-token.detected-github-token
-        origin: community
-- id: generic.secrets.security.detected-google-gcm-service-account.detected-google-gcm-service-account
-  pattern-regex: (("|'|`)?type("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?service_account("|'|`)?,?)
-  languages:
-  - regex
-  message: Google (GCM) Service account detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go
-    category: security
-    technology:
-    - secrets
-    - google-cloud
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-google-gcm-service-account.detected-google-gcm-service-account
-    shortlink: https://sg.run/6nXj
-    semgrep.dev:
-      rule:
-        rule_id: NbUkL8
-        version_id: K3TvjBP
-        url: https://semgrep.dev/playground/r/K3TvjBP/generic.secrets.security.detected-google-gcm-service-account.detected-google-gcm-service-account
-        origin: community
-- id: generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token
-  pattern-regex: ya29\.[0-9A-Za-z\-_]+
-  languages:
-  - regex
-  message: Google OAuth Access Token detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    technology:
-    - secrets
-    - google
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token
-    shortlink: https://sg.run/ox2n
-    semgrep.dev:
-      rule:
-        rule_id: kxUkpo
-        version_id: qkT2xzr
-        url: https://semgrep.dev/playground/r/qkT2xzr/generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token
-        origin: community
-- id: generic.secrets.security.detected-heroku-api-key.detected-heroku-api-key
-  pattern-regex: "[hH][eE][rR][oO][kK][uU].*[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
-  languages:
-  - regex
-  message: Heroku API Key detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    technology:
-    - secrets
-    - heroku
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-heroku-api-key.detected-heroku-api-key
-    shortlink: https://sg.run/pxXR
-    semgrep.dev:
-      rule:
-        rule_id: x8UnOB
-        version_id: YDTp2jG
-        url: https://semgrep.dev/playground/r/YDTp2jG/generic.secrets.security.detected-heroku-api-key.detected-heroku-api-key
-        origin: community
-- id: generic.secrets.security.detected-hockeyapp.detected-hockeyapp
-  pattern-regex: (?i)hockey.{0,50}(\\\"|'|`)?[0-9a-f]{32}(\\\"|'|`)?
-  languages:
-  - regex
-  message: HockeyApp detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go
-    category: security
-    technology:
-    - secrets
-    - hockeyapp
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-hockeyapp.detected-hockeyapp
-    shortlink: https://sg.run/2xoY
-    semgrep.dev:
-      rule:
-        rule_id: OrU3zo
-        version_id: 6xTvJOO
-        url: https://semgrep.dev/playground/r/6xTvJOO/generic.secrets.security.detected-hockeyapp.detected-hockeyapp
-        origin: community
-- id: generic.secrets.security.detected-jwt-token.detected-jwt-token
-  pattern-regex: eyJ[A-Za-z0-9-_=]{14,}\.[A-Za-z0-9-_=]{13,}\.?[A-Za-z0-9-_.+/=]*?
-  languages:
-  - regex
-  message: JWT token detected
-  severity: ERROR
-  metadata:
-    source-rule-url: https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/jwt.py
-    category: security
-    technology:
-    - secrets
-    - jwt
-    confidence: LOW
-    references:
-    - https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
-    cwe:
-    - 'CWE-321: Use of Hard-coded Cryptographic Key'
-    owasp:
-    - A02:2021 - Cryptographic Failures
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Cryptographic Issues
-    source: https://semgrep.dev/r/generic.secrets.security.detected-jwt-token.detected-jwt-token
-    shortlink: https://sg.run/05N5
-    semgrep.dev:
-      rule:
-        rule_id: kxU8E8
-        version_id: o5Tgljp
-        url: https://semgrep.dev/playground/r/o5Tgljp/generic.secrets.security.detected-jwt-token.detected-jwt-token
-        origin: community
-- id: generic.secrets.security.detected-kolide-api-key.detected-kolide-api-key
-  pattern-regex: k2sk_v[0-9]_[0-9a-zA-Z]{24}
-  languages:
-  - regex
-  message: Kolide API Key detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    category: security
-    technology:
-    - secrets
-    - kolide
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-kolide-api-key.detected-kolide-api-key
-    shortlink: https://sg.run/d2YQ
-    semgrep.dev:
-      rule:
-        rule_id: JDULYW
-        version_id: zyTK8vw
-        url: https://semgrep.dev/playground/r/zyTK8vw/generic.secrets.security.detected-kolide-api-key.detected-kolide-api-key
-        origin: community
-- id: generic.secrets.security.detected-mailchimp-api-key.detected-mailchimp-api-key
-  pattern-regex: "[0-9a-f]{32}-us[0-9]{1,2}"
-  languages:
-  - regex
-  message: MailChimp API Key detected
-  severity: ERROR
-  metadata:
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    technology:
-    - secrets
-    - mailchimp
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-mailchimp-api-key.detected-mailchimp-api-key
-    shortlink: https://sg.run/XBde
-    semgrep.dev:
-      rule:
-        rule_id: eqU8QR
-        version_id: pZT1yv8
-        url: https://semgrep.dev/playground/r/pZT1yv8/generic.secrets.security.detected-mailchimp-api-key.detected-mailchimp-api-key
-        origin: community
-- id: generic.secrets.security.detected-mailgun-api-key.detected-mailgun-api-key
-  pattern-regex: key-[0-9a-zA-Z]{32}
-  languages:
-  - regex
-  message: Mailgun API Key detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    technology:
-    - secrets
-    - mailgun
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-mailgun-api-key.detected-mailgun-api-key
-    shortlink: https://sg.run/jRL2
-    semgrep.dev:
-      rule:
-        rule_id: v8UneY
-        version_id: 2KTzrBe
-        url: https://semgrep.dev/playground/r/2KTzrBe/generic.secrets.security.detected-mailgun-api-key.detected-mailgun-api-key
-        origin: community
-- id: generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token
-  patterns:
-  - pattern: "$AUTHTOKEN = $VALUE"
-  - metavariable-regex:
-      metavariable: "$AUTHTOKEN"
-      regex: _(authToken|auth|password)
-  - pattern-not: "$AUTHTOKEN = ${...}"
-  languages:
-  - generic
-  message: NPM registry authentication token detected
-  paths:
-    include:
-    - "*npmrc*"
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    category: security
-    technology:
-    - secrets
-    - npm
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token
-    shortlink: https://sg.run/Ppg3
-    semgrep.dev:
-      rule:
-        rule_id: 5rU4pe
-        version_id: X0TQxXD
-        url: https://semgrep.dev/playground/r/X0TQxXD/generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token
-        origin: community
-- id: generic.secrets.security.detected-outlook-team.detected-outlook-team
-  pattern-regex: https://outlook\.office\.com/webhook/[0-9a-f-]{36}
-  languages:
-  - regex
-  message: Outlook Team detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go
-    category: security
-    technology:
-    - secrets
-    - outlook
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-outlook-team.detected-outlook-team
-    shortlink: https://sg.run/1ZwQ
-    semgrep.dev:
-      rule:
-        rule_id: d8UjXq
-        version_id: jQTgYAP
-        url: https://semgrep.dev/playground/r/jQTgYAP/generic.secrets.security.detected-outlook-team.detected-outlook-team
-        origin: community
-- id: generic.secrets.security.detected-paypal-braintree-access-token.detected-paypal-braintree-access-token
-  pattern-regex: access_token\$production\$[0-9a-z]{16}\$[0-9a-z]{32}
-  languages:
-  - regex
-  message: PayPal Braintree Access Token detected
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    technology:
-    - secrets
-    - paypal
-    - braintree
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-paypal-braintree-access-token.detected-paypal-braintree-access-token
-    shortlink: https://sg.run/9oBR
-    semgrep.dev:
-      rule:
-        rule_id: ZqU507
-        version_id: 1QTOYA1
-        url: https://semgrep.dev/playground/r/1QTOYA1/generic.secrets.security.detected-paypal-braintree-access-token.detected-paypal-braintree-access-token
-        origin: community
-- id: generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
-  pattern-regex: "-----BEGIN PGP PRIVATE KEY BLOCK-----"
-  languages:
-  - regex
-  message: Something that looks like a PGP private key block is detected. This is
-    a potential hardcoded secret that could be leaked if this code is committed. Instead,
-    remove this code block from the commit.
-  severity: ERROR
-  metadata:
-    cwe:
-    - 'CWE-798: Use of Hard-coded Credentials'
-    source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
-    category: security
-    technology:
-    - secrets
-    confidence: LOW
-    owasp:
-    - A07:2021 - Identification and Authentication Failures
-    references:
-    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Hard-coded Secrets
-    source: https://semgrep.dev/r/generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
-    shortlink: https://sg.run/ydKd
-    semgrep.dev:
-      rule:
-        rule_id: nJUzXz
-        version_id: 9lTdWYP
-        url: https://semgrep.dev/playground/r/9lTdWYP/generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
         origin: community
 - id: generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
   pattern-regex: sk_live_[0-9a-z]{32}
@@ -3381,6 +3011,8 @@ rules:
     shortlink: https://sg.run/rdGA
     semgrep.dev:
       rule:
+        r_id: 9069
+        rv_id: 109550
         rule_id: EwU274
         version_id: yeTR291
         url: https://semgrep.dev/playground/r/yeTR291/generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
@@ -3430,6 +3062,8 @@ rules:
     shortlink: https://sg.run/b7dr
     semgrep.dev:
       rule:
+        r_id: 9070
+        rv_id: 109551
         rule_id: 7KUQ0p
         version_id: rxTyLRv
         url: https://semgrep.dev/playground/r/rxTyLRv/generic.secrets.security.detected-private-key.detected-private-key
@@ -3466,6 +3100,8 @@ rules:
     shortlink: https://sg.run/N4k1
     semgrep.dev:
       rule:
+        r_id: 9071
+        rv_id: 109552
         rule_id: L1UyZ5
         version_id: bZTb1D3
         url: https://semgrep.dev/playground/r/bZTb1D3/generic.secrets.security.detected-sauce-token.detected-sauce-token
@@ -3502,6 +3138,8 @@ rules:
     shortlink: https://sg.run/qqOy
     semgrep.dev:
       rule:
+        r_id: 12856
+        rv_id: 109553
         rule_id: x8U2EG
         version_id: NdT3d0j
         url: https://semgrep.dev/playground/r/NdT3d0j/generic.secrets.security.detected-sendgrid-api-key.detected-sendgrid-api-key
@@ -3540,6 +3178,8 @@ rules:
     shortlink: https://sg.run/kXdz
     semgrep.dev:
       rule:
+        r_id: 9072
+        rv_id: 109554
         rule_id: 8GUjRA
         version_id: kbTdx0X
         url: https://semgrep.dev/playground/r/kbTdx0X/generic.secrets.security.detected-slack-token.detected-slack-token
@@ -3576,6 +3216,8 @@ rules:
     shortlink: https://sg.run/weWX
     semgrep.dev:
       rule:
+        r_id: 9073
+        rv_id: 109555
         rule_id: gxU1dy
         version_id: w8T9ndZ
         url: https://semgrep.dev/playground/r/w8T9ndZ/generic.secrets.security.detected-slack-webhook.detected-slack-webhook
@@ -3611,6 +3253,8 @@ rules:
     shortlink: https://sg.run/lxO9
     semgrep.dev:
       rule:
+        r_id: 12857
+        rv_id: 109556
         rule_id: OrUD9J
         version_id: xyTKZyY
         url: https://semgrep.dev/playground/r/xyTKZyY/generic.secrets.security.detected-snyk-api-key.detected-snyk-api-key
@@ -3647,6 +3291,8 @@ rules:
     shortlink: https://sg.run/YXq4
     semgrep.dev:
       rule:
+        r_id: 12858
+        rv_id: 109557
         rule_id: eqUplZ
         version_id: O9TNOKy
         url: https://semgrep.dev/playground/r/O9TNOKy/generic.secrets.security.detected-softlayer-api-key.detected-softlayer-api-key
@@ -3696,6 +3342,8 @@ rules:
     shortlink: https://sg.run/x10P
     semgrep.dev:
       rule:
+        r_id: 9074
+        rv_id: 109558
         rule_id: QrUzP1
         version_id: e1T01Xd
         url: https://semgrep.dev/playground/r/e1T01Xd/generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
@@ -3732,6 +3380,8 @@ rules:
     shortlink: https://sg.run/OP3b
     semgrep.dev:
       rule:
+        r_id: 9075
+        rv_id: 109559
         rule_id: 3qUPqO
         version_id: vdTYNxW
         url: https://semgrep.dev/playground/r/vdTYNxW/generic.secrets.security.detected-square-access-token.detected-square-access-token
@@ -3768,6 +3418,8 @@ rules:
     shortlink: https://sg.run/eL7E
     semgrep.dev:
       rule:
+        r_id: 9076
+        rv_id: 109560
         rule_id: 4bUk4l
         version_id: d6TrA5w
         url: https://semgrep.dev/playground/r/d6TrA5w/generic.secrets.security.detected-square-oauth-secret.detected-square-oauth-secret
@@ -3804,6 +3456,8 @@ rules:
     shortlink: https://sg.run/vzDR
     semgrep.dev:
       rule:
+        r_id: 9077
+        rv_id: 724918
         rule_id: PeUZ4d
         version_id: 3ZT6geb
         url: https://semgrep.dev/playground/r/3ZT6geb/generic.secrets.security.detected-ssh-password.detected-ssh-password
@@ -3840,6 +3494,8 @@ rules:
     shortlink: https://sg.run/dKd5
     semgrep.dev:
       rule:
+        r_id: 9078
+        rv_id: 109562
         rule_id: JDUy0z
         version_id: nWTxP1O
         url: https://semgrep.dev/playground/r/nWTxP1O/generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key
@@ -3876,6 +3532,8 @@ rules:
     shortlink: https://sg.run/ZvdL
     semgrep.dev:
       rule:
+        r_id: 9079
+        rv_id: 109563
         rule_id: 5rUOWq
         version_id: ExTjN3p
         url: https://semgrep.dev/playground/r/ExTjN3p/generic.secrets.security.detected-stripe-restricted-api-key.detected-stripe-restricted-api-key
@@ -3915,6 +3573,8 @@ rules:
     shortlink: https://sg.run/nd4b
     semgrep.dev:
       rule:
+        r_id: 9080
+        rv_id: 109564
         rule_id: GdU7Nl
         version_id: 7ZTgojQ
         url: https://semgrep.dev/playground/r/7ZTgojQ/generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key
@@ -3951,6 +3611,8 @@ rules:
     shortlink: https://sg.run/Ek2o
     semgrep.dev:
       rule:
+        r_id: 9081
+        rv_id: 109565
         rule_id: ReUgJn
         version_id: LjTqQo4
         url: https://semgrep.dev/playground/r/LjTqQo4/generic.secrets.security.detected-twilio-api-key.detected-twilio-api-key
@@ -3987,6 +3649,8 @@ rules:
     shortlink: https://sg.run/DL5d
     semgrep.dev:
       rule:
+        r_id: 52196
+        rv_id: 109567
         rule_id: EwU3kN
         version_id: gET3xog
         url: https://semgrep.dev/playground/r/gET3xog/generic.secrets.security.google-maps-apikeyleak.google-maps-apikeyleak
@@ -4032,6 +3696,8 @@ rules:
     shortlink: https://sg.run/nK4r
     semgrep.dev:
       rule:
+        r_id: 14880
+        rv_id: 109568
         rule_id: d8UeX4
         version_id: QkTW0jn
         url: https://semgrep.dev/playground/r/QkTW0jn/generic.unicode.security.bidi.contains-bidirectional-characters
@@ -4094,6 +3760,8 @@ rules:
     shortlink: https://sg.run/4xJZ
     semgrep.dev:
       rule:
+        r_id: 9088
+        rv_id: 109576
         rule_id: qNUj6g
         version_id: A8T95ZE
         url: https://semgrep.dev/playground/r/A8T95ZE/go.gorilla.security.audit.session-cookie-missing-httponly.session-cookie-missing-httponly
@@ -4142,6 +3810,8 @@ rules:
     shortlink: https://sg.run/PJdE
     semgrep.dev:
       rule:
+        r_id: 9089
+        rv_id: 109577
         rule_id: lBU9kw
         version_id: BjTXrnJ
         url: https://semgrep.dev/playground/r/BjTXrnJ/go.gorilla.security.audit.session-cookie-missing-secure.session-cookie-missing-secure
@@ -4149,6 +3819,54 @@ rules:
   fix-regex:
     regex: "(Secure\\s*:\\s+)false"
     replacement: "\\1true"
+  severity: WARNING
+  languages:
+  - go
+- id: go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
+  patterns:
+  - pattern-inside: |
+      &sessions.Options{
+        ...,
+        SameSite: http.SameSiteNoneMode,
+        ...,
+      }
+  - pattern: |
+      &sessions.Options{
+        ...,
+      }
+  message: Found SameSiteNoneMode setting in Gorilla session options. Consider setting
+    SameSite to Lax, Strict or Default for enhanced security.
+  metadata:
+    cwe:
+    - 'CWE-1275: Sensitive Cookie with Improper SameSite Attribute'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    references:
+    - https://pkg.go.dev/github.com/gorilla/sessions#Options
+    category: security
+    technology:
+    - gorilla
+    confidence: MEDIUM
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Cookie Security
+    source: https://semgrep.dev/r/go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
+    shortlink: https://sg.run/x8Nwj
+    semgrep.dev:
+      rule:
+        r_id: 133074
+        rv_id: 751089
+        rule_id: YGUpGd4
+        version_id: K3T5Lyr
+        url: https://semgrep.dev/playground/r/K3T5Lyr/go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
+        origin: community
+  fix-regex:
+    regex: "(SameSite\\s*:\\s+)http.SameSiteNoneMode"
+    replacement: "\\1http.SameSiteDefaultMode"
   severity: WARNING
   languages:
   - go
@@ -4197,6 +3915,8 @@ rules:
     shortlink: https://sg.run/xXpz
     semgrep.dev:
       rule:
+        r_id: 18430
+        rv_id: 109578
         rule_id: ReUKdz
         version_id: DkT6nZ7
         url: https://semgrep.dev/playground/r/DkT6nZ7/go.gorilla.security.audit.websocket-missing-origin-check.websocket-missing-origin-check
@@ -4224,6 +3944,8 @@ rules:
     shortlink: https://sg.run/J9yZ
     semgrep.dev:
       rule:
+        r_id: 9090
+        rv_id: 109580
         rule_id: PeUZ4X
         version_id: 0bTLlY6
         url: https://semgrep.dev/playground/r/0bTLlY6/go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
@@ -4264,6 +3986,8 @@ rules:
     shortlink: https://sg.run/5Q5l
     semgrep.dev:
       rule:
+        r_id: 9091
+        rv_id: 109581
         rule_id: JDUy0B
         version_id: K3Tvj6P
         url: https://semgrep.dev/playground/r/K3Tvj6P/go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
@@ -4319,6 +4043,8 @@ rules:
     shortlink: https://sg.run/Av66
     semgrep.dev:
       rule:
+        r_id: 9094
+        rv_id: 109582
         rule_id: ReUgJJ
         version_id: qkT2xPr
         url: https://semgrep.dev/playground/r/qkT2xPr/go.jwt-go.security.audit.jwt-parse-unverified.jwt-go-parse-unverified
@@ -4360,6 +4086,8 @@ rules:
     shortlink: https://sg.run/Gej1
     semgrep.dev:
       rule:
+        r_id: 9092
+        rv_id: 378644
         rule_id: 5rUOWQ
         version_id: 0bT59Rk
         url: https://semgrep.dev/playground/r/0bT59Rk/go.jwt-go.security.jwt-none-alg.jwt-go-none-algorithm
@@ -4408,6 +4136,8 @@ rules:
     shortlink: https://sg.run/l2gj
     semgrep.dev:
       rule:
+        r_id: 9113
+        rv_id: 109596
         rule_id: yyUnov
         version_id: l4T4vAR
         url: https://semgrep.dev/playground/r/l4T4vAR/go.lang.security.audit.crypto.bad_imports.insecure-module-used
@@ -4452,6 +4182,8 @@ rules:
     shortlink: https://sg.run/Yv6X
     semgrep.dev:
       rule:
+        r_id: 9114
+        rv_id: 109597
         rule_id: r6UrW9
         version_id: YDTp2K7
         url: https://semgrep.dev/playground/r/YDTp2K7/go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key
@@ -4489,6 +4221,8 @@ rules:
     shortlink: https://sg.run/9oY4
     semgrep.dev:
       rule:
+        r_id: 9123
+        rv_id: 109606
         rule_id: d8UjY3
         version_id: 9lTdWGe
         url: https://semgrep.dev/playground/r/9lTdWGe/go.lang.security.audit.crypto.use_of_weak_rsa_key.use-of-weak-rsa-key
@@ -4565,6 +4299,8 @@ rules:
     shortlink: https://sg.run/Bko5
     semgrep.dev:
       rule:
+        r_id: 9107
+        rv_id: 109607
         rule_id: pKUOZ9
         version_id: yeTR24B
         url: https://semgrep.dev/playground/r/yeTR24B/go.lang.security.audit.dangerous-command-write.dangerous-command-write
@@ -4665,6 +4401,8 @@ rules:
     shortlink: https://sg.run/Dorj
     semgrep.dev:
       rule:
+        r_id: 9108
+        rv_id: 109608
         rule_id: 2ZUb8l
         version_id: rxTyLpr
         url: https://semgrep.dev/playground/r/rxTyLpr/go.lang.security.audit.dangerous-exec-cmd.dangerous-exec-cmd
@@ -4745,6 +4483,8 @@ rules:
     shortlink: https://sg.run/W8lA
     semgrep.dev:
       rule:
+        r_id: 9109
+        rv_id: 109609
         rule_id: X5U8RQ
         version_id: bZTb17O
         url: https://semgrep.dev/playground/r/bZTb17O/go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
@@ -4858,6 +4598,8 @@ rules:
     shortlink: https://sg.run/0QRb
     semgrep.dev:
       rule:
+        r_id: 9110
+        rv_id: 109610
         rule_id: j2UvPl
         version_id: NdT3dKY
         url: https://semgrep.dev/playground/r/NdT3dKY/go.lang.security.audit.dangerous-syscall-exec.dangerous-syscall-exec
@@ -4899,6 +4641,8 @@ rules:
     shortlink: https://sg.run/ydEr
     semgrep.dev:
       rule:
+        r_id: 9124
+        rv_id: 258604
         rule_id: ZqU5bD
         version_id: JdT3NAn
         url: https://semgrep.dev/playground/r/JdT3NAn/go.lang.security.audit.database.string-formatted-query.string-formatted-query
@@ -5013,6 +4757,8 @@ rules:
     shortlink: https://sg.run/rdE0
     semgrep.dev:
       rule:
+        r_id: 9125
+        rv_id: 109613
         rule_id: nJUz3J
         version_id: xyTKZgN
         url: https://semgrep.dev/playground/r/xyTKZgN/go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
@@ -5052,6 +4798,8 @@ rules:
     shortlink: https://sg.run/weE0
     semgrep.dev:
       rule:
+        r_id: 9129
+        rv_id: 109617
         rule_id: 8GUjDW
         version_id: d6TrA0v
         url: https://semgrep.dev/playground/r/d6TrA0v/go.lang.security.audit.net.formatted-template-string.formatted-template-string
@@ -5111,6 +4859,8 @@ rules:
     shortlink: https://sg.run/x1Ep
     semgrep.dev:
       rule:
+        r_id: 9130
+        rv_id: 109619
         rule_id: gxU1Kp
         version_id: nWTxPb9
         url: https://semgrep.dev/playground/r/nWTxPb9/go.lang.security.audit.net.pprof.pprof-debug-exposure
@@ -5168,6 +4918,8 @@ rules:
     shortlink: https://sg.run/OPRp
     semgrep.dev:
       rule:
+        r_id: 9131
+        rv_id: 109620
         rule_id: QrUz9R
         version_id: ExTjNLe
         url: https://semgrep.dev/playground/r/ExTjNLe/go.lang.security.audit.net.unescaped-data-in-htmlattr.unescaped-data-in-htmlattr
@@ -5232,6 +4984,8 @@ rules:
     shortlink: https://sg.run/eLNl
     semgrep.dev:
       rule:
+        r_id: 9132
+        rv_id: 109621
         rule_id: 3qUP8K
         version_id: 7ZTgolZ
         url: https://semgrep.dev/playground/r/7ZTgolZ/go.lang.security.audit.net.unescaped-data-in-js.unescaped-data-in-js
@@ -5297,6 +5051,8 @@ rules:
     shortlink: https://sg.run/vzE4
     semgrep.dev:
       rule:
+        r_id: 9133
+        rv_id: 109622
         rule_id: 4bUkDW
         version_id: LjTqQWB
         url: https://semgrep.dev/playground/r/LjTqQWB/go.lang.security.audit.net.unescaped-data-in-url.unescaped-data-in-url
@@ -5331,41 +5087,6 @@ rules:
       $OTHER, $ERR = fmt.$P(..., $T, ...)
       ...
       template.URL($OTHER, ...)
-- id: go.lang.security.audit.net.use-tls.use-tls
-  pattern: http.ListenAndServe($ADDR, $HANDLER)
-  fix: http.ListenAndServeTLS($ADDR, certFile, keyFile, $HANDLER)
-  metadata:
-    cwe:
-    - 'CWE-319: Cleartext Transmission of Sensitive Information'
-    owasp:
-    - A03:2017 - Sensitive Data Exposure
-    - A02:2021 - Cryptographic Failures
-    references:
-    - https://golang.org/pkg/net/http/#ListenAndServeTLS
-    category: security
-    technology:
-    - go
-    confidence: MEDIUM
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Mishandled Sensitive Information
-    source: https://semgrep.dev/r/go.lang.security.audit.net.use-tls.use-tls
-    shortlink: https://sg.run/dKbY
-    semgrep.dev:
-      rule:
-        rule_id: PeUZ8X
-        version_id: 8KTQ9JB
-        url: https://semgrep.dev/playground/r/8KTQ9JB/go.lang.security.audit.net.use-tls.use-tls
-        origin: community
-  message: Found an HTTP server without TLS. Use 'http.ListenAndServeTLS' instead.
-    See https://golang.org/pkg/net/http/#ListenAndServeTLS for more information.
-  languages:
-  - go
-  severity: WARNING
 - id: go.lang.security.audit.reflect-makefunc.reflect-makefunc
   message: "'reflect.MakeFunc' detected. This will sidestep protections that are normally
     afforded by Go's type system. Audit this call and be sure that user input cannot
@@ -5393,6 +5114,8 @@ rules:
     shortlink: https://sg.run/KlPd
     semgrep.dev:
       rule:
+        r_id: 9111
+        rv_id: 109625
         rule_id: 10UKGb
         version_id: QkTW0YB
         url: https://semgrep.dev/playground/r/QkTW0YB/go.lang.security.audit.reflect-makefunc.reflect-makefunc
@@ -5444,6 +5167,8 @@ rules:
     shortlink: https://sg.run/R8Xv
     semgrep.dev:
       rule:
+        r_id: 10005
+        rv_id: 109630
         rule_id: BYUBdJ
         version_id: 5PTdAR2
         url: https://semgrep.dev/playground/r/5PTdAR2/go.lang.security.audit.unsafe-reflect-by-name.unsafe-reflect-by-name
@@ -5480,6 +5205,8 @@ rules:
     shortlink: https://sg.run/qxEx
     semgrep.dev:
       rule:
+        r_id: 9112
+        rv_id: 109631
         rule_id: 9AU1p1
         version_id: GxTv6nn
         url: https://semgrep.dev/playground/r/GxTv6nn/go.lang.security.audit.unsafe.use-of-unsafe-block
@@ -5520,6 +5247,8 @@ rules:
     shortlink: https://sg.run/ndEO
     semgrep.dev:
       rule:
+        r_id: 9136
+        rv_id: 109632
         rule_id: 5rUOZQ
         version_id: RGTDk68
         url: https://semgrep.dev/playground/r/RGTDk68/go.lang.security.audit.xss.import-text-template.import-text-template
@@ -5570,6 +5299,8 @@ rules:
     shortlink: https://sg.run/EkbA
     semgrep.dev:
       rule:
+        r_id: 9137
+        rv_id: 109633
         rule_id: GdU71y
         version_id: A8T95O8
         url: https://semgrep.dev/playground/r/A8T95O8/go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
@@ -5623,6 +5354,8 @@ rules:
     shortlink: https://sg.run/7oqR
     semgrep.dev:
       rule:
+        r_id: 9138
+        rv_id: 109634
         rule_id: ReUgyJ
         version_id: BjTXrgq
         url: https://semgrep.dev/playground/r/BjTXrgq/go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter
@@ -5674,6 +5407,8 @@ rules:
     shortlink: https://sg.run/LwJJ
     semgrep.dev:
       rule:
+        r_id: 9139
+        rv_id: 109635
         rule_id: AbUzBB
         version_id: DkT6nPE
         url: https://semgrep.dev/playground/r/DkT6nPE/go.lang.security.audit.xss.no-interpolation-in-tag.no-interpolation-in-tag
@@ -5722,6 +5457,8 @@ rules:
     shortlink: https://sg.run/8yl7
     semgrep.dev:
       rule:
+        r_id: 9140
+        rv_id: 109636
         rule_id: BYUNR6
         version_id: WrTWQX0
         url: https://semgrep.dev/playground/r/WrTWQX0/go.lang.security.audit.xss.no-interpolation-js-template-string.no-interpolation-js-template-string
@@ -5770,6 +5507,8 @@ rules:
     shortlink: https://sg.run/gLwn
     semgrep.dev:
       rule:
+        r_id: 9141
+        rv_id: 109637
         rule_id: DbUpEr
         version_id: 0bTLl8P
         url: https://semgrep.dev/playground/r/0bTLl8P/go.lang.security.audit.xss.no-io-writestring-to-responsewriter.no-io-writestring-to-responsewriter
@@ -5819,6 +5558,8 @@ rules:
     shortlink: https://sg.run/Q5BP
     semgrep.dev:
       rule:
+        r_id: 9142
+        rv_id: 109638
         rule_id: WAUoLp
         version_id: K3TvjDq
         url: https://semgrep.dev/playground/r/K3TvjDq/go.lang.security.audit.xss.no-printf-in-responsewriter.no-printf-in-responsewriter
@@ -5870,6 +5611,8 @@ rules:
     shortlink: https://sg.run/3xDb
     semgrep.dev:
       rule:
+        r_id: 9143
+        rv_id: 109639
         rule_id: 0oU5n3
         version_id: qkT2xdw
         url: https://semgrep.dev/playground/r/qkT2xdw/go.lang.security.audit.xss.template-html-does-not-escape.unsafe-template-type
@@ -5916,6 +5659,8 @@ rules:
     shortlink: https://sg.run/Gejn
     semgrep.dev:
       rule:
+        r_id: 9104
+        rv_id: 109641
         rule_id: 6JUjnL
         version_id: YDTp217
         url: https://semgrep.dev/playground/r/YDTp217/go.lang.security.bad_tmp.bad-tmp-file-creation
@@ -5990,6 +5735,8 @@ rules:
     shortlink: https://sg.run/RodK
     semgrep.dev:
       rule:
+        r_id: 9105
+        rv_id: 258244
         rule_id: oqUeqn
         version_id: JdT3NG6
         url: https://semgrep.dev/playground/r/JdT3NG6/go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
@@ -6023,6 +5770,8 @@ rules:
     shortlink: https://sg.run/Av64
     semgrep.dev:
       rule:
+        r_id: 9106
+        rv_id: 109647
         rule_id: zdUkoR
         version_id: X0TQxjB
         url: https://semgrep.dev/playground/r/X0TQxjB/go.lang.security.zip.path-traversal-inside-zip-extraction
@@ -6066,6 +5815,8 @@ rules:
     shortlink: https://sg.run/4xWE
     semgrep.dev:
       rule:
+        r_id: 9144
+        rv_id: 109648
         rule_id: KxUbxk
         version_id: jQTgY8k
         url: https://semgrep.dev/playground/r/jQTgY8k/go.otto.security.audit.dangerous-execution.dangerous-execution
@@ -6123,6 +5874,8 @@ rules:
     shortlink: https://sg.run/3A4o
     semgrep.dev:
       rule:
+        r_id: 9987
+        rv_id: 109673
         rule_id: JDUPQ7
         version_id: JdTNpEA
         url: https://semgrep.dev/playground/r/JdTNpEA/java.jboss.security.seam-log-injection.seam-log-injection
@@ -6162,6 +5915,8 @@ rules:
     shortlink: https://sg.run/0Q7b
     semgrep.dev:
       rule:
+        r_id: 9154
+        rv_id: 109675
         rule_id: j2Uvol
         version_id: GxTv63n
         url: https://semgrep.dev/playground/r/GxTv63n/java.jjwt.security.jwt-none-alg.jjwt-none-alg
@@ -6206,6 +5961,8 @@ rules:
     shortlink: https://sg.run/jR6A
     semgrep.dev:
       rule:
+        r_id: 9165
+        rv_id: 109680
         rule_id: eqU8J3
         version_id: WrTWQD0
         url: https://semgrep.dev/playground/r/WrTWQD0/java.lang.security.audit.anonymous-ldap-bind.anonymous-ldap-bind
@@ -6243,6 +6000,8 @@ rules:
     shortlink: https://sg.run/1Z7D
     semgrep.dev:
       rule:
+        r_id: 9166
+        rv_id: 109681
         rule_id: v8Uny0
         version_id: 0bTLlDP
         url: https://semgrep.dev/playground/r/0bTLlDP/java.lang.security.audit.bad-hexa-conversion.bad-hexa-conversion
@@ -6292,6 +6051,8 @@ rules:
     shortlink: https://sg.run/9o74
     semgrep.dev:
       rule:
+        r_id: 9167
+        rv_id: 109682
         rule_id: d8UjJ3
         version_id: K3TvjZq
         url: https://semgrep.dev/playground/r/K3TvjZq/java.lang.security.audit.blowfish-insufficient-key-size.blowfish-insufficient-key-size
@@ -6340,6 +6101,8 @@ rules:
     shortlink: https://sg.run/ydxr
     semgrep.dev:
       rule:
+        r_id: 9168
+        rv_id: 109683
         rule_id: ZqU5oD
         version_id: qkT2xEw
         url: https://semgrep.dev/playground/r/qkT2xEw/java.lang.security.audit.cbc-padding-oracle.cbc-padding-oracle
@@ -6456,6 +6219,8 @@ rules:
     shortlink: https://sg.run/rd90
     semgrep.dev:
       rule:
+        r_id: 9169
+        rv_id: 109684
         rule_id: nJUzvJ
         version_id: l4T4vgR
         url: https://semgrep.dev/playground/r/l4T4vgR/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
@@ -6643,6 +6408,8 @@ rules:
     shortlink: https://sg.run/gJJe
     semgrep.dev:
       rule:
+        r_id: 9941
+        rv_id: 109685
         rule_id: 4bUzzo
         version_id: YDTp2B7
         url: https://semgrep.dev/playground/r/YDTp2B7/java.lang.security.audit.command-injection-process-builder.command-injection-process-builder
@@ -6679,6 +6446,8 @@ rules:
     shortlink: https://sg.run/b7Be
     semgrep.dev:
       rule:
+        r_id: 9170
+        rv_id: 109686
         rule_id: EwU2z6
         version_id: JdTNpEW
         url: https://semgrep.dev/playground/r/JdTNpEW/java.lang.security.audit.cookie-missing-httponly.cookie-missing-httponly
@@ -6726,6 +6495,8 @@ rules:
     shortlink: https://sg.run/kXoK
     semgrep.dev:
       rule:
+        r_id: 9172
+        rv_id: 109688
         rule_id: L1Uyvp
         version_id: GxTv63G
         url: https://semgrep.dev/playground/r/GxTv63G/java.lang.security.audit.cookie-missing-secure-flag.cookie-missing-secure-flag
@@ -6774,6 +6545,8 @@ rules:
     shortlink: https://sg.run/PJ0p
     semgrep.dev:
       rule:
+        r_id: 9201
+        rv_id: 109698
         rule_id: KxUbW4
         version_id: YDTp25Q
         url: https://semgrep.dev/playground/r/YDTp25Q/java.lang.security.audit.crypto.ssl.avoid-implementing-custom-digests.avoid-implementing-custom-digests
@@ -6819,6 +6592,8 @@ rules:
     shortlink: https://sg.run/J9Gj
     semgrep.dev:
       rule:
+        r_id: 9202
+        rv_id: 109699
         rule_id: qNUj8b
         version_id: 6xTvJ31
         url: https://semgrep.dev/playground/r/6xTvJ31/java.lang.security.audit.crypto.ssl.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
@@ -6866,6 +6641,8 @@ rules:
     shortlink: https://sg.run/5QoD
     semgrep.dev:
       rule:
+        r_id: 9203
+        rv_id: 109700
         rule_id: lBU9n8
         version_id: o5Tglv2
         url: https://semgrep.dev/playground/r/o5Tglv2/java.lang.security.audit.crypto.ssl.insecure-hostname-verifier.insecure-hostname-verifier
@@ -6916,6 +6693,8 @@ rules:
     shortlink: https://sg.run/GePy
     semgrep.dev:
       rule:
+        r_id: 9204
+        rv_id: 109701
         rule_id: YGUR9A
         version_id: zyTK8dW
         url: https://semgrep.dev/playground/r/zyTK8dW/java.lang.security.audit.crypto.ssl.insecure-trust-manager.insecure-trust-manager
@@ -6983,6 +6762,8 @@ rules:
     shortlink: https://sg.run/NwBp
     semgrep.dev:
       rule:
+        r_id: 17327
+        rv_id: 109711
         rule_id: lBUW5D
         version_id: NdT3dLr
         url: https://semgrep.dev/playground/r/NdT3dLr/java.lang.security.audit.crypto.weak-random.weak-random
@@ -7042,6 +6823,8 @@ rules:
     shortlink: https://sg.run/58LK
     semgrep.dev:
       rule:
+        r_id: 10091
+        rv_id: 109713
         rule_id: ReUPKp
         version_id: w8T9nr4
         url: https://semgrep.dev/playground/r/w8T9nr4/java.lang.security.audit.dangerous-groovy-shell.dangerous-groovy-shell
@@ -7074,6 +6857,8 @@ rules:
     shortlink: https://sg.run/x1wp
     semgrep.dev:
       rule:
+        r_id: 9174
+        rv_id: 109714
         rule_id: gxU1Np
         version_id: xyTKZO1
         url: https://semgrep.dev/playground/r/xyTKZO1/java.lang.security.audit.el-injection.el-injection
@@ -7243,6 +7028,8 @@ rules:
     shortlink: https://sg.run/kkrX
     semgrep.dev:
       rule:
+        r_id: 11928
+        rv_id: 109718
         rule_id: KxUY7b
         version_id: d6TrA15
         url: https://semgrep.dev/playground/r/d6TrA15/java.lang.security.audit.java-reverse-shell.java-reverse-shell
@@ -7282,6 +7069,8 @@ rules:
     shortlink: https://sg.run/dKWY
     semgrep.dev:
       rule:
+        r_id: 9178
+        rv_id: 109719
         rule_id: PeUZNX
         version_id: ZRTQNn9
         url: https://semgrep.dev/playground/r/ZRTQNn9/java.lang.security.audit.jdbc-sql-formatted-string.jdbc-sql-formatted-string
@@ -7409,6 +7198,8 @@ rules:
     shortlink: https://sg.run/ZvOn
     semgrep.dev:
       rule:
+        r_id: 9179
+        rv_id: 109720
         rule_id: JDUy8B
         version_id: nWTxPjE
         url: https://semgrep.dev/playground/r/nWTxPjE/java.lang.security.audit.ldap-entry-poisoning.ldap-entry-poisoning
@@ -7460,6 +7251,8 @@ rules:
     shortlink: https://sg.run/nd2O
     semgrep.dev:
       rule:
+        r_id: 9180
+        rv_id: 109721
         rule_id: 5rUObQ
         version_id: ExTjNOO
         url: https://semgrep.dev/playground/r/ExTjNOO/java.lang.security.audit.ldap-injection.ldap-injection
@@ -7545,6 +7338,8 @@ rules:
     shortlink: https://sg.run/Ek0A
     semgrep.dev:
       rule:
+        r_id: 9181
+        rv_id: 109723
         rule_id: GdU7py
         version_id: LjTqQOj
         url: https://semgrep.dev/playground/r/LjTqQOj/java.lang.security.audit.object-deserialization.object-deserialization
@@ -7586,6 +7381,8 @@ rules:
     shortlink: https://sg.run/7o7R
     semgrep.dev:
       rule:
+        r_id: 9182
+        rv_id: 109724
         rule_id: ReUgjJ
         version_id: 8KTQ9Xw
         url: https://semgrep.dev/playground/r/8KTQ9Xw/java.lang.security.audit.ognl-injection.ognl-injection
@@ -8442,6 +8239,8 @@ rules:
     shortlink: https://sg.run/LwzJ
     semgrep.dev:
       rule:
+        r_id: 9183
+        rv_id: 109725
         rule_id: AbUzwB
         version_id: gET3xjQ
         url: https://semgrep.dev/playground/r/gET3xjQ/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission
@@ -8495,6 +8294,8 @@ rules:
     shortlink: https://sg.run/8y77
     semgrep.dev:
       rule:
+        r_id: 9184
+        rv_id: 109726
         rule_id: BYUN66
         version_id: QkTW0Dr
         url: https://semgrep.dev/playground/r/QkTW0Dr/java.lang.security.audit.permissive-cors.permissive-cors
@@ -8576,6 +8377,8 @@ rules:
     shortlink: https://sg.run/gLqn
     semgrep.dev:
       rule:
+        r_id: 9185
+        rv_id: 109727
         rule_id: DbUpAr
         version_id: 3ZTkQnw
         url: https://semgrep.dev/playground/r/3ZTkQnw/java.lang.security.audit.script-engine-injection.script-engine-injection
@@ -8715,6 +8518,8 @@ rules:
     shortlink: https://sg.run/Roqg
     semgrep.dev:
       rule:
+        r_id: 9205
+        rv_id: 109728
         rule_id: 6JUjPD
         version_id: 44TRlpj
         url: https://semgrep.dev/playground/r/44TRlpj/java.lang.security.audit.sqli.hibernate-sqli.hibernate-sqli
@@ -8790,6 +8595,8 @@ rules:
     shortlink: https://sg.run/AvkL
     semgrep.dev:
       rule:
+        r_id: 9206
+        rv_id: 109729
         rule_id: oqUe8K
         version_id: PkTJ1vy
         url: https://semgrep.dev/playground/r/PkTJ1vy/java.lang.security.audit.sqli.jdbc-sqli.jdbc-sqli
@@ -8894,6 +8701,8 @@ rules:
     shortlink: https://sg.run/Bkwx
     semgrep.dev:
       rule:
+        r_id: 9207
+        rv_id: 109730
         rule_id: zdUk7l
         version_id: JdTNpbW
         url: https://semgrep.dev/playground/r/JdTNpbW/java.lang.security.audit.sqli.jdo-sqli.jdo-sqli
@@ -8966,6 +8775,8 @@ rules:
     shortlink: https://sg.run/DoOd
     semgrep.dev:
       rule:
+        r_id: 9208
+        rv_id: 109731
         rule_id: pKUO7y
         version_id: 5PTdAjX
         url: https://semgrep.dev/playground/r/5PTdAjX/java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
@@ -9069,6 +8880,8 @@ rules:
     shortlink: https://sg.run/W8zL
     semgrep.dev:
       rule:
+        r_id: 9209
+        rv_id: 109733
         rule_id: 2ZUbJ3
         version_id: RGTDk7b
         url: https://semgrep.dev/playground/r/RGTDk7b/java.lang.security.audit.sqli.turbine-sqli.turbine-sqli
@@ -9148,6 +8961,8 @@ rules:
     shortlink: https://sg.run/0QKB
     semgrep.dev:
       rule:
+        r_id: 9210
+        rv_id: 109734
         rule_id: X5U86z
         version_id: A8T958Y
         url: https://semgrep.dev/playground/r/A8T958Y/java.lang.security.audit.sqli.vertx-sqli.vertx-sqli
@@ -9193,6 +9008,8 @@ rules:
     shortlink: https://sg.run/R8X8
     semgrep.dev:
       rule:
+        r_id: 9993
+        rv_id: 109740
         rule_id: DbUW1W
         version_id: qkT2x6j
         url: https://semgrep.dev/playground/r/qkT2x6j/java.lang.security.audit.unsafe-reflection.unsafe-reflection
@@ -9226,6 +9043,8 @@ rules:
     shortlink: https://sg.run/4x7E
     semgrep.dev:
       rule:
+        r_id: 9188
+        rv_id: 109743
         rule_id: KxUb1k
         version_id: 6xTvJn1
         url: https://semgrep.dev/playground/r/6xTvJn1/java.lang.security.audit.weak-ssl-context.weak-ssl-context
@@ -9276,6 +9095,8 @@ rules:
     shortlink: https://sg.run/PJjq
     semgrep.dev:
       rule:
+        r_id: 9189
+        rv_id: 109744
         rule_id: qNUj3y
         version_id: o5Tglq2
         url: https://semgrep.dev/playground/r/o5Tglq2/java.lang.security.audit.xml-decoder.xml-decoder
@@ -9329,6 +9150,8 @@ rules:
     shortlink: https://sg.run/qxne
     semgrep.dev:
       rule:
+        r_id: 9212
+        rv_id: 109745
         rule_id: 10UKqE
         version_id: zyTK8oW
         url: https://semgrep.dev/playground/r/zyTK8oW/java.lang.security.audit.xss.jsf.autoescape-disabled.autoescape-disabled
@@ -9369,6 +9192,8 @@ rules:
     shortlink: https://sg.run/J96Q
     semgrep.dev:
       rule:
+        r_id: 9190
+        rv_id: 109750
         rule_id: lBU9Gj
         version_id: 1QTOY6y
         url: https://semgrep.dev/playground/r/1QTOY6y/java.lang.security.audit.xssrequestwrapper-is-insecure.xssrequestwrapper-is-insecure
@@ -9417,6 +9242,8 @@ rules:
     shortlink: https://sg.run/6n76
     semgrep.dev:
       rule:
+        r_id: 9159
+        rv_id: 109757
         rule_id: bwUw28
         version_id: w8T9nX4
         url: https://semgrep.dev/playground/r/w8T9nX4/java.lang.security.do-privileged-use.do-privileged-use
@@ -9507,6 +9334,8 @@ rules:
     shortlink: https://sg.run/GDop
     semgrep.dev:
       rule:
+        r_id: 56948
+        rv_id: 109760
         rule_id: QrUD20
         version_id: e1T01QP
         url: https://semgrep.dev/playground/r/e1T01QP/java.lang.security.jackson-unsafe-deserialization.jackson-unsafe-deserialization
@@ -9539,6 +9368,8 @@ rules:
     shortlink: https://sg.run/L8qY
     semgrep.dev:
       rule:
+        r_id: 12683
+        rv_id: 109762
         rule_id: 6JU67x
         version_id: d6TrAX5
         url: https://semgrep.dev/playground/r/d6TrAX5/java.lang.security.use-snakeyaml-constructor.use-snakeyaml-constructor
@@ -9586,15 +9417,25 @@ rules:
     shortlink: https://sg.run/2x75
     semgrep.dev:
       rule:
+        r_id: 9163
+        rv_id: 745879
         rule_id: x8Unkq
-        version_id: ZRTQN09
-        url: https://semgrep.dev/playground/r/ZRTQN09/java.lang.security.xmlinputfactory-external-entities-enabled.xmlinputfactory-external-entities-enabled
+        version_id: WrTN4En
+        url: https://semgrep.dev/playground/r/WrTN4En/java.lang.security.xmlinputfactory-external-entities-enabled.xmlinputfactory-external-entities-enabled
         origin: community
   message: XML external entities are enabled for this XMLInputFactory. This is vulnerable
     to XML external entity attacks. Disable external entities by setting "javax.xml.stream.isSupportingExternalEntities"
     to false.
-  pattern: $XMLFACTORY.setProperty("javax.xml.stream.isSupportingExternalEntities",
-    true);
+  patterns:
+  - pattern-either:
+    - pattern: (javax.xml.stream.XMLInputFactory $XMLFACTORY).setProperty("javax.xml.stream.isSupportingExternalEntities",
+        true);
+    - pattern: "(javax.xml.stream.XMLInputFactory $XMLFACTORY).setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD,
+        true);"
+    - pattern: (javax.xml.stream.XMLInputFactory $XMLFACTORY).setProperty("javax.xml.stream.isSupportingExternalEntities",
+        Boolean.TRUE);
+    - pattern: "(javax.xml.stream.XMLInputFactory $XMLFACTORY).setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD,
+        Boolean.TRUE);"
   languages:
   - java
 - id: java.rmi.security.server-dangerous-class-deserialization.server-dangerous-class-deserialization
@@ -9626,6 +9467,8 @@ rules:
     shortlink: https://sg.run/oxg6
     semgrep.dev:
       rule:
+        r_id: 9216
+        rv_id: 109767
         rule_id: bwUwj4
         version_id: LjTqQZj
         url: https://semgrep.dev/playground/r/LjTqQZj/java.rmi.security.server-dangerous-class-deserialization.server-dangerous-class-deserialization
@@ -9674,6 +9517,8 @@ rules:
     shortlink: https://sg.run/zvnl
     semgrep.dev:
       rule:
+        r_id: 9217
+        rv_id: 109768
         rule_id: NbUkw5
         version_id: 8KTQ9Rw
         url: https://semgrep.dev/playground/r/8KTQ9Rw/java.rmi.security.server-dangerous-object-deserialization.server-dangerous-object-deserialization
@@ -9758,6 +9603,8 @@ rules:
     shortlink: https://sg.run/pxn0
     semgrep.dev:
       rule:
+        r_id: 9218
+        rv_id: 230005
         rule_id: kxUkn9
         version_id: xyTvPr0
         url: https://semgrep.dev/playground/r/xyTvPr0/java.servlets.security.cookie-issecure-false.cookie-issecure-false
@@ -9792,6 +9639,8 @@ rules:
     shortlink: https://sg.run/XBp4
     semgrep.dev:
       rule:
+        r_id: 9220
+        rv_id: 109770
         rule_id: x8Un7b
         version_id: QkTW0Pr
         url: https://semgrep.dev/playground/r/QkTW0Pr/java.spring.security.audit.spel-injection.spel-injection
@@ -9908,6 +9757,8 @@ rules:
     shortlink: https://sg.run/jRnl
     semgrep.dev:
       rule:
+        r_id: 9221
+        rv_id: 109775
         rule_id: OrU3gK
         version_id: 5PTdAWX
         url: https://semgrep.dev/playground/r/5PTdAWX/java.spring.security.audit.spring-csrf-disabled.spring-csrf-disabled
@@ -9947,6 +9798,8 @@ rules:
     shortlink: https://sg.run/Q88o
     semgrep.dev:
       rule:
+        r_id: 9942
+        rv_id: 109776
         rule_id: PeUkkL
         version_id: GxTv6NG
         url: https://semgrep.dev/playground/r/GxTv6NG/java.spring.security.audit.spring-jsp-eval.spring-jsp-eval
@@ -9997,6 +9850,8 @@ rules:
     shortlink: https://sg.run/2xlq
     semgrep.dev:
       rule:
+        r_id: 9219
+        rv_id: 109785
         rule_id: wdUJ7q
         version_id: l4T4vEd
         url: https://semgrep.dev/playground/r/l4T4vEd/java.spring.security.unrestricted-request-mapping.unrestricted-request-mapping
@@ -10029,6 +9884,8 @@ rules:
     shortlink: https://sg.run/d2jY
     semgrep.dev:
       rule:
+        r_id: 13578
+        rv_id: 109786
         rule_id: PeUo5X
         version_id: YDTp2LQ
         url: https://semgrep.dev/playground/r/YDTp2LQ/javascript.ajv.security.audit.ajv-allerrors-true.ajv-allerrors-true
@@ -10083,6 +9940,8 @@ rules:
     shortlink: https://sg.run/rdn1
     semgrep.dev:
       rule:
+        r_id: 9225
+        rv_id: 109789
         rule_id: ZqU5Yn
         version_id: GxTv61D
         url: https://semgrep.dev/playground/r/GxTv61D/javascript.angular.security.detect-angular-open-redirect.detect-angular-open-redirect
@@ -10126,6 +9985,8 @@ rules:
     shortlink: https://sg.run/b7kd
     semgrep.dev:
       rule:
+        r_id: 9226
+        rv_id: 109790
         rule_id: nJUzgX
         version_id: RGTDky2
         url: https://semgrep.dev/playground/r/RGTDky2/javascript.angular.security.detect-angular-resource-loading.detect-angular-resource-loading
@@ -10171,6 +10032,8 @@ rules:
     shortlink: https://sg.run/kXgo
     semgrep.dev:
       rule:
+        r_id: 9228
+        rv_id: 109792
         rule_id: 7KUQ4k
         version_id: BjTXrRr
         url: https://semgrep.dev/playground/r/BjTXrRr/javascript.angular.security.detect-angular-trust-as-css.detect-angular-trust-as-css-method
@@ -10219,6 +10082,8 @@ rules:
     shortlink: https://sg.run/wenn
     semgrep.dev:
       rule:
+        r_id: 9229
+        rv_id: 109793
         rule_id: L1Uy88
         version_id: DkT6nEY
         url: https://semgrep.dev/playground/r/DkT6nEY/javascript.angular.security.detect-angular-trust-as-html-method.detect-angular-trust-as-html-method
@@ -10267,6 +10132,8 @@ rules:
     shortlink: https://sg.run/x1nA
     semgrep.dev:
       rule:
+        r_id: 9230
+        rv_id: 109794
         rule_id: 8GUj8k
         version_id: WrTWQLq
         url: https://semgrep.dev/playground/r/WrTWQLq/javascript.angular.security.detect-angular-trust-as-js-method.detect-angular-trust-as-js-method
@@ -10315,6 +10182,8 @@ rules:
     shortlink: https://sg.run/eLOd
     semgrep.dev:
       rule:
+        r_id: 9232
+        rv_id: 109796
         rule_id: QrUzeq
         version_id: K3Tvjxg
         url: https://semgrep.dev/playground/r/K3Tvjxg/javascript.angular.security.detect-angular-trust-as-resourceurl-method.detect-angular-trust-as-resourceurl-method
@@ -10363,6 +10232,8 @@ rules:
     shortlink: https://sg.run/vznl
     semgrep.dev:
       rule:
+        r_id: 9233
+        rv_id: 109797
         rule_id: 3qUP01
         version_id: qkT2xDL
         url: https://semgrep.dev/playground/r/qkT2xDL/javascript.angular.security.detect-angular-trust-as-url-method.detect-angular-trust-as-url-method
@@ -10412,6 +10283,8 @@ rules:
     shortlink: https://sg.run/ZvXp
     semgrep.dev:
       rule:
+        r_id: 9235
+        rv_id: 109798
         rule_id: PeUZPg
         version_id: l4T4vE1
         url: https://semgrep.dev/playground/r/l4T4vE1/javascript.angular.security.detect-third-party-angular-translate.detect-angular-translateprovider-translations-method
@@ -10457,6 +10330,8 @@ rules:
     shortlink: https://sg.run/jkEZ
     semgrep.dev:
       rule:
+        r_id: 13021
+        rv_id: 109799
         rule_id: AbUGBR
         version_id: YDTp2LO
         url: https://semgrep.dev/playground/r/YDTp2LO/javascript.apollo.security.apollo-axios-ssrf.apollo-axios-ssrf
@@ -10512,6 +10387,8 @@ rules:
     shortlink: https://sg.run/AzoB
     semgrep.dev:
       rule:
+        r_id: 22550
+        rv_id: 109801
         rule_id: kxUYE9
         version_id: o5TglAW
         url: https://semgrep.dev/playground/r/o5TglAW/javascript.audit.detect-replaceall-sanitization.detect-replaceall-sanitization
@@ -10562,6 +10439,8 @@ rules:
     shortlink: https://sg.run/EkeL
     semgrep.dev:
       rule:
+        r_id: 9237
+        rv_id: 109814
         rule_id: 5rUOg6
         version_id: w8T9nYx
         url: https://semgrep.dev/playground/r/w8T9nYx/javascript.browser.security.dom-based-xss.dom-based-xss
@@ -10606,6 +10485,8 @@ rules:
     shortlink: https://sg.run/7ope
     semgrep.dev:
       rule:
+        r_id: 9238
+        rv_id: 109815
         rule_id: GdU7dw
         version_id: xyTKZ6r
         url: https://semgrep.dev/playground/r/xyTKZ6r/javascript.browser.security.eval-detected.eval-detected
@@ -10646,6 +10527,8 @@ rules:
     shortlink: https://sg.run/LwA9
     semgrep.dev:
       rule:
+        r_id: 9239
+        rv_id: 109816
         rule_id: ReUg41
         version_id: O9TNO1x
         url: https://semgrep.dev/playground/r/O9TNO1x/javascript.browser.security.insecure-document-method.insecure-document-method
@@ -10692,6 +10575,8 @@ rules:
     shortlink: https://sg.run/gL9x
     semgrep.dev:
       rule:
+        r_id: 9241
+        rv_id: 109818
         rule_id: BYUN0X
         version_id: vdTYNlP
         url: https://semgrep.dev/playground/r/vdTYNlP/javascript.browser.security.insufficient-postmessage-origin-validation.insufficient-postmessage-origin-validation
@@ -10756,6 +10641,8 @@ rules:
     shortlink: https://sg.run/PJ4p
     semgrep.dev:
       rule:
+        r_id: 9245
+        rv_id: 109824
         rule_id: KxUbq4
         version_id: LjTqQvN
         url: https://semgrep.dev/playground/r/LjTqQvN/javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
@@ -10797,6 +10684,8 @@ rules:
     shortlink: https://sg.run/BxzR
     semgrep.dev:
       rule:
+        r_id: 22551
+        rv_id: 109832
         rule_id: wdUKEq
         version_id: 5PTdAbp
         url: https://semgrep.dev/playground/r/5PTdAbp/javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage
@@ -10850,6 +10739,8 @@ rules:
     shortlink: https://sg.run/W70E
     semgrep.dev:
       rule:
+        r_id: 22553
+        rv_id: 109840
         rule_id: OrUX9K
         version_id: K3Tvj1g
         url: https://semgrep.dev/playground/r/K3Tvj1g/javascript.express.security.audit.express-detect-notevil-usage.express-detect-notevil-usage
@@ -10914,6 +10805,8 @@ rules:
     shortlink: https://sg.run/n8Ag
     semgrep.dev:
       rule:
+        r_id: 22080
+        rv_id: 109843
         rule_id: 2ZUY52
         version_id: YDTp2dO
         url: https://semgrep.dev/playground/r/YDTp2dO/javascript.express.security.audit.express-libxml-vm-noent.express-libxml-vm-noent
@@ -10976,6 +10869,8 @@ rules:
     shortlink: https://sg.run/OPv2
     semgrep.dev:
       rule:
+        r_id: 9275
+        rv_id: 109851
         rule_id: gxU12X
         version_id: 1QTOY1R
         url: https://semgrep.dev/playground/r/1QTOY1R/javascript.express.security.audit.possible-user-input-redirect.unknown-value-in-redirect
@@ -11027,6 +10922,8 @@ rules:
     shortlink: https://sg.run/dKXQ
     semgrep.dev:
       rule:
+        r_id: 9278
+        rv_id: 109855
         rule_id: 4bUkPO
         version_id: bZTb12y
         url: https://semgrep.dev/playground/r/bZTb12y/javascript.express.security.audit.xss.ejs.explicit-unescape.template-explicit-unescape
@@ -11075,6 +10972,8 @@ rules:
     shortlink: https://sg.run/Zv0p
     semgrep.dev:
       rule:
+        r_id: 9279
+        rv_id: 109856
         rule_id: PeUZrg
         version_id: NdT3d77
         url: https://semgrep.dev/playground/r/NdT3d77/javascript.express.security.audit.xss.ejs.var-in-href.var-in-href
@@ -11121,6 +11020,8 @@ rules:
     shortlink: https://sg.run/ndxZ
     semgrep.dev:
       rule:
+        r_id: 9280
+        rv_id: 109857
         rule_id: JDUyrJ
         version_id: kbTdx1n
         url: https://semgrep.dev/playground/r/kbTdx1n/javascript.express.security.audit.xss.ejs.var-in-script-src.var-in-script-src
@@ -11171,6 +11072,8 @@ rules:
     shortlink: https://sg.run/Ek9L
     semgrep.dev:
       rule:
+        r_id: 9281
+        rv_id: 109858
         rule_id: 5rUOD6
         version_id: w8T9nOx
         url: https://semgrep.dev/playground/r/w8T9nOx/javascript.express.security.audit.xss.ejs.var-in-script-tag.var-in-script-tag
@@ -11218,6 +11121,8 @@ rules:
     shortlink: https://sg.run/7oWe
     semgrep.dev:
       rule:
+        r_id: 9282
+        rv_id: 109859
         rule_id: GdU7Ew
         version_id: xyTKZkr
         url: https://semgrep.dev/playground/r/xyTKZkr/javascript.express.security.audit.xss.mustache.escape-function-overwrite.escape-function-overwrite
@@ -11265,6 +11170,8 @@ rules:
     shortlink: https://sg.run/Lwx9
     semgrep.dev:
       rule:
+        r_id: 9283
+        rv_id: 109860
         rule_id: ReUgG1
         version_id: O9TNO5x
         url: https://semgrep.dev/playground/r/O9TNO5x/javascript.express.security.audit.xss.mustache.explicit-unescape.template-explicit-unescape
@@ -11310,6 +11217,8 @@ rules:
     shortlink: https://sg.run/Q5jk
     semgrep.dev:
       rule:
+        r_id: 9286
+        rv_id: 109863
         rule_id: DbUpyq
         version_id: d6TrAJk
         url: https://semgrep.dev/playground/r/d6TrAJk/javascript.express.security.audit.xss.pug.and-attributes.template-and-attributes
@@ -11353,6 +11262,8 @@ rules:
     shortlink: https://sg.run/3xbe
     semgrep.dev:
       rule:
+        r_id: 9287
+        rv_id: 109864
         rule_id: WAUonl
         version_id: ZRTQNoL
         url: https://semgrep.dev/playground/r/ZRTQNoL/javascript.express.security.audit.xss.pug.explicit-unescape.template-explicit-unescape
@@ -11399,6 +11310,8 @@ rules:
     shortlink: https://sg.run/4xNx
     semgrep.dev:
       rule:
+        r_id: 9288
+        rv_id: 109865
         rule_id: 0oU535
         version_id: nWTxPv7
         url: https://semgrep.dev/playground/r/nWTxPv7/javascript.express.security.audit.xss.pug.var-in-href.var-in-href
@@ -11443,6 +11356,8 @@ rules:
     shortlink: https://sg.run/PJXp
     semgrep.dev:
       rule:
+        r_id: 9289
+        rv_id: 109866
         rule_id: KxUbL4
         version_id: ExTjNzk
         url: https://semgrep.dev/playground/r/ExTjNzk/javascript.express.security.audit.xss.pug.var-in-script-tag.var-in-script-tag
@@ -11488,6 +11403,8 @@ rules:
     shortlink: https://sg.run/pkpL
     semgrep.dev:
       rule:
+        r_id: 12818
+        rv_id: 109868
         rule_id: ReUo60
         version_id: LjTqQ8N
         url: https://semgrep.dev/playground/r/LjTqQ8N/javascript.express.security.express-data-exfiltration.express-data-exfiltration
@@ -11564,6 +11481,8 @@ rules:
     shortlink: https://sg.run/Do1d
     semgrep.dev:
       rule:
+        r_id: 9252
+        rv_id: 109871
         rule_id: pKUOjy
         version_id: QkTW0e7
         url: https://semgrep.dev/playground/r/QkTW0e7/javascript.express.security.express-jwt-hardcoded-secret.express-jwt-hardcoded-secret
@@ -11624,6 +11543,8 @@ rules:
     shortlink: https://sg.run/J9Yj
     semgrep.dev:
       rule:
+        r_id: 9290
+        rv_id: 109884
         rule_id: qNUjwb
         version_id: K3TvjWg
         url: https://semgrep.dev/playground/r/K3TvjWg/javascript.fbjs.security.audit.insecure-createnodesfrommarkup.insecure-createnodesfrommarkup
@@ -11667,6 +11588,8 @@ rules:
     shortlink: https://sg.run/5QkD
     semgrep.dev:
       rule:
+        r_id: 9291
+        rv_id: 109885
         rule_id: lBU9D8
         version_id: qkT2x8L
         url: https://semgrep.dev/playground/r/qkT2x8L/javascript.grpc.security.grpc-nodejs-insecure-connection.grpc-nodejs-insecure-connection
@@ -11730,6 +11653,8 @@ rules:
     shortlink: https://sg.run/BkAx
     semgrep.dev:
       rule:
+        r_id: 9295
+        rv_id: 109887
         rule_id: GdU7XP
         version_id: YDTp29O
         url: https://semgrep.dev/playground/r/YDTp29O/javascript.jose.security.audit.jose-exposed-data.jose-exposed-data
@@ -11786,6 +11711,8 @@ rules:
     shortlink: https://sg.run/J9YP
     semgrep.dev:
       rule:
+        r_id: 9302
+        rv_id: 109894
         rule_id: KxUbL3
         version_id: DkT6nrZ
         url: https://semgrep.dev/playground/r/DkT6nrZ/javascript.jsonwebtoken.security.audit.jwt-decode-without-verify.jwt-decode-without-verify
@@ -11840,6 +11767,8 @@ rules:
     shortlink: https://sg.run/5Qkj
     semgrep.dev:
       rule:
+        r_id: 9303
+        rv_id: 109895
         rule_id: qNUjwe
         version_id: WrTWQ4X
         url: https://semgrep.dev/playground/r/WrTWQ4X/javascript.jsonwebtoken.security.audit.jwt-exposed-data.jwt-exposed-data
@@ -11889,6 +11818,8 @@ rules:
     shortlink: https://sg.run/K9bn
     semgrep.dev:
       rule:
+        r_id: 22555
+        rv_id: 109918
         rule_id: v8UGEw
         version_id: e1T01kp
         url: https://semgrep.dev/playground/r/e1T01kp/javascript.lang.security.audit.hardcoded-hmac-key.hardcoded-hmac-key
@@ -11931,6 +11862,8 @@ rules:
     shortlink: https://sg.run/1GbQ
     semgrep.dev:
       rule:
+        r_id: 13466
+        rv_id: 109919
         rule_id: d8UlRq
         version_id: vdTYNz9
         url: https://semgrep.dev/playground/r/vdTYNz9/javascript.lang.security.audit.incomplete-sanitization.incomplete-sanitization
@@ -11976,6 +11909,8 @@ rules:
     shortlink: https://sg.run/w1DB
     semgrep.dev:
       rule:
+        r_id: 13373
+        rv_id: 109925
         rule_id: QrUpbJ
         version_id: LjTqQbA
         url: https://semgrep.dev/playground/r/LjTqQbA/javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop
@@ -12047,6 +11982,8 @@ rules:
     shortlink: https://sg.run/Wgeo
     semgrep.dev:
       rule:
+        r_id: 9853
+        rv_id: 109926
         rule_id: lBUdr5
         version_id: 8KTQ9k5
         url: https://semgrep.dev/playground/r/8KTQ9k5/javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
@@ -12104,6 +12041,8 @@ rules:
     shortlink: https://sg.run/1Zy1
     semgrep.dev:
       rule:
+        r_id: 9322
+        rv_id: 109931
         rule_id: OrU37Y
         version_id: PkTJ1rO
         url: https://semgrep.dev/playground/r/PkTJ1rO/javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
@@ -12146,6 +12085,8 @@ rules:
     shortlink: https://sg.run/qxpO
     semgrep.dev:
       rule:
+        r_id: 9312
+        rv_id: 109943
         rule_id: j2Uvj8
         version_id: l4T4vOE
         url: https://semgrep.dev/playground/r/l4T4vOE/javascript.lang.security.detect-buffer-noassert.detect-buffer-noassert
@@ -12191,6 +12132,8 @@ rules:
     shortlink: https://sg.run/l2lo
     semgrep.dev:
       rule:
+        r_id: 9313
+        rv_id: 109944
         rule_id: 10UKNB
         version_id: YDTp20d
         url: https://semgrep.dev/playground/r/YDTp20d/javascript.lang.security.detect-child-process.detect-child-process
@@ -12274,6 +12217,8 @@ rules:
     shortlink: https://sg.run/Yvwd
     semgrep.dev:
       rule:
+        r_id: 9314
+        rv_id: 109945
         rule_id: 9AU17r
         version_id: 6xTvJgP
         url: https://semgrep.dev/playground/r/6xTvJgP/javascript.lang.security.detect-disable-mustache-escape.detect-disable-mustache-escape
@@ -12314,6 +12259,8 @@ rules:
     shortlink: https://sg.run/GWyz
     semgrep.dev:
       rule:
+        r_id: 10048
+        rv_id: 109947
         rule_id: AbUWeE
         version_id: zyTK8J3
         url: https://semgrep.dev/playground/r/zyTK8J3/javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
@@ -12355,6 +12302,8 @@ rules:
     shortlink: https://sg.run/oxoX
     semgrep.dev:
       rule:
+        r_id: 9316
+        rv_id: 109948
         rule_id: r6UrvQ
         version_id: pZT1yj3
         url: https://semgrep.dev/playground/r/pZT1yj3/javascript.lang.security.detect-no-csrf-before-method-override.detect-no-csrf-before-method-override
@@ -12398,6 +12347,8 @@ rules:
     shortlink: https://sg.run/pxze
     semgrep.dev:
       rule:
+        r_id: 9318
+        rv_id: 109950
         rule_id: NbUkR2
         version_id: X0TQxN9
         url: https://semgrep.dev/playground/r/X0TQxN9/javascript.lang.security.detect-pseudorandombytes.detect-pseudoRandomBytes
@@ -12438,6 +12389,8 @@ rules:
     shortlink: https://sg.run/2xrr
     semgrep.dev:
       rule:
+        r_id: 9319
+        rv_id: 109953
         rule_id: kxUkPP
         version_id: 9lTdW0z
         url: https://semgrep.dev/playground/r/9lTdW0z/javascript.lang.security.spawn-git-clone.spawn-git-clone
@@ -12487,6 +12440,8 @@ rules:
     shortlink: https://sg.run/Jx7R
     semgrep.dev:
       rule:
+        r_id: 14402
+        rv_id: 109954
         rule_id: zdUYQb
         version_id: yeTR21L
         url: https://semgrep.dev/playground/r/yeTR21L/javascript.monaco-editor.security.audit.monaco-hover-htmlsupport.monaco-hover-htmlsupport
@@ -12538,6 +12493,8 @@ rules:
     shortlink: https://sg.run/eLdL
     semgrep.dev:
       rule:
+        r_id: 9332
+        rv_id: 109955
         rule_id: gxU171
         version_id: rxTyLzP
         url: https://semgrep.dev/playground/r/rxTyLzP/javascript.node-expat.security.audit.expat-xxe.expat-xxe
@@ -12631,6 +12588,8 @@ rules:
     shortlink: https://sg.run/dKv0
     semgrep.dev:
       rule:
+        r_id: 9334
+        rv_id: 109957
         rule_id: 3qUPXE
         version_id: NdT3dR3
         url: https://semgrep.dev/playground/r/NdT3dR3/javascript.phantom.security.audit.phantom-injection.phantom-injection
@@ -12681,6 +12640,8 @@ rules:
     shortlink: https://sg.run/Zv94
     semgrep.dev:
       rule:
+        r_id: 9335
+        rv_id: 109958
         rule_id: 4bUkj1
         version_id: kbTdxPg
         url: https://semgrep.dev/playground/r/kbTdxPg/javascript.playwright.security.audit.playwright-addinitscript-code-injection.playwright-addinitscript-code-injection
@@ -12726,6 +12687,8 @@ rules:
     shortlink: https://sg.run/ndgr
     semgrep.dev:
       rule:
+        r_id: 9336
+        rv_id: 109959
         rule_id: PeUZ30
         version_id: w8T9nbz
         url: https://semgrep.dev/playground/r/w8T9nbz/javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection
@@ -12771,6 +12734,8 @@ rules:
     shortlink: https://sg.run/EkJB
     semgrep.dev:
       rule:
+        r_id: 9337
+        rv_id: 109960
         rule_id: JDUyxl
         version_id: xyTKZrn
         url: https://semgrep.dev/playground/r/xyTKZrn/javascript.playwright.security.audit.playwright-evaluate-code-injection.playwright-evaluate-code-injection
@@ -12822,6 +12787,8 @@ rules:
     shortlink: https://sg.run/7oEQ
     semgrep.dev:
       rule:
+        r_id: 9338
+        rv_id: 109961
         rule_id: 5rUO1N
         version_id: O9TNO7G
         url: https://semgrep.dev/playground/r/O9TNO7G/javascript.playwright.security.audit.playwright-exposed-chrome-devtools.playwright-exposed-chrome-devtools
@@ -12866,6 +12833,8 @@ rules:
     shortlink: https://sg.run/LwWY
     semgrep.dev:
       rule:
+        r_id: 9339
+        rv_id: 109962
         rule_id: GdU7eP
         version_id: e1T01Kp
         url: https://semgrep.dev/playground/r/e1T01Kp/javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection
@@ -12913,6 +12882,8 @@ rules:
     shortlink: https://sg.run/8yEQ
     semgrep.dev:
       rule:
+        r_id: 9340
+        rv_id: 109963
         rule_id: ReUgLk
         version_id: vdTYNQ9
         url: https://semgrep.dev/playground/r/vdTYNQ9/javascript.playwright.security.audit.playwright-setcontent-injection.playwright-setcontent-injection
@@ -12960,6 +12931,8 @@ rules:
     shortlink: https://sg.run/gLQ5
     semgrep.dev:
       rule:
+        r_id: 9341
+        rv_id: 109964
         rule_id: AbUzdX
         version_id: d6TrAg4
         url: https://semgrep.dev/playground/r/d6TrAg4/javascript.puppeteer.security.audit.puppeteer-evaluate-arg-injection.puppeteer-evaluate-arg-injection
@@ -13006,6 +12979,8 @@ rules:
     shortlink: https://sg.run/Q5Yq
     semgrep.dev:
       rule:
+        r_id: 9342
+        rv_id: 109965
         rule_id: BYUNZk
         version_id: ZRTQNdl
         url: https://semgrep.dev/playground/r/ZRTQNdl/javascript.puppeteer.security.audit.puppeteer-evaluate-code-injection.puppeteer-evaluate-code-injection
@@ -13057,6 +13032,8 @@ rules:
     shortlink: https://sg.run/3xEW
     semgrep.dev:
       rule:
+        r_id: 9343
+        rv_id: 109966
         rule_id: DbUpbk
         version_id: nWTxPNn
         url: https://semgrep.dev/playground/r/nWTxPNn/javascript.puppeteer.security.audit.puppeteer-exposed-chrome-devtools.puppeteer-exposed-chrome-devtools
@@ -13101,6 +13078,8 @@ rules:
     shortlink: https://sg.run/4xE9
     semgrep.dev:
       rule:
+        r_id: 9344
+        rv_id: 109967
         rule_id: WAUoK7
         version_id: ExTjNWg
         url: https://semgrep.dev/playground/r/ExTjNWg/javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection
@@ -13148,6 +13127,8 @@ rules:
     shortlink: https://sg.run/PJlv
     semgrep.dev:
       rule:
+        r_id: 9345
+        rv_id: 109968
         rule_id: 0oU5zg
         version_id: 7ZTgoRo
         url: https://semgrep.dev/playground/r/7ZTgoRo/javascript.puppeteer.security.audit.puppeteer-setcontent-injection.puppeteer-setcontent-injection
@@ -13192,6 +13173,8 @@ rules:
     shortlink: https://sg.run/J9BP
     semgrep.dev:
       rule:
+        r_id: 9346
+        rv_id: 109970
         rule_id: KxUbk3
         version_id: 8KTQ9l5
         url: https://semgrep.dev/playground/r/8KTQ9l5/javascript.sandbox.security.audit.sandbox-code-injection.sandbox-code-injection
@@ -13253,6 +13236,8 @@ rules:
     shortlink: https://sg.run/5QEj
     semgrep.dev:
       rule:
+        r_id: 9347
+        rv_id: 109971
         rule_id: qNUj7e
         version_id: gET3xXP
         url: https://semgrep.dev/playground/r/gET3xXP/javascript.sax.security.audit.sax-xxe.sax-xxe
@@ -13301,6 +13286,8 @@ rules:
     shortlink: https://sg.run/yz6Z
     semgrep.dev:
       rule:
+        r_id: 9968
+        rv_id: 109972
         rule_id: NbUAYW
         version_id: QkTW0NE
         url: https://semgrep.dev/playground/r/QkTW0NE/javascript.sequelize.security.audit.sequelize-enforce-tls.sequelize-enforce-tls
@@ -13371,6 +13358,8 @@ rules:
     shortlink: https://sg.run/rAkj
     semgrep.dev:
       rule:
+        r_id: 9969
+        rv_id: 109975
         rule_id: kxUR80
         version_id: PkTJ1GO
         url: https://semgrep.dev/playground/r/PkTJ1GO/javascript.sequelize.security.audit.sequelize-tls-disabled-cert-validation.sequelize-tls-disabled-cert-validation
@@ -13427,6 +13416,8 @@ rules:
     shortlink: https://sg.run/bDrq
     semgrep.dev:
       rule:
+        r_id: 9970
+        rv_id: 109976
         rule_id: wdU8GB
         version_id: JdTNpRZ
         url: https://semgrep.dev/playground/r/JdTNpRZ/javascript.sequelize.security.audit.sequelize-weak-tls-version.sequelize-weak-tls-version
@@ -13482,6 +13473,8 @@ rules:
     shortlink: https://sg.run/Ro6N
     semgrep.dev:
       rule:
+        r_id: 9349
+        rv_id: 109977
         rule_id: YGURez
         version_id: 5PTdAGB
         url: https://semgrep.dev/playground/r/5PTdAGB/javascript.serialize-javascript.security.audit.unsafe-serialize-javascript.unsafe-serialize-javascript
@@ -13526,6 +13519,8 @@ rules:
     shortlink: https://sg.run/AvEB
     semgrep.dev:
       rule:
+        r_id: 9350
+        rv_id: 109978
         rule_id: 6JUj9k
         version_id: GxTv6Xg
         url: https://semgrep.dev/playground/r/GxTv6Xg/javascript.shelljs.security.shelljs-exec-injection.shelljs-exec-injection
@@ -13570,6 +13565,8 @@ rules:
     shortlink: https://sg.run/BkER
     semgrep.dev:
       rule:
+        r_id: 9351
+        rv_id: 109979
         rule_id: oqUeDG
         version_id: RGTDkxN
         url: https://semgrep.dev/playground/r/RGTDkxN/javascript.thenify.security.audit.multiargs-code-execution.multiargs-code-execution
@@ -13622,6 +13619,8 @@ rules:
     shortlink: https://sg.run/DoPG
     semgrep.dev:
       rule:
+        r_id: 9352
+        rv_id: 109980
         rule_id: zdUk2g
         version_id: A8T95lP
         url: https://semgrep.dev/playground/r/A8T95lP/javascript.vm2.security.audit.vm2-code-injection.vm2-code-injection
@@ -13700,6 +13699,8 @@ rules:
     shortlink: https://sg.run/W8XE
     semgrep.dev:
       rule:
+        r_id: 9353
+        rv_id: 109981
         rule_id: pKUO3v
         version_id: BjTXrLO
         url: https://semgrep.dev/playground/r/BjTXrLO/javascript.vm2.security.audit.vm2-context-injection.vm2-context-injection
@@ -14063,6 +14064,8 @@ rules:
     shortlink: https://sg.run/0QEw
     semgrep.dev:
       rule:
+        r_id: 9354
+        rv_id: 109982
         rule_id: 2ZUb2o
         version_id: DkT6nyZ
         url: https://semgrep.dev/playground/r/DkT6nyZ/javascript.vue.security.audit.xss.templates.avoid-v-html.avoid-v-html
@@ -14101,6 +14104,8 @@ rules:
     shortlink: https://sg.run/KlDn
     semgrep.dev:
       rule:
+        r_id: 9355
+        rv_id: 109983
         rule_id: X5U8yj
         version_id: WrTWQnX
         url: https://semgrep.dev/playground/r/WrTWQnX/javascript.wkhtmltoimage.security.audit.wkhtmltoimage-injection.wkhtmltoimage-injection
@@ -14145,6 +14150,8 @@ rules:
     shortlink: https://sg.run/qx8O
     semgrep.dev:
       rule:
+        r_id: 9356
+        rv_id: 109984
         rule_id: j2Uv58
         version_id: 0bTLl3D
         url: https://semgrep.dev/playground/r/0bTLl3D/javascript.wkhtmltopdf.security.audit.wkhtmltopdf-injection.wkhtmltopdf-injection
@@ -14195,6 +14202,8 @@ rules:
     shortlink: https://sg.run/l27o
     semgrep.dev:
       rule:
+        r_id: 9357
+        rv_id: 109985
         rule_id: 10UKpB
         version_id: K3TvjLe
         url: https://semgrep.dev/playground/r/K3TvjLe/javascript.xml2json.security.audit.xml2json-xxe.xml2json-xxe
@@ -14241,6 +14250,8 @@ rules:
     shortlink: https://sg.run/b25p
     semgrep.dev:
       rule:
+        r_id: 15126
+        rv_id: 109991
         rule_id: d8UegG
         version_id: GxTv6XX
         url: https://semgrep.dev/playground/r/GxTv6XX/kotlin.lang.security.bad-hexa-conversion.bad-hexa-conversion
@@ -14292,6 +14303,8 @@ rules:
     shortlink: https://sg.run/6nEK
     semgrep.dev:
       rule:
+        r_id: 9359
+        rv_id: 109992
         rule_id: yyUnpo
         version_id: RGTDkxL
         url: https://semgrep.dev/playground/r/RGTDkxL/kotlin.lang.security.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
@@ -14328,6 +14341,8 @@ rules:
     shortlink: https://sg.run/ox7X
     semgrep.dev:
       rule:
+        r_id: 9360
+        rv_id: 109993
         rule_id: r6UrKQ
         version_id: A8T95l2
         url: https://semgrep.dev/playground/r/A8T95l2/kotlin.lang.security.cookie-missing-httponly.cookie-missing-httponly
@@ -14373,6 +14388,8 @@ rules:
     shortlink: https://sg.run/zv7n
     semgrep.dev:
       rule:
+        r_id: 9361
+        rv_id: 109994
         rule_id: bwUw3j
         version_id: BjTXrLP
         url: https://semgrep.dev/playground/r/BjTXrLP/kotlin.lang.security.cookie-missing-secure-flag.cookie-missing-secure-flag
@@ -14424,6 +14441,8 @@ rules:
     shortlink: https://sg.run/RXEK
     semgrep.dev:
       rule:
+        r_id: 14693
+        rv_id: 109995
         rule_id: ReU3Yb
         version_id: DkT6nyD
         url: https://semgrep.dev/playground/r/DkT6nyD/kotlin.lang.security.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
@@ -14461,6 +14480,8 @@ rules:
     shortlink: https://sg.run/WpPA
     semgrep.dev:
       rule:
+        r_id: 14697
+        rv_id: 109997
         rule_id: WAUyAW
         version_id: 0bTLl3v
         url: https://semgrep.dev/playground/r/0bTLl3v/kotlin.lang.security.gcm-detection.gcm-detection
@@ -14511,6 +14532,8 @@ rules:
     shortlink: https://sg.run/KXZd
     semgrep.dev:
       rule:
+        r_id: 14699
+        rv_id: 109999
         rule_id: KxU76z
         version_id: qkT2xwl
         url: https://semgrep.dev/playground/r/qkT2xwl/kotlin.lang.security.unencrypted-socket.unencrypted-socket
@@ -14558,6 +14581,8 @@ rules:
     shortlink: https://sg.run/krq7
     semgrep.dev:
       rule:
+        r_id: 15128
+        rv_id: 110002
         rule_id: nJUZNL
         version_id: 6xTvJ9Z
         url: https://semgrep.dev/playground/r/6xTvJ9Z/kotlin.lang.security.weak-rsa.use-of-weak-rsa-key
@@ -14628,6 +14653,8 @@ rules:
     shortlink: https://sg.run/d8K80
     semgrep.dev:
       rule:
+        r_id: 92978
+        rv_id: 230014
         rule_id: 6JUvjv6
         version_id: LjT7Zeo
         url: https://semgrep.dev/playground/r/LjT7Zeo/ocaml.lang.security.unsafe.ocamllint-unsafe
@@ -14666,6 +14693,8 @@ rules:
     shortlink: https://sg.run/KXWn
     semgrep.dev:
       rule:
+        r_id: 13799
+        rv_id: 110029
         rule_id: X5UdZj
         version_id: QkTW0qD
         url: https://semgrep.dev/playground/r/QkTW0qD/php.doctrine.security.audit.doctrine-dbal-dangerous-query.doctrine-dbal-dangerous-query
@@ -14767,6 +14796,8 @@ rules:
     shortlink: https://sg.run/kzn7
     semgrep.dev:
       rule:
+        r_id: 17328
+        rv_id: 110033
         rule_id: YGUAoe
         version_id: JdTNpx9
         url: https://semgrep.dev/playground/r/JdTNpx9/php.lang.security.audit.openssl-decrypt-validate.openssl-decrypt-validate
@@ -14798,6 +14829,8 @@ rules:
     shortlink: https://sg.run/4xj9
     semgrep.dev:
       rule:
+        r_id: 9388
+        rv_id: 110034
         rule_id: WAUow7
         version_id: 5PTdA1D
         url: https://semgrep.dev/playground/r/5PTdA1D/php.lang.security.backticks-use.backticks-use
@@ -14830,6 +14863,8 @@ rules:
     shortlink: https://sg.run/kxpGo
     semgrep.dev:
       rule:
+        r_id: 115928
+        rv_id: 348110
         rule_id: 7KUgBAk
         version_id: 1QTKbNw
         url: https://semgrep.dev/playground/r/1QTKbNw/php.lang.security.base-convert-loses-precision.base-convert-loses-precision
@@ -14898,6 +14933,8 @@ rules:
     shortlink: https://sg.run/J9AP
     semgrep.dev:
       rule:
+        r_id: 9390
+        rv_id: 110037
         rule_id: KxUbX3
         version_id: A8T95d2
         url: https://semgrep.dev/playground/r/A8T95d2/php.lang.security.eval-use.eval-use
@@ -14936,6 +14973,8 @@ rules:
     shortlink: https://sg.run/5Q1j
     semgrep.dev:
       rule:
+        r_id: 9391
+        rv_id: 110038
         rule_id: qNUjye
         version_id: BjTXrZP
         url: https://semgrep.dev/playground/r/BjTXrZP/php.lang.security.exec-use.exec-use
@@ -14974,6 +15013,8 @@ rules:
     shortlink: https://sg.run/Ge56
     semgrep.dev:
       rule:
+        r_id: 9392
+        rv_id: 110039
         rule_id: lBU90N
         version_id: DkT6nbD
         url: https://semgrep.dev/playground/r/DkT6nbD/php.lang.security.file-inclusion.file-inclusion
@@ -15037,6 +15078,8 @@ rules:
     shortlink: https://sg.run/RoYN
     semgrep.dev:
       rule:
+        r_id: 9393
+        rv_id: 110040
         rule_id: PeUZyE
         version_id: WrTWQKR
         url: https://semgrep.dev/playground/r/WrTWQKR/php.lang.security.ftp-use.ftp-use
@@ -15079,6 +15122,8 @@ rules:
     shortlink: https://sg.run/18Rv
     semgrep.dev:
       rule:
+        r_id: 13966
+        rv_id: 110046
         rule_id: wdUjA5
         version_id: 6xTvJoZ
         url: https://semgrep.dev/playground/r/6xTvJoZ/php.lang.security.ldap-bind-without-password.ldap-bind-without-password
@@ -15117,6 +15162,8 @@ rules:
     shortlink: https://sg.run/AvdB
     semgrep.dev:
       rule:
+        r_id: 9394
+        rv_id: 110047
         rule_id: JDUyj4
         version_id: o5Tglwy
         url: https://semgrep.dev/playground/r/o5Tglwy/php.lang.security.mb-ereg-replace-eval.mb-ereg-replace-eval
@@ -15153,6 +15200,8 @@ rules:
     shortlink: https://sg.run/BkZR
     semgrep.dev:
       rule:
+        r_id: 9395
+        rv_id: 110048
         rule_id: 5rUOzK
         version_id: zyTK8Zk
         url: https://semgrep.dev/playground/r/zyTK8Zk/php.lang.security.mcrypt-use.mcrypt-use
@@ -15192,6 +15241,8 @@ rules:
     shortlink: https://sg.run/Do4G
     semgrep.dev:
       rule:
+        r_id: 9396
+        rv_id: 110049
         rule_id: GdU7RO
         version_id: pZT1yYG
         url: https://semgrep.dev/playground/r/pZT1yYG/php.lang.security.md5-loose-equality.md5-loose-equality
@@ -15234,6 +15285,8 @@ rules:
     shortlink: https://sg.run/y1XR
     semgrep.dev:
       rule:
+        r_id: 13968
+        rv_id: 110053
         rule_id: OrU6JZ
         version_id: 1QTOYvP
         url: https://semgrep.dev/playground/r/1QTOYvP/php.lang.security.php-permissive-cors.php-permissive-cors
@@ -15275,6 +15328,8 @@ rules:
     shortlink: https://sg.run/rYeR
     semgrep.dev:
       rule:
+        r_id: 13969
+        rv_id: 110059
         rule_id: eqUzDE
         version_id: kbTdxbD
         url: https://semgrep.dev/playground/r/kbTdxbD/php.lang.security.unlink-use.unlink-use
@@ -15315,6 +15370,8 @@ rules:
     shortlink: https://sg.run/b24E
     semgrep.dev:
       rule:
+        r_id: 13970
+        rv_id: 110060
         rule_id: v8U9OJ
         version_id: w8T9nLW
         url: https://semgrep.dev/playground/r/w8T9nLW/php.lang.security.unserialize-use.unserialize-use
@@ -15353,6 +15410,8 @@ rules:
     shortlink: https://sg.run/KlBn
     semgrep.dev:
       rule:
+        r_id: 9399
+        rv_id: 110061
         rule_id: BYUNAg
         version_id: xyTKZ50
         url: https://semgrep.dev/playground/r/xyTKZ50/php.lang.security.weak-crypto.weak-crypto
@@ -15409,6 +15468,8 @@ rules:
     shortlink: https://sg.run/N1gz
     semgrep.dev:
       rule:
+        r_id: 13971
+        rv_id: 110073
         rule_id: d8UeKO
         version_id: QkTW0OD
         url: https://semgrep.dev/playground/r/QkTW0OD/php.symfony.security.audit.symfony-csrf-protection-disabled.symfony-csrf-protection-disabled
@@ -15450,6 +15511,8 @@ rules:
     shortlink: https://sg.run/4ey5
     semgrep.dev:
       rule:
+        r_id: 13800
+        rv_id: 110074
         rule_id: j2U3q8
         version_id: 3ZTkQ1q
         url: https://semgrep.dev/playground/r/3ZTkQ1q/php.symfony.security.audit.symfony-non-literal-redirect.symfony-non-literal-redirect
@@ -15505,6 +15568,8 @@ rules:
     shortlink: https://sg.run/kr92
     semgrep.dev:
       rule:
+        r_id: 13972
+        rv_id: 110075
         rule_id: ZqUOlR
         version_id: 44TRldD
         url: https://semgrep.dev/playground/r/44TRldD/php.symfony.security.audit.symfony-permissive-cors.symfony-permissive-cors
@@ -15550,6 +15615,8 @@ rules:
     shortlink: https://sg.run/B0eA
     semgrep.dev:
       rule:
+        r_id: 39195
+        rv_id: 110076
         rule_id: DbUe2y
         version_id: PkTJ1yN
         url: https://semgrep.dev/playground/r/PkTJ1yN/php.wordpress-plugins.security.audit.wp-ajax-no-auth-and-auth-hooks-audit.wp-ajax-no-auth-and-auth-hooks-audit
@@ -15590,6 +15657,8 @@ rules:
     shortlink: https://sg.run/DqeP
     semgrep.dev:
       rule:
+        r_id: 39196
+        rv_id: 110077
         rule_id: WAU6YK
         version_id: JdTNpj9
         url: https://semgrep.dev/playground/r/JdTNpj9/php.wordpress-plugins.security.audit.wp-authorisation-checks-audit.wp-authorisation-checks-audit
@@ -15631,6 +15700,8 @@ rules:
     shortlink: https://sg.run/WKD2
     semgrep.dev:
       rule:
+        r_id: 39197
+        rv_id: 110078
         rule_id: 0oU6pX
         version_id: 5PTdAzD
         url: https://semgrep.dev/playground/r/5PTdAzD/php.wordpress-plugins.security.audit.wp-code-execution-audit.wp-code-execution-audit
@@ -15674,6 +15745,8 @@ rules:
     shortlink: https://sg.run/01Wj
     semgrep.dev:
       rule:
+        r_id: 39198
+        rv_id: 110079
         rule_id: KxUOw0
         version_id: GxTv6RX
         url: https://semgrep.dev/playground/r/GxTv6RX/php.wordpress-plugins.security.audit.wp-command-execution-audit.wp-command-execution-audit
@@ -15711,6 +15784,8 @@ rules:
     shortlink: https://sg.run/K2y5
     semgrep.dev:
       rule:
+        r_id: 39199
+        rv_id: 110080
         rule_id: qNUKpk
         version_id: RGTDklL
         url: https://semgrep.dev/playground/r/RGTDklL/php.wordpress-plugins.security.audit.wp-csrf-audit.wp-csrf-audit
@@ -15752,6 +15827,8 @@ rules:
     shortlink: https://sg.run/4gkz
     semgrep.dev:
       rule:
+        r_id: 39200
+        rv_id: 110081
         rule_id: lBUNXL
         version_id: A8T9522
         url: https://semgrep.dev/playground/r/A8T9522/php.wordpress-plugins.security.audit.wp-file-download-audit.wp-file-download-audit
@@ -15802,6 +15879,8 @@ rules:
     shortlink: https://sg.run/PGPW
     semgrep.dev:
       rule:
+        r_id: 39201
+        rv_id: 110082
         rule_id: YGU8Yo
         version_id: BjTXrAP
         url: https://semgrep.dev/playground/r/BjTXrAP/php.wordpress-plugins.security.audit.wp-file-inclusion-audit.wp-file-inclusion-audit
@@ -15848,6 +15927,8 @@ rules:
     shortlink: https://sg.run/JpwW
     semgrep.dev:
       rule:
+        r_id: 39202
+        rv_id: 110083
         rule_id: 6JU0yK
         version_id: DkT6njD
         url: https://semgrep.dev/playground/r/DkT6njD/php.wordpress-plugins.security.audit.wp-file-manipulation-audit.wp-file-manipulation-audit
@@ -15886,6 +15967,8 @@ rules:
     shortlink: https://sg.run/5nZX
     semgrep.dev:
       rule:
+        r_id: 39203
+        rv_id: 110084
         rule_id: oqU5KY
         version_id: WrTWQwR
         url: https://semgrep.dev/playground/r/WrTWQwR/php.wordpress-plugins.security.audit.wp-open-redirect-audit.wp-open-redirect-audit
@@ -15927,6 +16010,8 @@ rules:
     shortlink: https://sg.run/G6X2
     semgrep.dev:
       rule:
+        r_id: 39204
+        rv_id: 110085
         rule_id: zdUelq
         version_id: 0bTLlXv
         url: https://semgrep.dev/playground/r/0bTLlXv/php.wordpress-plugins.security.audit.wp-php-object-injection-audit.wp-php-object-injection-audit
@@ -15978,6 +16063,8 @@ rules:
     shortlink: https://sg.run/RAbe
     semgrep.dev:
       rule:
+        r_id: 39205
+        rv_id: 110086
         rule_id: pKUQN1
         version_id: K3TvjXy
         url: https://semgrep.dev/playground/r/K3TvjXy/php.wordpress-plugins.security.audit.wp-sql-injection-audit.wp-sql-injection-audit
@@ -16008,6 +16095,8 @@ rules:
     shortlink: https://sg.run/2x9L
     semgrep.dev:
       rule:
+        r_id: 9419
+        rv_id: 110107
         rule_id: NbUkl9
         version_id: 2KTzrqw
         url: https://semgrep.dev/playground/r/2KTzrqw/problem-based-packs.insecure-transport.java-stdlib.socket-request.socket-request
@@ -16063,6 +16152,8 @@ rules:
     shortlink: https://sg.run/x1zL
     semgrep.dev:
       rule:
+        r_id: 9430
+        rv_id: 110118
         rule_id: 7KUQAE
         version_id: xyTKZoP
         url: https://semgrep.dev/playground/r/xyTKZoP/problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server
@@ -16108,6 +16199,8 @@ rules:
     shortlink: https://sg.run/ndBY
     semgrep.dev:
       rule:
+        r_id: 9436
+        rv_id: 110124
         rule_id: 4bUkOY
         version_id: nWTxPKL
         url: https://semgrep.dev/playground/r/nWTxPKL/python.airflow.security.audit.formatted-string-bashoperator.formatted-string-bashoperator
@@ -16188,6 +16281,8 @@ rules:
     shortlink: https://sg.run/4xr5
     semgrep.dev:
       rule:
+        r_id: 9444
+        rv_id: 252915
         rule_id: DbUp5g
         version_id: l4TlPgr
         url: https://semgrep.dev/playground/r/l4TlPgr/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
@@ -16240,6 +16335,8 @@ rules:
     shortlink: https://sg.run/GeQq
     semgrep.dev:
       rule:
+        r_id: 9448
+        rv_id: 251691
         rule_id: qNUjZ3
         version_id: YDTNPqv
         url: https://semgrep.dev/playground/r/YDTNPqv/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
@@ -16290,6 +16387,8 @@ rules:
     shortlink: https://sg.run/RoQq
     semgrep.dev:
       rule:
+        r_id: 9449
+        rv_id: 252918
         rule_id: lBU9jn
         version_id: o5TkxOr
         url: https://semgrep.dev/playground/r/o5TkxOr/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
@@ -16327,6 +16426,8 @@ rules:
     shortlink: https://sg.run/N9JL
     semgrep.dev:
       rule:
+        r_id: 31871
+        rv_id: 110158
         rule_id: lBUpNZ
         version_id: bZTb1qg
         url: https://semgrep.dev/playground/r/bZTb1qg/python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
@@ -16389,6 +16490,8 @@ rules:
     shortlink: https://sg.run/yd0P
     semgrep.dev:
       rule:
+        r_id: 9468
+        rv_id: 110181
         rule_id: eqU8Wr
         version_id: RGTDkXP
         url: https://semgrep.dev/playground/r/RGTDkXP/python.django.security.audit.avoid-mark-safe.avoid-mark-safe
@@ -16430,6 +16533,8 @@ rules:
     shortlink: https://sg.run/b7bW
     semgrep.dev:
       rule:
+        r_id: 9470
+        rv_id: 110183
         rule_id: d8Ujk6
         version_id: BjTXr9d
         url: https://semgrep.dev/playground/r/BjTXr9d/python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql
@@ -16475,6 +16580,8 @@ rules:
     shortlink: https://sg.run/vzBY
     semgrep.dev:
       rule:
+        r_id: 9477
+        rv_id: 110185
         rule_id: gxU1wE
         version_id: WrTWQRd
         url: https://semgrep.dev/playground/r/WrTWQRd/python.django.security.audit.django-rest-framework.missing-throttle-config.missing-throttle-config
@@ -16516,6 +16623,8 @@ rules:
     shortlink: https://sg.run/N4Ay
     semgrep.dev:
       rule:
+        r_id: 9471
+        rv_id: 110186
         rule_id: ZqU5z3
         version_id: 0bTLl4p
         url: https://semgrep.dev/playground/r/0bTLl4p/python.django.security.audit.extends-custom-expression.extends-custom-expression
@@ -16669,6 +16778,8 @@ rules:
     shortlink: https://sg.run/kXZP
     semgrep.dev:
       rule:
+        r_id: 9472
+        rv_id: 110187
         rule_id: nJUzBP
         version_id: K3TvjpJ
         url: https://semgrep.dev/playground/r/K3TvjpJ/python.django.security.audit.query-set-extra.avoid-query-set-extra
@@ -16712,6 +16823,8 @@ rules:
     shortlink: https://sg.run/weDA
     semgrep.dev:
       rule:
+        r_id: 9473
+        rv_id: 110188
         rule_id: EwU2JA
         version_id: qkT2x0x
         url: https://semgrep.dev/playground/r/qkT2x0x/python.django.security.audit.raw-query.avoid-raw-sql
@@ -16787,6 +16900,8 @@ rules:
     shortlink: https://sg.run/x1WL
     semgrep.dev:
       rule:
+        r_id: 9474
+        rv_id: 110189
         rule_id: 7KUQ2E
         version_id: l4T4vL6
         url: https://semgrep.dev/playground/r/l4T4vL6/python.django.security.audit.secure-cookies.django-secure-set-cookie
@@ -16828,6 +16943,8 @@ rules:
     shortlink: https://sg.run/dK3E
     semgrep.dev:
       rule:
+        r_id: 9478
+        rv_id: 110190
         rule_id: QrUzb2
         version_id: YDTp23Z
         url: https://semgrep.dev/playground/r/YDTp23Z/python.django.security.audit.templates.debug-template-tag.debug-template-tag
@@ -16887,6 +17004,8 @@ rules:
     shortlink: https://sg.run/OPBL
     semgrep.dev:
       rule:
+        r_id: 9475
+        rv_id: 255673
         rule_id: L1UywG
         version_id: 44TAy70
         url: https://semgrep.dev/playground/r/44TAy70/python.django.security.audit.unvalidated-password.unvalidated-password
@@ -16927,6 +17046,8 @@ rules:
     shortlink: https://sg.run/Zvpw
     semgrep.dev:
       rule:
+        r_id: 9479
+        rv_id: 110192
         rule_id: 3qUPve
         version_id: 5PTdAv7
         url: https://semgrep.dev/playground/r/5PTdAv7/python.django.security.audit.xss.class-extends-safestring.class-extends-safestring
@@ -16975,6 +17096,8 @@ rules:
     shortlink: https://sg.run/nd7Y
     semgrep.dev:
       rule:
+        r_id: 9480
+        rv_id: 110193
         rule_id: 4bUknY
         version_id: GxTv6GY
         url: https://semgrep.dev/playground/r/GxTv6GY/python.django.security.audit.xss.context-autoescape-off.context-autoescape-off
@@ -17031,6 +17154,8 @@ rules:
     shortlink: https://sg.run/EknN
     semgrep.dev:
       rule:
+        r_id: 9481
+        rv_id: 110194
         rule_id: PeUZgE
         version_id: RGTDkX9
         url: https://semgrep.dev/playground/r/RGTDkX9/python.django.security.audit.xss.direct-use-of-httpresponse.direct-use-of-httpresponse
@@ -17102,6 +17227,8 @@ rules:
     shortlink: https://sg.run/7o12
     semgrep.dev:
       rule:
+        r_id: 9482
+        rv_id: 110195
         rule_id: JDUyd4
         version_id: A8T956L
         url: https://semgrep.dev/playground/r/A8T956L/python.django.security.audit.xss.filter-with-is-safe.filter-with-is-safe
@@ -17145,6 +17272,8 @@ rules:
     shortlink: https://sg.run/lxQo
     semgrep.dev:
       rule:
+        r_id: 12657
+        rv_id: 110196
         rule_id: v8UjKg
         version_id: BjTXr9G
         url: https://semgrep.dev/playground/r/BjTXr9G/python.django.security.audit.xss.formathtml-fstring-parameter.formathtml-fstring-parameter
@@ -17187,6 +17316,8 @@ rules:
     shortlink: https://sg.run/LwG6
     semgrep.dev:
       rule:
+        r_id: 9483
+        rv_id: 110197
         rule_id: 5rUOXK
         version_id: DkT6nO3
         url: https://semgrep.dev/playground/r/DkT6nO3/python.django.security.audit.xss.global-autoescape-off.global-autoescape-off
@@ -17239,6 +17370,8 @@ rules:
     shortlink: https://sg.run/8y9N
     semgrep.dev:
       rule:
+        r_id: 9484
+        rv_id: 110198
         rule_id: GdU7QO
         version_id: WrTWQRg
         url: https://semgrep.dev/playground/r/WrTWQRg/python.django.security.audit.xss.html-magic-method.html-magic-method
@@ -17287,6 +17420,8 @@ rules:
     shortlink: https://sg.run/gLO0
     semgrep.dev:
       rule:
+        r_id: 9485
+        rv_id: 110199
         rule_id: ReUg5Y
         version_id: 0bTLl40
         url: https://semgrep.dev/playground/r/0bTLl40/python.django.security.audit.xss.html-safe.html-safe
@@ -17331,6 +17466,8 @@ rules:
     shortlink: https://sg.run/Q5WZ
     semgrep.dev:
       rule:
+        r_id: 9486
+        rv_id: 110200
         rule_id: AbUzAZ
         version_id: K3Tvjp9
         url: https://semgrep.dev/playground/r/K3Tvjp9/python.django.security.audit.xss.template-autoescape-off.template-autoescape-off
@@ -17394,6 +17531,8 @@ rules:
     shortlink: https://sg.run/3xpK
     semgrep.dev:
       rule:
+        r_id: 9487
+        rv_id: 110201
         rule_id: BYUNwg
         version_id: qkT2x0z
         url: https://semgrep.dev/playground/r/qkT2x0z/python.django.security.audit.xss.template-blocktranslate-no-escape.template-blocktranslate-no-escape
@@ -17535,6 +17674,8 @@ rules:
     shortlink: https://sg.run/PJDz
     semgrep.dev:
       rule:
+        r_id: 9489
+        rv_id: 110203
         rule_id: WAUov9
         version_id: YDTp231
         url: https://semgrep.dev/playground/r/YDTp231/python.django.security.audit.xss.template-translate-as-no-escape.template-translate-as-no-escape
@@ -17570,6 +17711,8 @@ rules:
     shortlink: https://sg.run/5Q30
     semgrep.dev:
       rule:
+        r_id: 9491
+        rv_id: 110205
         rule_id: KxUbdx
         version_id: o5Tgl7v
         url: https://semgrep.dev/playground/r/o5Tgl7v/python.django.security.audit.xss.template-var-unescaped-with-safeseq.template-var-unescaped-with-safeseq
@@ -17616,6 +17759,8 @@ rules:
     shortlink: https://sg.run/7GYv
     semgrep.dev:
       rule:
+        r_id: 11938
+        rv_id: 110207
         rule_id: j2UR3n
         version_id: pZT1yBE
         url: https://semgrep.dev/playground/r/pZT1yBE/python.django.security.globals-as-template-context.globals-as-template-context
@@ -17658,6 +17803,8 @@ rules:
     shortlink: https://sg.run/Kl55
     semgrep.dev:
       rule:
+        r_id: 9499
+        rv_id: 110209
         rule_id: AbUzAA
         version_id: X0TQxv6
         url: https://semgrep.dev/playground/r/X0TQxv6/python.django.security.injection.code.globals-misuse-code-execution.globals-misuse-code-execution
@@ -17894,6 +18041,8 @@ rules:
     shortlink: https://sg.run/Ro0q
     semgrep.dev:
       rule:
+        r_id: 9493
+        rv_id: 110219
         rule_id: lBU97n
         version_id: xyTKZYJ
         url: https://semgrep.dev/playground/r/xyTKZYJ/python.django.security.injection.mass-assignment.mass-assignment
@@ -17934,6 +18083,8 @@ rules:
     shortlink: https://sg.run/Dovo
     semgrep.dev:
       rule:
+        r_id: 9508
+        rv_id: 110222
         rule_id: 6JUjLj
         version_id: vdTYN21
         url: https://semgrep.dev/playground/r/vdTYN21/python.django.security.injection.path-traversal.path-traversal-join.path-traversal-join
@@ -18046,6 +18197,8 @@ rules:
     shortlink: https://sg.run/PbZp
     semgrep.dev:
       rule:
+        r_id: 14701
+        rv_id: 110235
         rule_id: lBU8Ad
         version_id: JdTNpqk
         url: https://semgrep.dev/playground/r/JdTNpqk/python.django.security.injection.tainted-sql-string.tainted-sql-string
@@ -18110,6 +18263,8 @@ rules:
     shortlink: https://sg.run/oYz6
     semgrep.dev:
       rule:
+        r_id: 14760
+        rv_id: 110236
         rule_id: 6JU1l0
         version_id: 5PTdA67
         url: https://semgrep.dev/playground/r/5PTdA67/python.django.security.injection.tainted-url-host.tainted-url-host
@@ -18191,6 +18346,8 @@ rules:
     shortlink: https://sg.run/L8XL
     semgrep.dev:
       rule:
+        r_id: 11939
+        rv_id: 110237
         rule_id: 10Ued2
         version_id: GxTv62Y
         url: https://semgrep.dev/playground/r/GxTv62Y/python.django.security.locals-as-template-context.locals-as-template-context
@@ -18249,6 +18406,8 @@ rules:
     shortlink: https://sg.run/pxEL
     semgrep.dev:
       rule:
+        r_id: 9518
+        rv_id: 110241
         rule_id: r6Ur5A
         version_id: DkT6nQ3
         url: https://semgrep.dev/playground/r/DkT6nQ3/python.docker.security.audit.docker-arbitrary-container-run.docker-arbitrary-container-run
@@ -18281,6 +18440,8 @@ rules:
     shortlink: https://sg.run/LwPo
     semgrep.dev:
       rule:
+        r_id: 9539
+        rv_id: 110255
         rule_id: JDUyJR
         version_id: 1QTOYjN
         url: https://semgrep.dev/playground/r/1QTOYjN/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_DEBUG
@@ -18320,6 +18481,8 @@ rules:
     shortlink: https://sg.run/7oXW
     semgrep.dev:
       rule:
+        r_id: 9538
+        rv_id: 110254
         rule_id: PeUZpr
         version_id: jQTgYKX
         url: https://semgrep.dev/playground/r/jQTgYKX/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_ENV
@@ -18357,6 +18520,8 @@ rules:
     shortlink: https://sg.run/Ekde
     semgrep.dev:
       rule:
+        r_id: 9537
+        rv_id: 110253
         rule_id: 4bUkX0
         version_id: X0TQxP6
         url: https://semgrep.dev/playground/r/X0TQxP6/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_SECRET_KEY
@@ -18394,6 +18559,8 @@ rules:
     shortlink: https://sg.run/ndZ2
     semgrep.dev:
       rule:
+        r_id: 9536
+        rv_id: 110252
         rule_id: 3qUPoy
         version_id: 2KTzr19
         url: https://semgrep.dev/playground/r/2KTzr19/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_TESTING
@@ -18430,6 +18597,8 @@ rules:
     shortlink: https://sg.run/8yjE
     semgrep.dev:
       rule:
+        r_id: 9540
+        rv_id: 110257
         rule_id: 5rUOv1
         version_id: yeTR2Xr
         url: https://semgrep.dev/playground/r/yeTR2Xr/python.flask.security.audit.render-template-string.render-template-string
@@ -18484,6 +18653,8 @@ rules:
     shortlink: https://sg.run/gLkZ
     semgrep.dev:
       rule:
+        r_id: 9541
+        rv_id: 251895
         rule_id: GdU7GR
         version_id: 5PTk5OX
         url: https://semgrep.dev/playground/r/5PTk5OX/python.flask.security.audit.secure-set-cookie.secure-set-cookie
@@ -18522,6 +18693,8 @@ rules:
     shortlink: https://sg.run/Q5AQ
     semgrep.dev:
       rule:
+        r_id: 9542
+        rv_id: 252100
         rule_id: ReUgXz
         version_id: A8TkY3P
         url: https://semgrep.dev/playground/r/A8TkY3P/python.flask.security.audit.wtf-csrf-disabled.flask-wtf-csrf-disabled
@@ -18628,6 +18801,8 @@ rules:
     shortlink: https://sg.run/3x3p
     semgrep.dev:
       rule:
+        r_id: 9543
+        rv_id: 110260
         rule_id: AbUz6A
         version_id: NdT3d1x
         url: https://semgrep.dev/playground/r/NdT3d1x/python.flask.security.audit.xss.make-response-with-unknown-content.make-response-with-unknown-content
@@ -18661,6 +18836,8 @@ rules:
     shortlink: https://sg.run/b79E
     semgrep.dev:
       rule:
+        r_id: 9526
+        rv_id: 110261
         rule_id: v8UnZJ
         version_id: kbTdx77
         url: https://semgrep.dev/playground/r/kbTdx77/python.flask.security.dangerous-template-string.dangerous-template-string
@@ -18747,6 +18924,8 @@ rules:
     shortlink: https://sg.run/bDWr
     semgrep.dev:
       rule:
+        r_id: 10126
+        rv_id: 110262
         rule_id: NbUAeY
         version_id: w8T9n32
         url: https://semgrep.dev/playground/r/w8T9n32/python.flask.security.flask-api-method-string-format.flask-api-method-string-format
@@ -18784,6 +18963,8 @@ rules:
     shortlink: https://sg.run/4xzz
     semgrep.dev:
       rule:
+        r_id: 9544
+        rv_id: 110266
         rule_id: BYUN99
         version_id: vdTYNk1
         url: https://semgrep.dev/playground/r/vdTYNk1/python.flask.security.injection.os-system-injection.os-system-injection
@@ -18864,6 +19045,8 @@ rules:
     shortlink: https://sg.run/PJRW
     semgrep.dev:
       rule:
+        r_id: 9545
+        rv_id: 110267
         rule_id: DbUpOQ
         version_id: d6TrARQ
         url: https://semgrep.dev/playground/r/d6TrARQ/python.flask.security.injection.path-traversal-open.path-traversal-open
@@ -18972,6 +19155,8 @@ rules:
     shortlink: https://sg.run/N45z
     semgrep.dev:
       rule:
+        r_id: 9527
+        rv_id: 110275
         rule_id: d8UjBO
         version_id: QkTW0yZ
         url: https://semgrep.dev/playground/r/QkTW0yZ/python.flask.security.insecure-deserialization.insecure-deserialization
@@ -19062,6 +19247,8 @@ rules:
     shortlink: https://sg.run/kXe2
     semgrep.dev:
       rule:
+        r_id: 9528
+        rv_id: 110276
         rule_id: ZqU5LR
         version_id: 3ZTkQJQ
         url: https://semgrep.dev/playground/r/3ZTkQJQ/python.flask.security.open-redirect.open-redirect
@@ -19101,6 +19288,8 @@ rules:
     shortlink: https://sg.run/weGP
     semgrep.dev:
       rule:
+        r_id: 9529
+        rv_id: 110277
         rule_id: nJUz6A
         version_id: 44TRl36
         url: https://semgrep.dev/playground/r/44TRl36/python.flask.security.secure-static-file-serve.avoid_send_file_without_path_sanitization
@@ -19142,6 +19331,8 @@ rules:
     shortlink: https://sg.run/x1Rg
     semgrep.dev:
       rule:
+        r_id: 9530
+        rv_id: 110278
         rule_id: EwU293
         version_id: PkTJ1LR
         url: https://semgrep.dev/playground/r/PkTJ1LR/python.flask.security.unescaped-template-extension.unescaped-template-extension
@@ -19205,6 +19396,8 @@ rules:
     shortlink: https://sg.run/OPGn
     semgrep.dev:
       rule:
+        r_id: 9531
+        rv_id: 110279
         rule_id: 7KUQLl
         version_id: JdTNpgk
         url: https://semgrep.dev/playground/r/JdTNpgk/python.flask.security.unsanitized-input.response-contains-unsanitized-input
@@ -19260,6 +19453,8 @@ rules:
     shortlink: https://sg.run/RoKe
     semgrep.dev:
       rule:
+        r_id: 9549
+        rv_id: 110280
         rule_id: qNUjN2
         version_id: 5PTdA57
         url: https://semgrep.dev/playground/r/5PTdA57/python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
@@ -19311,6 +19506,8 @@ rules:
     shortlink: https://sg.run/AvZ8
     semgrep.dev:
       rule:
+        r_id: 9550
+        rv_id: 110281
         rule_id: lBU95l
         version_id: GxTv6wY
         url: https://semgrep.dev/playground/r/GxTv6wY/python.flask.security.xss.audit.explicit-unescape-with-markup.explicit-unescape-with-markup
@@ -19355,6 +19552,8 @@ rules:
     shortlink: https://sg.run/Bkn2
     semgrep.dev:
       rule:
+        r_id: 9551
+        rv_id: 110282
         rule_id: YGURo6
         version_id: RGTDkv9
         url: https://semgrep.dev/playground/r/RGTDkv9/python.flask.security.xss.audit.template-autoescape-off.template-autoescape-off
@@ -19395,6 +19594,8 @@ rules:
     shortlink: https://sg.run/ox8R
     semgrep.dev:
       rule:
+        r_id: 9560
+        rv_id: 110288
         rule_id: 9AU1zW
         version_id: K3Tvjy9
         url: https://semgrep.dev/playground/r/K3Tvjy9/python.jwt.security.audit.jwt-exposed-data.jwt-python-exposed-data
@@ -19434,6 +19635,8 @@ rules:
     shortlink: https://sg.run/qxPy
     semgrep.dev:
       rule:
+        r_id: 9556
+        rv_id: 110289
         rule_id: 2ZUb1L
         version_id: qkT2xqz
         url: https://semgrep.dev/playground/r/qkT2xqz/python.jwt.security.jwt-exposed-credentials.jwt-python-exposed-credentials
@@ -19501,6 +19704,8 @@ rules:
     shortlink: https://sg.run/6nyB
     semgrep.dev:
       rule:
+        r_id: 9559
+        rv_id: 110292
         rule_id: 10UKjo
         version_id: JdTNpgE
         url: https://semgrep.dev/playground/r/JdTNpgE/python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
@@ -19544,6 +19749,8 @@ rules:
     shortlink: https://sg.run/x1lz
     semgrep.dev:
       rule:
+        r_id: 9630
+        rv_id: 110362
         rule_id: nJUzeK
         version_id: kbTdLKO
         url: https://semgrep.dev/playground/r/kbTdLKO/python.lang.security.audit.conn_recv.multiprocessing-recv
@@ -19593,6 +19800,8 @@ rules:
     shortlink: https://sg.run/8R6J
     semgrep.dev:
       rule:
+        r_id: 11940
+        rv_id: 110363
         rule_id: 9AUkR3
         version_id: w8T9D1K
         url: https://semgrep.dev/playground/r/w8T9D1K/python.lang.security.audit.dangerous-annotations-usage.dangerous-annotations-usage
@@ -19658,6 +19867,8 @@ rules:
     shortlink: https://sg.run/dKZZ
     semgrep.dev:
       rule:
+        r_id: 9634
+        rv_id: 110385
         rule_id: 8GUj22
         version_id: BjTXpW3
         url: https://semgrep.dev/playground/r/BjTXpW3/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
@@ -19703,6 +19914,8 @@ rules:
     shortlink: https://sg.run/ZvrD
     semgrep.dev:
       rule:
+        r_id: 9635
+        rv_id: 110386
         rule_id: gxU149
         version_id: DkT6Yd0
         url: https://semgrep.dev/playground/r/DkT6Yd0/python.lang.security.audit.eval-detected.eval-detected
@@ -19747,6 +19960,8 @@ rules:
     shortlink: https://sg.run/ndRX
     semgrep.dev:
       rule:
+        r_id: 9636
+        rv_id: 110387
         rule_id: QrUzKv
         version_id: WrTW3zn
         url: https://semgrep.dev/playground/r/WrTW3zn/python.lang.security.audit.exec-detected.exec-detected
@@ -19782,6 +19997,8 @@ rules:
     shortlink: https://sg.run/EkWw
     semgrep.dev:
       rule:
+        r_id: 9637
+        rv_id: 110388
         rule_id: 3qUP9k
         version_id: 0bTLexz
         url: https://semgrep.dev/playground/r/0bTLexz/python.lang.security.audit.formatted-sql-query.formatted-sql-query
@@ -19834,6 +20051,8 @@ rules:
     shortlink: https://sg.run/7oyZ
     semgrep.dev:
       rule:
+        r_id: 9638
+        rv_id: 110389
         rule_id: 4bUkv7
         version_id: K3TvG2X
         url: https://semgrep.dev/playground/r/K3TvG2X/python.lang.security.audit.ftplib.ftplib
@@ -19878,6 +20097,8 @@ rules:
     shortlink: https://sg.run/Lw9r
     semgrep.dev:
       rule:
+        r_id: 9639
+        rv_id: 110390
         rule_id: PeUZAW
         version_id: qkT2BYZ
         url: https://semgrep.dev/playground/r/qkT2BYZ/python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument
@@ -19911,6 +20132,8 @@ rules:
     shortlink: https://sg.run/8yby
     semgrep.dev:
       rule:
+        r_id: 9640
+        rv_id: 110391
         rule_id: JDUy7y
         version_id: l4T46Q7
         url: https://semgrep.dev/playground/r/l4T46Q7/python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
@@ -19952,6 +20175,8 @@ rules:
     shortlink: https://sg.run/AvPp
     semgrep.dev:
       rule:
+        r_id: 9650
+        rv_id: 110393
         rule_id: qNUjlR
         version_id: JdTNv1q
         url: https://semgrep.dev/playground/r/JdTNv1q/python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
@@ -20018,6 +20243,8 @@ rules:
     shortlink: https://sg.run/Bk5W
     semgrep.dev:
       rule:
+        r_id: 9651
+        rv_id: 110394
         rule_id: lBU9BZ
         version_id: 5PTdeJ5
         url: https://semgrep.dev/playground/r/5PTdeJ5/python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
@@ -20084,6 +20311,8 @@ rules:
     shortlink: https://sg.run/DoBY
     semgrep.dev:
       rule:
+        r_id: 9652
+        rv_id: 110395
         rule_id: YGURXw
         version_id: GxTv8L9
         url: https://semgrep.dev/playground/r/GxTv8L9/python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
@@ -20124,6 +20353,8 @@ rules:
     shortlink: https://sg.run/W8J4
     semgrep.dev:
       rule:
+        r_id: 9653
+        rv_id: 110396
         rule_id: 6JUjpG
         version_id: RGTDRDO
         url: https://semgrep.dev/playground/r/RGTDRDO/python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
@@ -20187,6 +20418,8 @@ rules:
     shortlink: https://sg.run/0Q0v
     semgrep.dev:
       rule:
+        r_id: 9654
+        rv_id: 110397
         rule_id: oqUeYJ
         version_id: A8T9X99
         url: https://semgrep.dev/playground/r/A8T9X99/python.lang.security.audit.insecure-transport.ssl.no-set-ciphers.no-set-ciphers
@@ -20222,6 +20455,8 @@ rules:
     shortlink: https://sg.run/Klj7
     semgrep.dev:
       rule:
+        r_id: 9655
+        rv_id: 110398
         rule_id: zdUkPQ
         version_id: BjTXpXx
         url: https://semgrep.dev/playground/r/BjTXpXx/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open-ftp.insecure-openerdirector-open-ftp
@@ -20285,6 +20520,8 @@ rules:
     shortlink: https://sg.run/qxKz
     semgrep.dev:
       rule:
+        r_id: 9656
+        rv_id: 110399
         rule_id: pKUO9Q
         version_id: DkT6Y69
         url: https://semgrep.dev/playground/r/DkT6Y69/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open.insecure-openerdirector-open
@@ -20355,6 +20592,8 @@ rules:
     shortlink: https://sg.run/l2Py
     semgrep.dev:
       rule:
+        r_id: 9657
+        rv_id: 110400
         rule_id: 2ZUbWA
         version_id: WrTW3Wo
         url: https://semgrep.dev/playground/r/WrTW3Wo/python.lang.security.audit.insecure-transport.urllib.insecure-request-object-ftp.insecure-request-object-ftp
@@ -20398,6 +20637,8 @@ rules:
     shortlink: https://sg.run/YvAe
     semgrep.dev:
       rule:
+        r_id: 9658
+        rv_id: 110401
         rule_id: X5U8Bp
         version_id: 0bTLeLE
         url: https://semgrep.dev/playground/r/0bTLeLE/python.lang.security.audit.insecure-transport.urllib.insecure-request-object.insecure-request-object
@@ -20446,6 +20687,8 @@ rules:
     shortlink: https://sg.run/6n1o
     semgrep.dev:
       rule:
+        r_id: 9659
+        rv_id: 110402
         rule_id: j2UvOG
         version_id: K3TvGvY
         url: https://semgrep.dev/playground/r/K3TvGvY/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen-ftp.insecure-urlopen-ftp
@@ -20489,6 +20732,8 @@ rules:
     shortlink: https://sg.run/oxB9
     semgrep.dev:
       rule:
+        r_id: 9660
+        rv_id: 110403
         rule_id: 10UKgW
         version_id: qkT2B2X
         url: https://semgrep.dev/playground/r/qkT2B2X/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
@@ -20536,6 +20781,8 @@ rules:
     shortlink: https://sg.run/zvwG
     semgrep.dev:
       rule:
+        r_id: 9661
+        rv_id: 110404
         rule_id: 9AU1DY
         version_id: l4T464W
         url: https://semgrep.dev/playground/r/l4T464W/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open-ftp.insecure-urlopener-open-ftp
@@ -20599,6 +20846,8 @@ rules:
     shortlink: https://sg.run/pxWg
     semgrep.dev:
       rule:
+        r_id: 9662
+        rv_id: 110405
         rule_id: yyUnwW
         version_id: YDTpnpl
         url: https://semgrep.dev/playground/r/YDTpnpl/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open.insecure-urlopener-open
@@ -20667,6 +20916,8 @@ rules:
     shortlink: https://sg.run/2xY0
     semgrep.dev:
       rule:
+        r_id: 9663
+        rv_id: 110406
         rule_id: r6UrPp
         version_id: 6xTvQvy
         url: https://semgrep.dev/playground/r/6xTvQvy/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve-ftp.insecure-urlopener-retrieve-ftp
@@ -20730,6 +20981,8 @@ rules:
     shortlink: https://sg.run/XBGK
     semgrep.dev:
       rule:
+        r_id: 9664
+        rv_id: 110407
         rule_id: bwUw0n
         version_id: o5Tg9gZ
         url: https://semgrep.dev/playground/r/o5Tg9gZ/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve.insecure-urlopener-retrieve
@@ -20798,6 +21051,8 @@ rules:
     shortlink: https://sg.run/jR8Y
     semgrep.dev:
       rule:
+        r_id: 9665
+        rv_id: 110408
         rule_id: NbUknL
         version_id: zyTKDK8
         url: https://semgrep.dev/playground/r/zyTKDK8/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve-ftp.insecure-urlretrieve-ftp
@@ -20841,6 +21096,8 @@ rules:
     shortlink: https://sg.run/1Zqw
     semgrep.dev:
       rule:
+        r_id: 9666
+        rv_id: 110409
         rule_id: kxUk4N
         version_id: pZT1L1L
         url: https://semgrep.dev/playground/r/pZT1L1L/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve.insecure-urlretrieve
@@ -20893,6 +21150,8 @@ rules:
     shortlink: https://sg.run/9okY
     semgrep.dev:
       rule:
+        r_id: 9667
+        rv_id: 110410
         rule_id: wdUJQY
         version_id: 2KTz3zv
         url: https://semgrep.dev/playground/r/2KTz3zv/python.lang.security.audit.logging.listeneval.listen-eval
@@ -20933,6 +21192,8 @@ rules:
     shortlink: https://sg.run/Q5v4
     semgrep.dev:
       rule:
+        r_id: 9642
+        rv_id: 110412
         rule_id: GdU79Z
         version_id: jQTgyg1
         url: https://semgrep.dev/playground/r/jQTgyg1/python.lang.security.audit.mako-templates-detected.mako-templates-detected
@@ -20971,6 +21232,8 @@ rules:
     shortlink: https://sg.run/3xor
     semgrep.dev:
       rule:
+        r_id: 9643
+        rv_id: 110413
         rule_id: ReUg13
         version_id: 1QTO7O3
         url: https://semgrep.dev/playground/r/1QTO7O3/python.lang.security.audit.marshal.marshal-usage
@@ -21007,6 +21270,8 @@ rules:
     shortlink: https://sg.run/N4Np
     semgrep.dev:
       rule:
+        r_id: 9671
+        rv_id: 110417
         rule_id: v8UnWQ
         version_id: bZTb9bx
         url: https://semgrep.dev/playground/r/bZTb9bx/python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
@@ -21050,6 +21315,8 @@ rules:
     shortlink: https://sg.run/y6Jk
     semgrep.dev:
       rule:
+        r_id: 12068
+        rv_id: 110418
         rule_id: AbUGN5
         version_id: NdT3o3E
         url: https://semgrep.dev/playground/r/NdT3o3E/python.lang.security.audit.non-literal-import.non-literal-import
@@ -21092,6 +21359,8 @@ rules:
     shortlink: https://sg.run/4xpl
     semgrep.dev:
       rule:
+        r_id: 9644
+        rv_id: 110420
         rule_id: AbUzbe
         version_id: w8T9D9g
         url: https://semgrep.dev/playground/r/w8T9D9g/python.lang.security.audit.paramiko-implicit-trust-host-key.paramiko-implicit-trust-host-key
@@ -21136,6 +21405,8 @@ rules:
     shortlink: https://sg.run/kXQ7
     semgrep.dev:
       rule:
+        r_id: 9672
+        rv_id: 110419
         rule_id: d8Uj9x
         version_id: kbTdLdQ
         url: https://semgrep.dev/playground/r/kbTdLdQ/python.lang.security.audit.paramiko.paramiko-exec-command.paramiko-exec-command
@@ -21179,6 +21450,8 @@ rules:
     shortlink: https://sg.run/gYZJ
     semgrep.dev:
       rule:
+        r_id: 15185
+        rv_id: 110421
         rule_id: nJUZRY
         version_id: xyTKpKy
         url: https://semgrep.dev/playground/r/xyTKpKy/python.lang.security.audit.python-reverse-shell.python-reverse-shell
@@ -21220,6 +21493,8 @@ rules:
     shortlink: https://sg.run/WgGL
     semgrep.dev:
       rule:
+        r_id: 10309
+        rv_id: 110423
         rule_id: DbUWRY
         version_id: e1T030o
         url: https://semgrep.dev/playground/r/e1T030o/python.lang.security.audit.sqli.aiopg-sqli.aiopg-sqli
@@ -21334,6 +21609,8 @@ rules:
     shortlink: https://sg.run/0nBB
     semgrep.dev:
       rule:
+        r_id: 10310
+        rv_id: 110424
         rule_id: WAUZqq
         version_id: vdTY8YE
         url: https://semgrep.dev/playground/r/vdTY8YE/python.lang.security.audit.sqli.asyncpg-sqli.asyncpg-sqli
@@ -21436,6 +21713,8 @@ rules:
     shortlink: https://sg.run/KWAL
     semgrep.dev:
       rule:
+        r_id: 10311
+        rv_id: 110425
         rule_id: 0oUEKo
         version_id: d6Trvr1
         url: https://semgrep.dev/playground/r/d6Trvr1/python.lang.security.audit.sqli.pg8000-sqli.pg8000-sqli
@@ -21533,6 +21812,8 @@ rules:
     shortlink: https://sg.run/qrLe
     semgrep.dev:
       rule:
+        r_id: 10312
+        rv_id: 110426
         rule_id: KxU4Kg
         version_id: ZRTQpQ0
         url: https://semgrep.dev/playground/r/ZRTQpQ0/python.lang.security.audit.sqli.psycopg-sqli.psycopg-sqli
@@ -21628,6 +21909,8 @@ rules:
     shortlink: https://sg.run/5QXA
     semgrep.dev:
       rule:
+        r_id: 9647
+        rv_id: 110429
         rule_id: WAUorE
         version_id: 7ZTgng4
         url: https://semgrep.dev/playground/r/7ZTgng4/python.lang.security.audit.system-wildcard-detected.system-wildcard-detected
@@ -21663,6 +21946,8 @@ rules:
     shortlink: https://sg.run/Gelp
     semgrep.dev:
       rule:
+        r_id: 9648
+        rv_id: 110430
         rule_id: 0oU5Wl
         version_id: LjTqAqb
         url: https://semgrep.dev/playground/r/LjTqAqb/python.lang.security.audit.telnetlib.telnetlib
@@ -21705,6 +21990,8 @@ rules:
     shortlink: https://sg.run/RoZO
     semgrep.dev:
       rule:
+        r_id: 9649
+        rv_id: 110431
         rule_id: KxUbNG
         version_id: 8KTQyQl
         url: https://semgrep.dev/playground/r/8KTQyQl/python.lang.security.audit.weak-ssl-version.weak-ssl-version
@@ -21779,6 +22066,8 @@ rules:
     shortlink: https://sg.run/jNzn
     semgrep.dev:
       rule:
+        r_id: 10065
+        rv_id: 110433
         rule_id: 9AUOZP
         version_id: QkTWwWO
         url: https://semgrep.dev/playground/r/QkTWwWO/python.lang.security.dangerous-globals-use.dangerous-globals-use
@@ -21820,6 +22109,8 @@ rules:
     shortlink: https://sg.run/rkNP
     semgrep.dev:
       rule:
+        r_id: 12069
+        rv_id: 110440
         rule_id: BYU7Kp
         version_id: RGTDReO
         url: https://semgrep.dev/playground/r/RGTDReO/python.lang.security.deserialization.avoid-jsonpickle.avoid-jsonpickle
@@ -21857,6 +22148,8 @@ rules:
     shortlink: https://sg.run/we9Y
     semgrep.dev:
       rule:
+        r_id: 9673
+        rv_id: 110441
         rule_id: ZqU5jZ
         version_id: A8T9Xk9
         url: https://semgrep.dev/playground/r/A8T9Xk9/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
@@ -21915,6 +22208,8 @@ rules:
     shortlink: https://sg.run/x1rz
     semgrep.dev:
       rule:
+        r_id: 9674
+        rv_id: 110442
         rule_id: nJUzqK
         version_id: BjTXpxx
         url: https://semgrep.dev/playground/r/BjTXpxx/python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
@@ -21954,6 +22249,8 @@ rules:
     shortlink: https://sg.run/eLxb
     semgrep.dev:
       rule:
+        r_id: 9676
+        rv_id: 110444
         rule_id: 7KUQNL
         version_id: WrTW3Oo
         url: https://semgrep.dev/playground/r/WrTW3Oo/python.lang.security.deserialization.pickle.avoid-cPickle
@@ -21994,6 +22291,8 @@ rules:
     shortlink: https://sg.run/vzjA
     semgrep.dev:
       rule:
+        r_id: 9677
+        rv_id: 110445
         rule_id: L1Uy60
         version_id: 0bTLeyE
         url: https://semgrep.dev/playground/r/0bTLeyE/python.lang.security.deserialization.pickle.avoid-dill
@@ -22034,6 +22333,8 @@ rules:
     shortlink: https://sg.run/OPwB
     semgrep.dev:
       rule:
+        r_id: 9675
+        rv_id: 110443
         rule_id: EwU2BJ
         version_id: DkT6Yq9
         url: https://semgrep.dev/playground/r/DkT6Yq9/python.lang.security.deserialization.pickle.avoid-pickle
@@ -22077,6 +22378,8 @@ rules:
     shortlink: https://sg.run/dKkZ
     semgrep.dev:
       rule:
+        r_id: 9678
+        rv_id: 110446
         rule_id: 8GUje2
         version_id: K3TvGnY
         url: https://semgrep.dev/playground/r/K3TvGnY/python.lang.security.deserialization.pickle.avoid-shelve
@@ -22124,6 +22427,8 @@ rules:
     shortlink: https://sg.run/rdBn
     semgrep.dev:
       rule:
+        r_id: 9625
+        rv_id: 110449
         rule_id: OrU30g
         version_id: YDTpnNl
         url: https://semgrep.dev/playground/r/YDTpnNl/python.lang.security.insecure-hash-function.insecure-hash-function
@@ -22168,6 +22473,8 @@ rules:
     shortlink: https://sg.run/N4lp
     semgrep.dev:
       rule:
+        r_id: 9627
+        rv_id: 110451
         rule_id: v8UnkQ
         version_id: o5Tg9kZ
         url: https://semgrep.dev/playground/r/o5Tg9kZ/python.lang.security.unverified-ssl-context.unverified-ssl-context
@@ -22203,6 +22510,8 @@ rules:
     shortlink: https://sg.run/kX47
     semgrep.dev:
       rule:
+        r_id: 9628
+        rv_id: 110453
         rule_id: d8UjRx
         version_id: pZT1LkL
         url: https://semgrep.dev/playground/r/pZT1LkL/python.lang.security.use-defused-xml.use-defused-xml
@@ -22248,6 +22557,8 @@ rules:
     shortlink: https://sg.run/weqY
     semgrep.dev:
       rule:
+        r_id: 9629
+        rv_id: 110454
         rule_id: ZqU5EZ
         version_id: 2KTz3Gv
         url: https://semgrep.dev/playground/r/2KTz3Gv/python.lang.security.use-defused-xmlrpc.use-defused-xmlrpc
@@ -22281,6 +22592,8 @@ rules:
     shortlink: https://sg.run/AlYp
     semgrep.dev:
       rule:
+        r_id: 9694
+        rv_id: 110490
         rule_id: qNUoYR
         version_id: K3TvGzY
         url: https://semgrep.dev/playground/r/K3TvGzY/python.requests.security.disabled-cert-validation.disabled-cert-validation
@@ -22333,6 +22646,8 @@ rules:
     shortlink: https://sg.run/B4NW
     semgrep.dev:
       rule:
+        r_id: 9695
+        rv_id: 110491
         rule_id: lBUdQZ
         version_id: qkT2B1X
         url: https://semgrep.dev/playground/r/qkT2B1X/python.requests.security.no-auth-over-http.no-auth-over-http
@@ -22379,6 +22694,8 @@ rules:
     shortlink: https://sg.run/Wg34
     semgrep.dev:
       rule:
+        r_id: 9697
+        rv_id: 110492
         rule_id: JDUP1G
         version_id: l4T46rW
         url: https://semgrep.dev/playground/r/l4T46rW/python.sh.security.string-concat.string-concat
@@ -22448,6 +22765,8 @@ rules:
     shortlink: https://sg.run/yP1O
     semgrep.dev:
       rule:
+        r_id: 15824
+        rv_id: 253874
         rule_id: r6U2wE
         version_id: 2KTGW4q
         url: https://semgrep.dev/playground/r/2KTGW4q/python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
@@ -22490,6 +22809,8 @@ rules:
     shortlink: https://sg.run/2b1L
     semgrep.dev:
       rule:
+        r_id: 10563
+        rv_id: 110498
         rule_id: oqUz5y
         version_id: A8T9Xrg
         url: https://semgrep.dev/playground/r/A8T9Xrg/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
@@ -22551,6 +22872,8 @@ rules:
     shortlink: https://sg.run/AlYg
     semgrep.dev:
       rule:
+        r_id: 9706
+        rv_id: 110506
         rule_id: KxU426
         version_id: YDTpn6x
         url: https://semgrep.dev/playground/r/YDTpn6x/ruby.jwt.security.audit.jwt-decode-without-verify.ruby-jwt-decode-without-verify
@@ -22592,6 +22915,8 @@ rules:
     shortlink: https://sg.run/B4Nb
     semgrep.dev:
       rule:
+        r_id: 9707
+        rv_id: 110507
         rule_id: qNUoYd
         version_id: 6xTvQ54
         url: https://semgrep.dev/playground/r/6xTvQ54/ruby.jwt.security.audit.jwt-exposed-data.ruby-jwt-exposed-data
@@ -22637,6 +22962,8 @@ rules:
     shortlink: https://sg.run/58Y6
     semgrep.dev:
       rule:
+        r_id: 9703
+        rv_id: 110508
         rule_id: DbUWdB
         version_id: o5Tg9yQ
         url: https://semgrep.dev/playground/r/o5Tg9yQ/ruby.jwt.security.jwt-exposed-credentials.ruby-jwt-exposed-credentials
@@ -22682,6 +23009,8 @@ rules:
     shortlink: https://sg.run/GW2B
     semgrep.dev:
       rule:
+        r_id: 9704
+        rv_id: 729097
         rule_id: WAUZz5
         version_id: ExTq53v
         url: https://semgrep.dev/playground/r/ExTq53v/ruby.jwt.security.jwt-hardcode.ruby-jwt-hardcoded-secret
@@ -22749,6 +23078,8 @@ rules:
     shortlink: https://sg.run/R8kE
     semgrep.dev:
       rule:
+        r_id: 9705
+        rv_id: 110510
         rule_id: 0oUExR
         version_id: pZT1L64
         url: https://semgrep.dev/playground/r/pZT1L64/ruby.jwt.security.jwt-none-alg.ruby-jwt-none-alg
@@ -22791,6 +23122,8 @@ rules:
     shortlink: https://sg.run/Wg3y
     semgrep.dev:
       rule:
+        r_id: 9709
+        rv_id: 110514
         rule_id: YGUrq5
         version_id: 1QTO7b6
         url: https://semgrep.dev/playground/r/1QTO7b6/ruby.lang.security.cookie-serialization.cookie-serialization
@@ -22837,6 +23170,8 @@ rules:
     shortlink: https://sg.run/0nLk
     semgrep.dev:
       rule:
+        r_id: 9710
+        rv_id: 110515
         rule_id: 6JUqbn
         version_id: 9lTd5op
         url: https://semgrep.dev/playground/r/9lTd5op/ruby.lang.security.create-with.create-with
@@ -22881,6 +23216,8 @@ rules:
     shortlink: https://sg.run/Al8Q
     semgrep.dev:
       rule:
+        r_id: 9806
+        rv_id: 110517
         rule_id: 0oUEyd
         version_id: rxTy4o7
         url: https://semgrep.dev/playground/r/rxTy4o7/ruby.lang.security.dangerous-open.dangerous-open
@@ -22925,6 +23262,8 @@ rules:
     shortlink: https://sg.run/B4jv
     semgrep.dev:
       rule:
+        r_id: 9807
+        rv_id: 110518
         rule_id: KxU4nd
         version_id: bZTb9Ke
         url: https://semgrep.dev/playground/r/bZTb9Ke/ruby.lang.security.dangerous-open3-pipeline.dangerous-open3-pipeline
@@ -22967,6 +23306,8 @@ rules:
     shortlink: https://sg.run/NrxL
     semgrep.dev:
       rule:
+        r_id: 9827
+        rv_id: 110519
         rule_id: OrUGn8
         version_id: NdT3o9R
         url: https://semgrep.dev/playground/r/NdT3o9R/ruby.lang.security.dangerous-subshell.dangerous-subshell
@@ -23003,6 +23344,8 @@ rules:
     shortlink: https://sg.run/DJkv
     semgrep.dev:
       rule:
+        r_id: 9808
+        rv_id: 110520
         rule_id: qNUo50
         version_id: kbTdLjG
         url: https://semgrep.dev/playground/r/kbTdLjG/ruby.lang.security.dangerous-syscall.dangerous-syscall
@@ -23041,6 +23384,8 @@ rules:
     shortlink: https://sg.run/qrR1
     semgrep.dev:
       rule:
+        r_id: 9712
+        rv_id: 110522
         rule_id: zdUyqE
         version_id: xyTKpAo
         url: https://semgrep.dev/playground/r/xyTKpAo/ruby.lang.security.file-disclosure.file-disclosure
@@ -23086,6 +23431,8 @@ rules:
     shortlink: https://sg.run/ljNL
     semgrep.dev:
       rule:
+        r_id: 9713
+        rv_id: 110523
         rule_id: pKUGP7
         version_id: O9TNdne
         url: https://semgrep.dev/playground/r/O9TNdne/ruby.lang.security.filter-skipping.filter-skipping
@@ -23131,6 +23478,8 @@ rules:
     shortlink: https://sg.run/6r0w
     semgrep.dev:
       rule:
+        r_id: 9715
+        rv_id: 110525
         rule_id: X5UZWK
         version_id: vdTY8p2
         url: https://semgrep.dev/playground/r/vdTY8p2/ruby.lang.security.hardcoded-http-auth-in-controller.hardcoded-http-auth-in-controller
@@ -23174,6 +23523,8 @@ rules:
     shortlink: https://sg.run/plr3
     semgrep.dev:
       rule:
+        r_id: 9718
+        rv_id: 110530
         rule_id: 9AUOQB
         version_id: 7ZTgnQD
         url: https://semgrep.dev/playground/r/7ZTgnQD/ruby.lang.security.json-entity-escape.json-entity-escape
@@ -23211,6 +23562,8 @@ rules:
     shortlink: https://sg.run/2byz
     semgrep.dev:
       rule:
+        r_id: 9719
+        rv_id: 110531
         rule_id: yyUvkJ
         version_id: LjTqAy2
         url: https://semgrep.dev/playground/r/LjTqAy2/ruby.lang.security.mass-assignment-protection-disabled.mass-assignment-protection-disabled
@@ -23263,6 +23616,8 @@ rules:
     shortlink: https://sg.run/XLel
     semgrep.dev:
       rule:
+        r_id: 9720
+        rv_id: 110533
         rule_id: r6UkO5
         version_id: gET3O1W
         url: https://semgrep.dev/playground/r/gET3O1W/ruby.lang.security.missing-csrf-protection.missing-csrf-protection
@@ -23298,6 +23653,8 @@ rules:
     shortlink: https://sg.run/jNrZ
     semgrep.dev:
       rule:
+        r_id: 9721
+        rv_id: 110534
         rule_id: bwUOAG
         version_id: QkTWwzp
         url: https://semgrep.dev/playground/r/QkTWwzp/ruby.lang.security.model-attr-accessible.model-attr-accessible
@@ -23373,6 +23730,8 @@ rules:
     shortlink: https://sg.run/1nrb
     semgrep.dev:
       rule:
+        r_id: 9722
+        rv_id: 110535
         rule_id: NbUADO
         version_id: 3ZTkrPj
         url: https://semgrep.dev/playground/r/3ZTkrPj/ruby.lang.security.model-attributes-attr-accessible.model-attributes-attr-accessible
@@ -23409,6 +23768,8 @@ rules:
     shortlink: https://sg.run/Nrbx
     semgrep.dev:
       rule:
+        r_id: 9727
+        rv_id: 110540
         rule_id: eqUv0L
         version_id: GxTv876
         url: https://semgrep.dev/playground/r/GxTv876/ruby.lang.security.no-send.bad-send
@@ -23471,6 +23832,8 @@ rules:
     shortlink: https://sg.run/xY8e
     semgrep.dev:
       rule:
+        r_id: 9730
+        rv_id: 110543
         rule_id: ZqUqQg
         version_id: BjTXpNb
         url: https://semgrep.dev/playground/r/BjTXpNb/ruby.lang.security.unprotected-mass-assign.mass-assignment-vuln
@@ -23503,6 +23866,8 @@ rules:
     shortlink: https://sg.run/Je0d
     semgrep.dev:
       rule:
+        r_id: 16546
+        rv_id: 110554
         rule_id: 8GUAo4
         version_id: pZT1LO4
         url: https://semgrep.dev/playground/r/pZT1LO4/ruby.rails.security.audit.detailed-exceptions.detailed-exceptions
@@ -23566,6 +23931,8 @@ rules:
     shortlink: https://sg.run/PgwY
     semgrep.dev:
       rule:
+        r_id: 16201
+        rv_id: 110568
         rule_id: QrUnEk
         version_id: e1T0386
         url: https://semgrep.dev/playground/r/e1T0386/ruby.rails.security.audit.rails-skip-forgery-protection.rails-skip-forgery-protection
@@ -23599,6 +23966,8 @@ rules:
     shortlink: https://sg.run/dg8P
     semgrep.dev:
       rule:
+        r_id: 9734
+        rv_id: 110570
         rule_id: L1U4qz
         version_id: d6TrvjR
         url: https://semgrep.dev/playground/r/d6TrvjR/ruby.rails.security.audit.xss.avoid-content-tag.avoid-content-tag
@@ -23637,6 +24006,8 @@ rules:
     shortlink: https://sg.run/Pbrq
     semgrep.dev:
       rule:
+        r_id: 13589
+        rv_id: 110571
         rule_id: qNUXYy
         version_id: ZRTQp5j
         url: https://semgrep.dev/playground/r/ZRTQp5j/ruby.rails.security.audit.xss.avoid-default-routes.avoid-default-routes
@@ -23684,6 +24055,8 @@ rules:
     shortlink: https://sg.run/Zeq7
     semgrep.dev:
       rule:
+        r_id: 9735
+        rv_id: 110572
         rule_id: 8GUEQK
         version_id: nWTxoYW
         url: https://semgrep.dev/playground/r/nWTxoYW/ruby.rails.security.audit.xss.avoid-html-safe.avoid-html-safe
@@ -23726,6 +24099,8 @@ rules:
     shortlink: https://sg.run/nqJG
     semgrep.dev:
       rule:
+        r_id: 9736
+        rv_id: 110574
         rule_id: gxUW3x
         version_id: 7ZTgneD
         url: https://semgrep.dev/playground/r/7ZTgneD/ruby.rails.security.audit.xss.avoid-raw.avoid-raw
@@ -23766,6 +24141,8 @@ rules:
     shortlink: https://sg.run/E5w8
     semgrep.dev:
       rule:
+        r_id: 9737
+        rv_id: 110577
         rule_id: QrU6Ww
         version_id: gET3OWW
         url: https://semgrep.dev/playground/r/gET3OWW/ruby.rails.security.audit.xss.avoid-render-inline.avoid-render-inline
@@ -23806,6 +24183,8 @@ rules:
     shortlink: https://sg.run/70Kv
     semgrep.dev:
       rule:
+        r_id: 9738
+        rv_id: 110578
         rule_id: 3qUBk4
         version_id: QkTWw6p
         url: https://semgrep.dev/playground/r/QkTWw6p/ruby.rails.security.audit.xss.avoid-render-text.avoid-render-text
@@ -23848,6 +24227,8 @@ rules:
     shortlink: https://sg.run/L01L
     semgrep.dev:
       rule:
+        r_id: 9739
+        rv_id: 110579
         rule_id: 4bUzR9
         version_id: 3ZTkrBj
         url: https://semgrep.dev/playground/r/3ZTkrBj/ruby.rails.security.audit.xss.manual-template-creation.manual-template-creation
@@ -23893,6 +24274,8 @@ rules:
     shortlink: https://sg.run/8nGJ
     semgrep.dev:
       rule:
+        r_id: 9740
+        rv_id: 110580
         rule_id: PeUkJe
         version_id: 44TR6zg
         url: https://semgrep.dev/playground/r/44TR6zg/ruby.rails.security.audit.xss.templates.alias-for-html-safe.alias-for-html-safe
@@ -23939,6 +24322,8 @@ rules:
     shortlink: https://sg.run/gJxo
     semgrep.dev:
       rule:
+        r_id: 9741
+        rv_id: 110581
         rule_id: JDUPNG
         version_id: PkTJdkx
         url: https://semgrep.dev/playground/r/PkTJdkx/ruby.rails.security.audit.xss.templates.avoid-content-tag.avoid-content-tag
@@ -23985,6 +24370,8 @@ rules:
     shortlink: https://sg.run/Q8rD
     semgrep.dev:
       rule:
+        r_id: 9742
+        rv_id: 110582
         rule_id: 5rU4dE
         version_id: JdTNvPo
         url: https://semgrep.dev/playground/r/JdTNvPo/ruby.rails.security.audit.xss.templates.avoid-html-safe.avoid-html-safe
@@ -24031,6 +24418,8 @@ rules:
     shortlink: https://sg.run/3Aqg
     semgrep.dev:
       rule:
+        r_id: 9743
+        rv_id: 110583
         rule_id: GdU0vJ
         version_id: 5PTde49
         url: https://semgrep.dev/playground/r/5PTde49/ruby.rails.security.audit.xss.templates.avoid-raw.avoid-raw
@@ -24075,6 +24464,8 @@ rules:
     shortlink: https://sg.run/PpeN
     semgrep.dev:
       rule:
+        r_id: 9745
+        rv_id: 110585
         rule_id: AbUW9y
         version_id: RGTDRPR
         url: https://semgrep.dev/playground/r/RGTDRPR/ruby.rails.security.audit.xss.templates.unquoted-attribute.unquoted-attribute
@@ -24128,6 +24519,8 @@ rules:
     shortlink: https://sg.run/J3Do
     semgrep.dev:
       rule:
+        r_id: 9746
+        rv_id: 110586
         rule_id: BYUBXo
         version_id: A8T9XWg
         url: https://semgrep.dev/playground/r/A8T9XWg/ruby.rails.security.audit.xss.templates.var-in-href.var-in-href
@@ -24176,6 +24569,8 @@ rules:
     shortlink: https://sg.run/58r6
     semgrep.dev:
       rule:
+        r_id: 9747
+        rv_id: 110587
         rule_id: DbUW6B
         version_id: BjTXpBb
         url: https://semgrep.dev/playground/r/BjTXpBb/ruby.rails.security.audit.xss.templates.var-in-script-tag.var-in-script-tag
@@ -24236,6 +24631,8 @@ rules:
     shortlink: https://sg.run/WDYA
     semgrep.dev:
       rule:
+        r_id: 20153
+        rv_id: 110591
         rule_id: KxUw3v
         version_id: K3TvG4Q
         url: https://semgrep.dev/playground/r/K3TvG4Q/ruby.rails.security.brakeman.check-cookie-store-session-security-attributes.check-cookie-store-session-security-attributes
@@ -24276,6 +24673,8 @@ rules:
     shortlink: https://sg.run/4k0Z
     semgrep.dev:
       rule:
+        r_id: 20044
+        rv_id: 110594
         rule_id: 5rUNql
         version_id: YDTpnrx
         url: https://semgrep.dev/playground/r/YDTpnrx/ruby.rails.security.brakeman.check-permit-attributes-high.check-permit-attributes-high
@@ -24316,6 +24715,8 @@ rules:
     shortlink: https://sg.run/PPLE
     semgrep.dev:
       rule:
+        r_id: 20045
+        rv_id: 110595
         rule_id: GdUoq5
         version_id: JdTNvPO
         url: https://semgrep.dev/playground/r/JdTNvPO/ruby.rails.security.brakeman.check-permit-attributes-medium.check-permit-attributes-medium
@@ -24369,6 +24770,8 @@ rules:
     shortlink: https://sg.run/0Wvb
     semgrep.dev:
       rule:
+        r_id: 20154
+        rv_id: 110596
         rule_id: qNUpJ5
         version_id: 5PTde4l
         url: https://semgrep.dev/playground/r/5PTde4l/ruby.rails.security.brakeman.check-rails-secret-yaml.check-rails-secret-yaml
@@ -24397,6 +24800,8 @@ rules:
     shortlink: https://sg.run/G6k6
     semgrep.dev:
       rule:
+        r_id: 40104
+        rv_id: 110613
         rule_id: DbUeEe
         version_id: X0TQ2ZP
         url: https://semgrep.dev/playground/r/X0TQ2ZP/rust.lang.security.args-os.args-os
@@ -24428,6 +24833,8 @@ rules:
     shortlink: https://sg.run/RADN
     semgrep.dev:
       rule:
+        r_id: 40105
+        rv_id: 110614
         rule_id: WAU6Lk
         version_id: jQTgyqZ
         url: https://semgrep.dev/playground/r/jQTgyqZ/rust.lang.security.args.args
@@ -24459,6 +24866,8 @@ rules:
     shortlink: https://sg.run/AW1B
     semgrep.dev:
       rule:
+        r_id: 40106
+        rv_id: 110615
         rule_id: 0oU6nZ
         version_id: 1QTO7Zg
         url: https://semgrep.dev/playground/r/1QTO7Zg/rust.lang.security.current-exe.current-exe
@@ -24495,6 +24904,8 @@ rules:
     shortlink: https://sg.run/B09R
     semgrep.dev:
       rule:
+        r_id: 40107
+        rv_id: 110616
         rule_id: KxUOxA
         version_id: 9lTd5kQ
         url: https://semgrep.dev/playground/r/9lTd5kQ/rust.lang.security.insecure-hashes.insecure-hashes
@@ -24551,6 +24962,8 @@ rules:
     shortlink: https://sg.run/WKlE
     semgrep.dev:
       rule:
+        r_id: 40109
+        rv_id: 110618
         rule_id: lBUNEw
         version_id: rxTy490
         url: https://semgrep.dev/playground/r/rxTy490/rust.lang.security.reqwest-set-sensitive.reqwest-set-sensitive
@@ -24584,6 +24997,8 @@ rules:
     shortlink: https://sg.run/qzEO
     semgrep.dev:
       rule:
+        r_id: 40112
+        rv_id: 110621
         rule_id: oqU5AO
         version_id: kbTdL8R
         url: https://semgrep.dev/playground/r/kbTdL8R/rust.lang.security.temp-dir.temp-dir
@@ -24612,6 +25027,8 @@ rules:
     shortlink: https://sg.run/lqgo
     semgrep.dev:
       rule:
+        r_id: 40113
+        rv_id: 110622
         rule_id: zdUezd
         version_id: w8T9DGG
         url: https://semgrep.dev/playground/r/w8T9DGG/rust.lang.security.unsafe-usage.unsafe-usage
@@ -24666,6 +25083,8 @@ rules:
     shortlink: https://sg.run/79b2
     semgrep.dev:
       rule:
+        r_id: 18282
+        rv_id: 110625
         rule_id: JDUle4
         version_id: e1T03pD
         url: https://semgrep.dev/playground/r/e1T03pD/scala.lang.security.audit.dangerous-seq-run.dangerous-seq-run
@@ -24720,6 +25139,8 @@ rules:
     shortlink: https://sg.run/Lg76
     semgrep.dev:
       rule:
+        r_id: 18283
+        rv_id: 110626
         rule_id: 5rUy3K
         version_id: vdTY8jv
         url: https://semgrep.dev/playground/r/vdTY8jv/scala.lang.security.audit.dangerous-shell-run.dangerous-shell-run
@@ -24770,6 +25191,8 @@ rules:
     shortlink: https://sg.run/gR6J
     semgrep.dev:
       rule:
+        r_id: 18485
+        rv_id: 110627
         rule_id: 5rUyl4
         version_id: d6TrvlP
         url: https://semgrep.dev/playground/r/d6TrvlP/scala.lang.security.audit.dispatch-ssrf.dispatch-ssrf
@@ -24803,6 +25226,8 @@ rules:
     shortlink: https://sg.run/JxAw
     semgrep.dev:
       rule:
+        r_id: 15190
+        rv_id: 110629
         rule_id: gxUgDk
         version_id: nWTxoro
         url: https://semgrep.dev/playground/r/nWTxoro/scala.lang.security.audit.insecure-random.insecure-random
@@ -24865,6 +25290,8 @@ rules:
     shortlink: https://sg.run/Qbz4
     semgrep.dev:
       rule:
+        r_id: 18486
+        rv_id: 110630
         rule_id: GdUDOZ
         version_id: ExTjAQE
         url: https://semgrep.dev/playground/r/ExTjAQE/scala.lang.security.audit.io-source-ssrf.io-source-ssrf
@@ -24901,6 +25328,8 @@ rules:
     shortlink: https://sg.run/5D1A
     semgrep.dev:
       rule:
+        r_id: 15191
+        rv_id: 110631
         rule_id: QrUdOZ
         version_id: 7ZTgnpB
         url: https://semgrep.dev/playground/r/7ZTgnpB/scala.lang.security.audit.path-traversal-fromfile.path-traversal-fromfile
@@ -24965,6 +25394,8 @@ rules:
     shortlink: https://sg.run/GO5p
     semgrep.dev:
       rule:
+        r_id: 15192
+        rv_id: 110632
         rule_id: 3qUj1Q
         version_id: LjTqArR
         url: https://semgrep.dev/playground/r/LjTqArR/scala.lang.security.audit.rsa-padding-set.rsa-padding-set
@@ -25057,6 +25488,8 @@ rules:
     shortlink: https://sg.run/QbYP
     semgrep.dev:
       rule:
+        r_id: 19042
+        rv_id: 110633
         rule_id: KxUrkq
         version_id: 8KTQyxg
         url: https://semgrep.dev/playground/r/8KTQyxg/scala.lang.security.audit.sax-dtd-enabled.sax-dtd-enabled
@@ -25126,6 +25559,8 @@ rules:
     shortlink: https://sg.run/wZBY
     semgrep.dev:
       rule:
+        r_id: 17329
+        rv_id: 110634
         rule_id: 6JUEeo
         version_id: gET3OY0
         url: https://semgrep.dev/playground/r/gET3OY0/scala.lang.security.audit.scala-dangerous-process-run.scala-dangerous-process-run
@@ -25166,6 +25601,8 @@ rules:
     shortlink: https://sg.run/QbGd
     semgrep.dev:
       rule:
+        r_id: 18686
+        rv_id: 110635
         rule_id: JDUlE0
         version_id: QkTWwpg
         url: https://semgrep.dev/playground/r/QkTWwpg/scala.lang.security.audit.scalac-debug.scalac-debug
@@ -25216,6 +25653,8 @@ rules:
     shortlink: https://sg.run/OgjB
     semgrep.dev:
       rule:
+        r_id: 18431
+        rv_id: 110636
         rule_id: AbU3xA
         version_id: 3ZTkrEx
         url: https://semgrep.dev/playground/r/3ZTkrEx/scala.lang.security.audit.scalaj-http-ssrf.scalaj-http-ssrf
@@ -25266,6 +25705,8 @@ rules:
     shortlink: https://sg.run/3BEb
     semgrep.dev:
       rule:
+        r_id: 19043
+        rv_id: 110639
         rule_id: qNUQ7w
         version_id: JdTNvQO
         url: https://semgrep.dev/playground/r/JdTNvQO/scala.lang.security.audit.xmlinputfactory-dtd-enabled.xmlinputfactory-dtd-enabled
@@ -25297,8 +25738,9 @@ rules:
   message: A parameter being passed directly into `WSClient` most likely lead to SSRF.
     This could allow an attacker to send data to their own server, potentially exposing
     sensitive data sent with this request. They could also probe internal servers
-    or other resources that the server runnig this code can access. Do not allow arbitrary
-    hosts. Instead, create an allowlist for approved hosts hardcode the correct host.
+    or other resources that the server running this code can access. Do not allow
+    arbitrary hosts. Instead, create an allowlist for approved hosts hardcode the
+    correct host.
   metadata:
     cwe:
     - 'CWE-918: Server-Side Request Forgery (SSRF)'
@@ -25325,9 +25767,11 @@ rules:
     shortlink: https://sg.run/reRR
     semgrep.dev:
       rule:
+        r_id: 18369
+        rv_id: 751092
         rule_id: PeUxEE
-        version_id: WrTW3PB
-        url: https://semgrep.dev/playground/r/WrTW3PB/scala.play.security.webservice-ssrf.webservice-ssrf
+        version_id: YDTAbP2
+        url: https://semgrep.dev/playground/r/YDTAbP2/scala.play.security.webservice-ssrf.webservice-ssrf
         origin: community
   languages:
   - scala
@@ -25364,6 +25808,8 @@ rules:
     shortlink: https://sg.run/Z40o
     semgrep.dev:
       rule:
+        r_id: 15079
+        rv_id: 110647
         rule_id: OrU6W1
         version_id: 0bTLeJn
         url: https://semgrep.dev/playground/r/0bTLeJn/scala.scala-jwt.security.jwt-hardcode.scala-jwt-hardcoded-secret
@@ -25467,6 +25913,8 @@ rules:
     shortlink: https://sg.run/PYe0
     semgrep.dev:
       rule:
+        r_id: 17501
+        rv_id: 110648
         rule_id: wdUA97
         version_id: K3TvGY1
         url: https://semgrep.dev/playground/r/K3TvGY1/scala.slick.security.scala-slick-overridesql-literal.scala-slick-overrideSql-literal
@@ -25512,6 +25960,8 @@ rules:
     shortlink: https://sg.run/JgDk
     semgrep.dev:
       rule:
+        r_id: 17502
+        rv_id: 110649
         rule_id: x8UNKe
         version_id: qkT2Bb8
         url: https://semgrep.dev/playground/r/qkT2Bb8/scala.slick.security.scala-slick-sql-non-literal.scala-slick-sql-non-literal
@@ -25537,6 +25987,8 @@ rules:
     shortlink: https://sg.run/6DyK
     semgrep.dev:
       rule:
+        r_id: 67659
+        rv_id: 110687
         rule_id: 5rUD6Z
         version_id: A8T9XQO
         url: https://semgrep.dev/playground/r/A8T9XQO/solidity.security.no-bidi-characters.no-bidi-characters
@@ -25584,6 +26036,8 @@ rules:
     shortlink: https://sg.run/YWLd
     semgrep.dev:
       rule:
+        r_id: 66514
+        rv_id: 110702
         rule_id: lBUOZk
         version_id: DkT6Y18
         url: https://semgrep.dev/playground/r/DkT6Y18/swift.webview.webview-js-window.swift-webview-config-allows-js-open-windows
@@ -25679,6 +26133,8 @@ rules:
     shortlink: https://sg.run/gX7J
     semgrep.dev:
       rule:
+        r_id: 17341
+        rv_id: 110726
         rule_id: NbUXOA
         version_id: e1T03rw
         url: https://semgrep.dev/playground/r/e1T03rw/terraform.aws.security.aws-athena-workgroup-unencrypted.aws-athena-workgroup-unencrypted
@@ -25721,6 +26177,8 @@ rules:
     shortlink: https://sg.run/18yw
     semgrep.dev:
       rule:
+        r_id: 15122
+        rv_id: 110727
         rule_id: x8UxrP
         version_id: vdTY84K
         url: https://semgrep.dev/playground/r/vdTY84K/terraform.aws.security.aws-backup-vault-unencrypted.aws-backup-vault-unencrypted
@@ -25762,6 +26220,8 @@ rules:
     shortlink: https://sg.run/38kr
     semgrep.dev:
       rule:
+        r_id: 17343
+        rv_id: 110729
         rule_id: wdUl2j
         version_id: ZRTQpG1
         url: https://semgrep.dev/playground/r/ZRTQpG1/terraform.aws.security.aws-cloudtrail-encrypted-with-cmk.aws-cloudtrail-encrypted-with-cmk
@@ -25812,6 +26272,8 @@ rules:
     shortlink: https://sg.run/Pg6Y
     semgrep.dev:
       rule:
+        r_id: 17345
+        rv_id: 110731
         rule_id: OrUl0J
         version_id: ExTjAqL
         url: https://semgrep.dev/playground/r/ExTjAqL/terraform.aws.security.aws-cloudwatch-log-group-unencrypted.aws-cloudwatch-log-group-unencrypted
@@ -25874,6 +26336,8 @@ rules:
     shortlink: https://sg.run/JeWw
     semgrep.dev:
       rule:
+        r_id: 17346
+        rv_id: 110733
         rule_id: eqUrdZ
         version_id: LjTqAPO
         url: https://semgrep.dev/playground/r/LjTqAPO/terraform.aws.security.aws-codebuild-project-artifacts-unencrypted.aws-codebuild-project-artifacts-unencrypted
@@ -25929,6 +26393,8 @@ rules:
     shortlink: https://sg.run/O6A7
     semgrep.dev:
       rule:
+        r_id: 47275
+        rv_id: 110735
         rule_id: DbUo7v
         version_id: gET3OJK
         url: https://semgrep.dev/playground/r/gET3OJK/terraform.aws.security.aws-config-aggregator-not-all-regions.aws-config-aggregator-not-all-regions
@@ -25970,6 +26436,8 @@ rules:
     shortlink: https://sg.run/RyzO
     semgrep.dev:
       rule:
+        r_id: 17349
+        rv_id: 110737
         rule_id: ZqUGEp
         version_id: 3ZTkr60
         url: https://semgrep.dev/playground/r/3ZTkr60/terraform.aws.security.aws-docdb-encrypted-with-cmk.aws-docdb-encrypted-with-cmk
@@ -26019,6 +26487,8 @@ rules:
     shortlink: https://sg.run/xJYP
     semgrep.dev:
       rule:
+        r_id: 48630
+        rv_id: 110738
         rule_id: AbU1WN
         version_id: 44TR6gP
         url: https://semgrep.dev/playground/r/44TR6gP/terraform.aws.security.aws-documentdb-auditing-disabled.aws-documentdb-auditing-disabled
@@ -26063,6 +26533,8 @@ rules:
     shortlink: https://sg.run/WW14
     semgrep.dev:
       rule:
+        r_id: 17353
+        rv_id: 110744
         rule_id: L1UPY9
         version_id: A8T9Xe6
         url: https://semgrep.dev/playground/r/A8T9Xe6/terraform.aws.security.aws-ebs-volume-encrypted-with-cmk.aws-ebs-volume-encrypted-with-cmk
@@ -26114,6 +26586,8 @@ rules:
     shortlink: https://sg.run/6ZbY
     semgrep.dev:
       rule:
+        r_id: 50759
+        rv_id: 110745
         rule_id: YGUKl1
         version_id: BjTXpzE
         url: https://semgrep.dev/playground/r/BjTXpzE/terraform.aws.security.aws-ebs-volume-unencrypted.aws-ebs-volume-unencrypted
@@ -26175,6 +26649,8 @@ rules:
     shortlink: https://sg.run/pg9J
     semgrep.dev:
       rule:
+        r_id: 50762
+        rv_id: 110749
         rule_id: zdU0Wo
         version_id: K3TvGrv
         url: https://semgrep.dev/playground/r/K3TvGrv/terraform.aws.security.aws-ec2-launch-template-metadata-service-v1-enabled.aws-ec2-launch-template-metadata-service-v1-enabled
@@ -26222,6 +26698,8 @@ rules:
     shortlink: https://sg.run/ZEeL
     semgrep.dev:
       rule:
+        r_id: 48635
+        rv_id: 110753
         rule_id: KxUB4o
         version_id: 6xTvQDq
         url: https://semgrep.dev/playground/r/6xTvQDq/terraform.aws.security.aws-ecr-mutable-image-tags.aws-ecr-mutable-image-tags
@@ -26266,6 +26744,8 @@ rules:
     shortlink: https://sg.run/Kk07
     semgrep.dev:
       rule:
+        r_id: 17355
+        rv_id: 110755
         rule_id: gxUJ4n
         version_id: zyTKDWY
         url: https://semgrep.dev/playground/r/zyTKDWY/terraform.aws.security.aws-efs-filesystem-encrypted-with-cmk.aws-efs-filesystem-encrypted-with-cmk
@@ -26312,6 +26792,8 @@ rules:
     shortlink: https://sg.run/6gOo
     semgrep.dev:
       rule:
+        r_id: 17359
+        rv_id: 110760
         rule_id: PeU0L7
         version_id: 1QTO7PY
         url: https://semgrep.dev/playground/r/1QTO7PY/terraform.aws.security.aws-emr-encrypted-with-cmk.aws-emr-encrypted-with-cmk
@@ -26358,6 +26840,8 @@ rules:
     shortlink: https://sg.run/oNG9
     semgrep.dev:
       rule:
+        r_id: 17360
+        rv_id: 110761
         rule_id: JDU6gw
         version_id: 9lTd5J5
         url: https://semgrep.dev/playground/r/9lTd5J5/terraform.aws.security.aws-fsx-lustre-files-ystem.aws-fsx-lustre-filesystem-encrypted-with-cmk
@@ -26403,6 +26887,8 @@ rules:
     shortlink: https://sg.run/zJ6G
     semgrep.dev:
       rule:
+        r_id: 17361
+        rv_id: 110762
         rule_id: 5rUp50
         version_id: yeTRZNx
         url: https://semgrep.dev/playground/r/yeTRZNx/terraform.aws.security.aws-fsx-lustre-filesystem-encrypted-with-cmk.aws-fsx-lustre-filesystem-encrypted-with-cmk
@@ -26447,6 +26933,8 @@ rules:
     shortlink: https://sg.run/pyRg
     semgrep.dev:
       rule:
+        r_id: 17362
+        rv_id: 110763
         rule_id: GdUzwK
         version_id: rxTy4D1
         url: https://semgrep.dev/playground/r/rxTy4D1/terraform.aws.security.aws-fsx-ontapfs-encrypted-with-cmk.aws-fsx-ontapfs-encrypted-with-cmk
@@ -26491,6 +26979,8 @@ rules:
     shortlink: https://sg.run/2pN0
     semgrep.dev:
       rule:
+        r_id: 17363
+        rv_id: 110764
         rule_id: ReUqv6
         version_id: bZTb9BE
         url: https://semgrep.dev/playground/r/bZTb9BE/terraform.aws.security.aws-fsx-windows-encrypted-with-cmk.aws-fsx-windows-encrypted-with-cmk
@@ -26535,6 +27025,8 @@ rules:
     shortlink: https://sg.run/9vdY
     semgrep.dev:
       rule:
+        r_id: 17367
+        rv_id: 110768
         rule_id: WAUNxL
         version_id: xyTKpN3
         url: https://semgrep.dev/playground/r/xyTKpN3/terraform.aws.security.aws-imagebuilder-component-encrypted-with-cmk.aws-imagebuilder-component-encrypted-with-cmk
@@ -26579,6 +27071,8 @@ rules:
     shortlink: https://sg.run/ryBn
     semgrep.dev:
       rule:
+        r_id: 17369
+        rv_id: 110771
         rule_id: KxU5yW
         version_id: vdTY8OK
         url: https://semgrep.dev/playground/r/vdTY8OK/terraform.aws.security.aws-kinesis-stream-encrypted-with-cmk.aws-kinesis-stream-encrypted-with-cmk
@@ -26631,6 +27125,8 @@ rules:
     shortlink: https://sg.run/KZ0L
     semgrep.dev:
       rule:
+        r_id: 52199
+        rv_id: 110772
         rule_id: 8GU72N
         version_id: d6TrvKN
         url: https://semgrep.dev/playground/r/d6TrvKN/terraform.aws.security.aws-kinesis-stream-unencrypted.aws-kinesis-stream-unencrypted
@@ -26672,6 +27168,8 @@ rules:
     shortlink: https://sg.run/bXvp
     semgrep.dev:
       rule:
+        r_id: 17370
+        rv_id: 110773
         rule_id: qNUWqn
         version_id: ZRTQpl1
         url: https://semgrep.dev/playground/r/ZRTQpl1/terraform.aws.security.aws-kinesis-video-stream-encrypted-with-cmk.aws-kinesis-video-stream-encrypted-with-cmk
@@ -26738,6 +27236,8 @@ rules:
     shortlink: https://sg.run/x4lz
     semgrep.dev:
       rule:
+        r_id: 17374
+        rv_id: 110777
         rule_id: 5rUp5w
         version_id: LjTqAEO
         url: https://semgrep.dev/playground/r/LjTqAEO/terraform.aws.security.aws-lambda-environment-unencrypted.aws-lambda-environment-unencrypted
@@ -26790,6 +27290,8 @@ rules:
     shortlink: https://sg.run/wO2Y
     semgrep.dev:
       rule:
+        r_id: 54773
+        rv_id: 110779
         rule_id: eqUl1O
         version_id: gET3OyK
         url: https://semgrep.dev/playground/r/gET3OyK/terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
@@ -26832,6 +27334,8 @@ rules:
     shortlink: https://sg.run/eXnb
     semgrep.dev:
       rule:
+        r_id: 17376
+        rv_id: 110786
         rule_id: ReUqvX
         version_id: GxTv8DA
         url: https://semgrep.dev/playground/r/GxTv8DA/terraform.aws.security.aws-redshift-cluster-encrypted-with-cmk.aws-redshift-cluster-encrypted-with-cmk
@@ -26876,6 +27380,8 @@ rules:
     shortlink: https://sg.run/veKA
     semgrep.dev:
       rule:
+        r_id: 17377
+        rv_id: 110787
         rule_id: AbUeYR
         version_id: RGTDRK5
         url: https://semgrep.dev/playground/r/RGTDRK5/terraform.aws.security.aws-s3-bucket-object-encrypted-with-cmk.aws-s3-bucket-object-encrypted-with-cmk
@@ -26920,6 +27426,8 @@ rules:
     shortlink: https://sg.run/d1ZZ
     semgrep.dev:
       rule:
+        r_id: 17378
+        rv_id: 110788
         rule_id: BYUzYY
         version_id: A8T9X36
         url: https://semgrep.dev/playground/r/A8T9X36/terraform.aws.security.aws-s3-object-copy-encrypted-with-cmk.aws-s3-object-copy-encrypted-with-cmk
@@ -26964,6 +27472,8 @@ rules:
     shortlink: https://sg.run/ZjrD
     semgrep.dev:
       rule:
+        r_id: 17379
+        rv_id: 110789
         rule_id: DbUx8z
         version_id: BjTXpeE
         url: https://semgrep.dev/playground/r/BjTXpeE/terraform.aws.security.aws-sagemaker-domain-encrypted-with-cmk.aws-sagemaker-domain-encrypted-with-cmk
@@ -27015,6 +27525,8 @@ rules:
     shortlink: https://sg.run/nrRX
     semgrep.dev:
       rule:
+        r_id: 17380
+        rv_id: 110790
         rule_id: WAUNrz
         version_id: DkT6YG8
         url: https://semgrep.dev/playground/r/DkT6YG8/terraform.aws.security.aws-secretsmanager-secret-unencrypted.aws-secretsmanager-secret-unencrypted
@@ -27069,6 +27581,8 @@ rules:
     shortlink: https://sg.run/EyWw
     semgrep.dev:
       rule:
+        r_id: 17381
+        rv_id: 110795
         rule_id: 0oUrWL
         version_id: l4T46Xr
         url: https://semgrep.dev/playground/r/l4T46Xr/terraform.aws.security.aws-ssm-document-logging-issues.aws-ssm-document-logging-issues
@@ -27124,6 +27638,8 @@ rules:
     shortlink: https://sg.run/XJZw
     semgrep.dev:
       rule:
+        r_id: 50764
+        rv_id: 110796
         rule_id: 2ZUo79
         version_id: YDTpnYR
         url: https://semgrep.dev/playground/r/YDTpnYR/terraform.aws.security.aws-subnet-has-public-ip-address.aws-subnet-has-public-ip-address
@@ -27165,6 +27681,8 @@ rules:
     shortlink: https://sg.run/7nyZ
     semgrep.dev:
       rule:
+        r_id: 17382
+        rv_id: 110797
         rule_id: KxU5Nn
         version_id: JdTNvoP
         url: https://semgrep.dev/playground/r/JdTNvoP/terraform.aws.security.aws-timestream-database-encrypted-with-cmk.aws-timestream-database-encrypted-with-cmk
@@ -27210,6 +27728,8 @@ rules:
     shortlink: https://sg.run/L39r
     semgrep.dev:
       rule:
+        r_id: 17383
+        rv_id: 110798
         rule_id: qNUWl1
         version_id: 5PTdeN8
         url: https://semgrep.dev/playground/r/5PTdeN8/terraform.aws.security.aws-transfer-server-is-public.aws-transfer-server-is-public
@@ -27259,6 +27779,8 @@ rules:
     shortlink: https://sg.run/8gby
     semgrep.dev:
       rule:
+        r_id: 17384
+        rv_id: 110799
         rule_id: lBUWB9
         version_id: GxTv8or
         url: https://semgrep.dev/playground/r/GxTv8or/terraform.aws.security.aws-workspaces-root-volume-unencrypted.aws-workspaces-root-volume-unencrypted
@@ -27304,6 +27826,8 @@ rules:
     shortlink: https://sg.run/gXdJ
     semgrep.dev:
       rule:
+        r_id: 17385
+        rv_id: 110800
         rule_id: YGUAXr
         version_id: RGTDR2q
         url: https://semgrep.dev/playground/r/RGTDR2q/terraform.aws.security.aws-workspaces-user-volume-unencrypted.aws-workspaces-user-volume-unencrypted
@@ -27348,6 +27872,8 @@ rules:
     shortlink: https://sg.run/kzro
     semgrep.dev:
       rule:
+        r_id: 15828
+        rv_id: 110802
         rule_id: wdUljO
         version_id: BjTXpKK
         url: https://semgrep.dev/playground/r/BjTXpKK/terraform.aws.security.missing-athena-workgroup-encryption.missing-athena-workgroup-encryption
@@ -27378,6 +27904,8 @@ rules:
     shortlink: https://sg.run/LWlY
     semgrep.dev:
       rule:
+        r_id: 70983
+        rv_id: 110803
         rule_id: 7KU3dr
         version_id: DkT6Y2N
         url: https://semgrep.dev/playground/r/DkT6Y2N/terraform.aws.security.unrestricted-github-oidc-policy.unrestricted-github-oidc-policy
@@ -27468,6 +27996,8 @@ rules:
     shortlink: https://sg.run/PbXY
     semgrep.dev:
       rule:
+        r_id: 15101
+        rv_id: 110864
         rule_id: WAUynd
         version_id: rxTy46E
         url: https://semgrep.dev/playground/r/rxTy46E/terraform.azure.security.appservice.appservice-account-identity-registered.appservice-account-identity-registered
@@ -27514,6 +28044,8 @@ rules:
     shortlink: https://sg.run/rDwn
     semgrep.dev:
       rule:
+        r_id: 23969
+        rv_id: 110879
         rule_id: v8UNL7
         version_id: 8KTQyKe
         url: https://semgrep.dev/playground/r/8KTQyKe/terraform.azure.security.appservice.azure-appservice-min-tls-version.azure-appservice-min-tls-version
@@ -27578,6 +28110,8 @@ rules:
     shortlink: https://sg.run/B6AW
     semgrep.dev:
       rule:
+        r_id: 15107
+        rv_id: 110926
         rule_id: 6JU1X8
         version_id: xyTKppv
         url: https://semgrep.dev/playground/r/xyTKppv/terraform.azure.security.functionapp.functionapp-authentication-enabled.functionapp-authentication-enabled
@@ -27639,6 +28173,8 @@ rules:
     shortlink: https://sg.run/DzDY
     semgrep.dev:
       rule:
+        r_id: 15108
+        rv_id: 110927
         rule_id: oqU41L
         version_id: O9TNddn
         url: https://semgrep.dev/playground/r/O9TNddn/terraform.azure.security.functionapp.functionapp-enable-http2.functionapp-enable-http2
@@ -27702,6 +28238,8 @@ rules:
     shortlink: https://sg.run/nKgX
     semgrep.dev:
       rule:
+        r_id: 15136
+        rv_id: 110932
         rule_id: 4bU1jy
         version_id: nWTxooG
         url: https://semgrep.dev/playground/r/nWTxooG/terraform.azure.security.keyvault.keyvault-specify-network-acl.keyvault-specify-network-acl
@@ -27774,6 +28312,8 @@ rules:
     shortlink: https://sg.run/WpX4
     semgrep.dev:
       rule:
+        r_id: 15153
+        rv_id: 110933
         rule_id: GdUreY
         version_id: ExTjAAr
         url: https://semgrep.dev/playground/r/ExTjAAr/terraform.azure.security.storage.storage-allow-microsoft-service-bypass.storage-allow-microsoft-service-bypass
@@ -27823,6 +28363,8 @@ rules:
     shortlink: https://sg.run/WpN4
     semgrep.dev:
       rule:
+        r_id: 15109
+        rv_id: 110934
         rule_id: zdUY3N
         version_id: 7ZTgnnb
         url: https://semgrep.dev/playground/r/7ZTgnnb/terraform.azure.security.storage.storage-default-action-deny.storage-default-action-deny
@@ -27886,6 +28428,8 @@ rules:
     shortlink: https://sg.run/0yEv
     semgrep.dev:
       rule:
+        r_id: 15154
+        rv_id: 110936
         rule_id: ReU3L9
         version_id: 8KTQyy9
         url: https://semgrep.dev/playground/r/8KTQyy9/terraform.azure.security.storage.storage-queue-services-logging.storage-queue-services-logging
@@ -27937,6 +28481,8 @@ rules:
     shortlink: https://sg.run/R8eE
     semgrep.dev:
       rule:
+        r_id: 9749
+        rv_id: 111050
         rule_id: 0oUELR
         version_id: WrTW381
         url: https://semgrep.dev/playground/r/WrTW381/terraform.lang.security.ecr-image-scan-on-push.ecr-image-scan-on-push
@@ -27993,6 +28539,8 @@ rules:
     shortlink: https://sg.run/wZ3n
     semgrep.dev:
       rule:
+        r_id: 15829
+        rv_id: 111051
         rule_id: x8UGx7
         version_id: 0bTLeoA
         url: https://semgrep.dev/playground/r/0bTLeoA/terraform.lang.security.eks-insufficient-control-plane-logging.eks-insufficient-control-plane-logging
@@ -28044,6 +28592,8 @@ rules:
     shortlink: https://sg.run/Albg
     semgrep.dev:
       rule:
+        r_id: 9750
+        rv_id: 111052
         rule_id: KxU4v6
         version_id: K3TvGop
         url: https://semgrep.dev/playground/r/K3TvGop/terraform.lang.security.eks-public-endpoint-enabled.eks-public-endpoint-enabled
@@ -28094,6 +28644,8 @@ rules:
     shortlink: https://sg.run/B4Yb
     semgrep.dev:
       rule:
+        r_id: 9751
+        rv_id: 111053
         rule_id: qNUo2d
         version_id: qkT2BON
         url: https://semgrep.dev/playground/r/qkT2BON/terraform.lang.security.elastic-search-encryption-at-rest.elastic-search-encryption-at-rest
@@ -28202,6 +28754,8 @@ rules:
     shortlink: https://sg.run/oY0N
     semgrep.dev:
       rule:
+        r_id: 13560
+        rv_id: 111054
         rule_id: NbUNDX
         version_id: l4T46ZP
         url: https://semgrep.dev/playground/r/l4T46ZP/terraform.lang.security.iam.no-iam-admin-privileges.no-iam-admin-privileges
@@ -28434,6 +28988,8 @@ rules:
     shortlink: https://sg.run/zxY1
     semgrep.dev:
       rule:
+        r_id: 13561
+        rv_id: 378646
         rule_id: kxUwK2
         version_id: qkTjezP
         url: https://semgrep.dev/playground/r/qkTjezP/terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
@@ -28574,6 +29130,8 @@ rules:
     shortlink: https://sg.run/pYrN
     semgrep.dev:
       rule:
+        r_id: 13562
+        rv_id: 378647
         rule_id: wdUj1k
         version_id: l4T92wK
         url: https://semgrep.dev/playground/r/l4T92wK/terraform.lang.security.iam.no-iam-data-exfiltration.no-iam-data-exfiltration
@@ -28713,6 +29271,8 @@ rules:
     shortlink: https://sg.run/28y5
     semgrep.dev:
       rule:
+        r_id: 13563
+        rv_id: 378648
         rule_id: x8UxLq
         version_id: YDTROjB
         url: https://semgrep.dev/playground/r/YDTROjB/terraform.lang.security.iam.no-iam-priv-esc-funcs.no-iam-priv-esc-funcs
@@ -28841,6 +29401,8 @@ rules:
     shortlink: https://sg.run/XOeA
     semgrep.dev:
       rule:
+        r_id: 13564
+        rv_id: 378649
         rule_id: OrU6jO
         version_id: JdTyeAb
         url: https://semgrep.dev/playground/r/JdTyeAb/terraform.lang.security.iam.no-iam-priv-esc-other-users.no-iam-priv-esc-other-users
@@ -29003,6 +29565,8 @@ rules:
     shortlink: https://sg.run/jwrA
     semgrep.dev:
       rule:
+        r_id: 13565
+        rv_id: 378650
         rule_id: eqUzR3
         version_id: 5PTO30W
         url: https://semgrep.dev/playground/r/5PTO30W/terraform.lang.security.iam.no-iam-priv-esc-roles.no-iam-priv-esc-roles
@@ -30162,6 +30726,8 @@ rules:
     shortlink: https://sg.run/18rD
     semgrep.dev:
       rule:
+        r_id: 13566
+        rv_id: 378651
         rule_id: v8U9r0
         version_id: GxT7J51
         url: https://semgrep.dev/playground/r/GxT7J51/terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
@@ -30267,6 +30833,8 @@ rules:
     shortlink: https://sg.run/9rZ4
     semgrep.dev:
       rule:
+        r_id: 13567
+        rv_id: 378652
         rule_id: d8Uew3
         version_id: RGTgrYj
         url: https://semgrep.dev/playground/r/RGTgrYj/terraform.lang.security.iam.no-iam-star-actions.no-iam-star-actions
@@ -30310,6 +30878,8 @@ rules:
     shortlink: https://sg.run/Oye2
     semgrep.dev:
       rule:
+        r_id: 15831
+        rv_id: 111063
         rule_id: eqUrzK
         version_id: 1QTO7Ed
         url: https://semgrep.dev/playground/r/1QTO7Ed/terraform.lang.security.rds-public-access.rds-public-access
@@ -30345,6 +30915,8 @@ rules:
     shortlink: https://sg.run/DJb2
     semgrep.dev:
       rule:
+        r_id: 9752
+        rv_id: 111064
         rule_id: lBUd4g
         version_id: 9lTd53Z
         url: https://semgrep.dev/playground/r/9lTd53Z/terraform.lang.security.s3-cors-all-origins.all-origins-allowed
@@ -30389,6 +30961,8 @@ rules:
     shortlink: https://sg.run/WgAy
     semgrep.dev:
       rule:
+        r_id: 9753
+        rv_id: 111065
         rule_id: YGUrp5
         version_id: yeTRZqN
         url: https://semgrep.dev/playground/r/yeTRZqN/terraform.lang.security.s3-public-read-bucket.s3-public-read-bucket
@@ -30417,6 +30991,8 @@ rules:
     shortlink: https://sg.run/w13x
     semgrep.dev:
       rule:
+        r_id: 11929
+        rv_id: 111076
         rule_id: qNUbXo
         version_id: ZRTQpDy
         url: https://semgrep.dev/playground/r/ZRTQpDy/typescript.lang.security.audit.cors-regex-wildcard.cors-regex-wildcard
@@ -30465,6 +31041,8 @@ rules:
     shortlink: https://sg.run/ljBL
     semgrep.dev:
       rule:
+        r_id: 9757
+        rv_id: 111077
         rule_id: pKUG17
         version_id: nWTxoQd
         url: https://semgrep.dev/playground/r/nWTxoQd/typescript.nestjs.security.audit.nestjs-header-cors-any.nestjs-header-cors-any
@@ -30517,6 +31095,8 @@ rules:
     shortlink: https://sg.run/YgGW
     semgrep.dev:
       rule:
+        r_id: 9758
+        rv_id: 111078
         rule_id: 2ZU4zx
         version_id: ExTjAeb
         url: https://semgrep.dev/playground/r/ExTjAeb/typescript.nestjs.security.audit.nestjs-header-xss-disabled.nestjs-header-xss-disabled
@@ -30557,6 +31137,8 @@ rules:
     shortlink: https://sg.run/6rJw
     semgrep.dev:
       rule:
+        r_id: 9759
+        rv_id: 111079
         rule_id: X5UZQK
         version_id: 7ZTgnKJ
         url: https://semgrep.dev/playground/r/7ZTgnKJ/typescript.nestjs.security.audit.nestjs-open-redirect.nestjs-open-redirect
@@ -30602,6 +31184,8 @@ rules:
     shortlink: https://sg.run/wx8x
     semgrep.dev:
       rule:
+        r_id: 9773
+        rv_id: 111095
         rule_id: d8Uzqz
         version_id: 0bTLeGA
         url: https://semgrep.dev/playground/r/0bTLeGA/typescript.react.security.audit.react-jwt-decoded-property.react-jwt-decoded-property
@@ -30643,6 +31227,8 @@ rules:
     shortlink: https://sg.run/xYye
     semgrep.dev:
       rule:
+        r_id: 9774
+        rv_id: 111096
         rule_id: ZqUq6g
         version_id: K3TvGgp
         url: https://semgrep.dev/playground/r/K3TvGgp/typescript.react.security.audit.react-jwt-in-localstorage.react-jwt-in-localstorage
@@ -30694,6 +31280,8 @@ rules:
     shortlink: https://sg.run/9qAk
     semgrep.dev:
       rule:
+        r_id: 9767
+        rv_id: 111107
         rule_id: kxURd4
         version_id: WrTW3Gy
         url: https://semgrep.dev/playground/r/WrTW3Gy/typescript.react.security.react-markdown-insecure-html.react-markdown-insecure-html
@@ -30798,6 +31386,8 @@ rules:
     shortlink: https://sg.run/O14b
     semgrep.dev:
       rule:
+        r_id: 10131
+        rv_id: 111109
         rule_id: eqUvZ9
         version_id: K3TvG8r
         url: https://semgrep.dev/playground/r/K3TvG8r/yaml.docker-compose.security.exposing-docker-socket-volume.exposing-docker-socket-volume
@@ -30845,6 +31435,8 @@ rules:
     shortlink: https://sg.run/KWkY
     semgrep.dev:
       rule:
+        r_id: 10055
+        rv_id: 111112
         rule_id: lBUdW3
         version_id: YDTpnk2
         url: https://semgrep.dev/playground/r/YDTpnk2/yaml.docker-compose.security.seccomp-confinement-disabled.seccomp-confinement-disabled
@@ -30893,6 +31485,8 @@ rules:
     shortlink: https://sg.run/qryb
     semgrep.dev:
       rule:
+        r_id: 10056
+        rv_id: 111113
         rule_id: YGUrAG
         version_id: 6xTvQGQ
         url: https://semgrep.dev/playground/r/6xTvQGQ/yaml.docker-compose.security.selinux-separation-disabled.selinux-separation-disabled
@@ -30949,6 +31543,8 @@ rules:
     shortlink: https://sg.run/e4JE
     semgrep.dev:
       rule:
+        r_id: 10132
+        rv_id: 111114
         rule_id: v8U5vN
         version_id: o5Tg9ob
         url: https://semgrep.dev/playground/r/o5Tg9ob/yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service
@@ -30992,6 +31588,8 @@ rules:
     shortlink: https://sg.run/9r7r
     semgrep.dev:
       rule:
+        r_id: 14967
+        rv_id: 111116
         rule_id: X5Udrd
         version_id: pZT1Le2
         url: https://semgrep.dev/playground/r/pZT1Le2/yaml.github-actions.security.curl-eval.curl-eval
@@ -31049,6 +31647,8 @@ rules:
     shortlink: https://sg.run/jkdn
     semgrep.dev:
       rule:
+        r_id: 13365
+        rv_id: 111118
         rule_id: d8Ulkd
         version_id: X0TQ2kn
         url: https://semgrep.dev/playground/r/X0TQ2kn/yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout
@@ -31118,6 +31718,8 @@ rules:
     shortlink: https://sg.run/y6x8
     semgrep.dev:
       rule:
+        r_id: 13024
+        rv_id: 111128
         rule_id: WAUP0z
         version_id: xyTKp0E
         url: https://semgrep.dev/playground/r/xyTKp0E/yaml.kubernetes.security.env.flask-debugging-enabled.flask-debugging-enabled
@@ -31163,6 +31765,8 @@ rules:
     shortlink: https://sg.run/nqGO
     semgrep.dev:
       rule:
+        r_id: 10236
+        rv_id: 111130
         rule_id: nJUYPE
         version_id: e1T03bQ
         url: https://semgrep.dev/playground/r/e1T03bQ/yaml.kubernetes.security.hostipc-pod.hostipc-pod
@@ -31202,6 +31806,8 @@ rules:
     shortlink: https://sg.run/E51A
     semgrep.dev:
       rule:
+        r_id: 10237
+        rv_id: 111131
         rule_id: EwU4NO
         version_id: vdTY8ol
         url: https://semgrep.dev/playground/r/vdTY8ol/yaml.kubernetes.security.hostnetwork-pod.hostnetwork-pod
@@ -31242,6 +31848,8 @@ rules:
     shortlink: https://sg.run/708R
     semgrep.dev:
       rule:
+        r_id: 10238
+        rv_id: 111132
         rule_id: 7KUeo0
         version_id: d6Trv7J
         url: https://semgrep.dev/playground/r/d6Trv7J/yaml.kubernetes.security.hostpid-pod.hostpid-pod
@@ -31312,6 +31920,8 @@ rules:
     shortlink: https://sg.run/D9No
     semgrep.dev:
       rule:
+        r_id: 26096
+        rv_id: 111137
         rule_id: L1UAxy
         version_id: LjTqA93
         url: https://semgrep.dev/playground/r/LjTqA93/yaml.kubernetes.security.run-as-non-root-unsafe-value.run-as-non-root-unsafe-value
@@ -31392,6 +32002,8 @@ rules:
     shortlink: https://sg.run/dgP5
     semgrep.dev:
       rule:
+        r_id: 10134
+        rv_id: 111138
         rule_id: ZqUqeK
         version_id: 8KTQyg1
         url: https://semgrep.dev/playground/r/8KTQyg1/yaml.kubernetes.security.run-as-non-root.run-as-non-root
@@ -31449,6 +32061,8 @@ rules:
     shortlink: https://sg.run/ZePL
     semgrep.dev:
       rule:
+        r_id: 10135
+        rv_id: 111143
         rule_id: nJUYn9
         version_id: PkTJd2A
         url: https://semgrep.dev/playground/r/PkTJd2A/yaml.kubernetes.security.writable-filesystem-container.writable-filesystem-container

--- a/assets/semgrep_rules/generated/nonfree/others.yaml
+++ b/assets/semgrep_rules/generated/nonfree/others.yaml
@@ -28,6 +28,8 @@ rules:
     shortlink: https://sg.run/R5vK
     semgrep.dev:
       rule:
+        r_id: 20149
+        rv_id: 109335
         rule_id: BYUKJE
         version_id: K3TvjOd
         url: https://semgrep.dev/playground/r/K3TvjOd/generic.dockerfile.missing-zypper-no-confirm-switch.missing-zypper-no-confirm-switch
@@ -56,6 +58,8 @@ rules:
     shortlink: https://sg.run/Y8BW
     semgrep.dev:
       rule:
+        r_id: 14114
+        rv_id: 109969
         rule_id: eqUz1k
         version_id: LjTqQeA
         url: https://semgrep.dev/playground/r/LjTqQeA/javascript.react.correctness.hooks.set-state-no-op.calling-set-state-on-current-state
@@ -75,6 +79,8 @@ rules:
     shortlink: https://sg.run/dKe0
     semgrep.dev:
       rule:
+        r_id: 9378
+        rv_id: 110016
         rule_id: 3qUP1E
         version_id: w8T9noW
         url: https://semgrep.dev/playground/r/w8T9noW/ocaml.lang.compatibility.deprecated.deprecated-pervasives
@@ -100,6 +106,8 @@ rules:
     shortlink: https://sg.run/v2gY
     semgrep.dev:
       rule:
+        r_id: 12777
+        rv_id: 110025
         rule_id: DbUKZX
         version_id: 7ZTgo3q
         url: https://semgrep.dev/playground/r/7ZTgo3q/ocaml.lang.portability.crlf-support.broken-input-line
@@ -123,6 +131,8 @@ rules:
     shortlink: https://sg.run/d0YE
     semgrep.dev:
       rule:
+        r_id: 12778
+        rv_id: 110026
         rule_id: WAUPAJ
         version_id: LjTqQgo
         url: https://semgrep.dev/playground/r/LjTqQgo/ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
@@ -146,6 +156,8 @@ rules:
     shortlink: https://sg.run/ZkGw
     semgrep.dev:
       rule:
+        r_id: 12779
+        rv_id: 110027
         rule_id: 0oUJY9
         version_id: 8KTQ9rJ
         url: https://semgrep.dev/playground/r/8KTQ9rJ/ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
@@ -167,6 +179,8 @@ rules:
     shortlink: https://sg.run/Q4ZZ
     semgrep.dev:
       rule:
+        r_id: 12786
+        rv_id: 110028
         rule_id: zdU100
         version_id: gET3x7z
         url: https://semgrep.dev/playground/r/gET3x7z/ocaml.lang.portability.slash-tmp.not-portable-tmp-string
@@ -220,6 +234,8 @@ rules:
     shortlink: https://sg.run/jROJ
     semgrep.dev:
       rule:
+        r_id: 9521
+        rv_id: 110244
         rule_id: kxUko3
         version_id: K3Tvjl9
         url: https://semgrep.dev/playground/r/K3Tvjl9/python.flask.caching.query-string.flask-cache-query-string
@@ -239,6 +255,8 @@ rules:
     shortlink: https://sg.run/weBP
     semgrep.dev:
       rule:
+        r_id: 9573
+        rv_id: 110307
         rule_id: nJUz7A
         version_id: zyTK8RP
         url: https://semgrep.dev/playground/r/zyTK8RP/python.lang.compatibility.python36.python36-compatibility-Popen1
@@ -258,6 +276,8 @@ rules:
     shortlink: https://sg.run/x1Dg
     semgrep.dev:
       rule:
+        r_id: 9574
+        rv_id: 110308
         rule_id: EwU2n3
         version_id: pZT1y9P
         url: https://semgrep.dev/playground/r/pZT1y9P/python.lang.compatibility.python36.python36-compatibility-Popen2
@@ -277,6 +297,8 @@ rules:
     shortlink: https://sg.run/kXn2
     semgrep.dev:
       rule:
+        r_id: 9572
+        rv_id: 110306
         rule_id: ZqU5wR
         version_id: o5Tglxx
         url: https://semgrep.dev/playground/r/o5Tglxx/python.lang.compatibility.python36.python36-compatibility-ssl
@@ -298,6 +320,8 @@ rules:
     shortlink: https://sg.run/vzAb
     semgrep.dev:
       rule:
+        r_id: 9577
+        rv_id: 110311
         rule_id: 8GUjbX
         version_id: jQTgYO6
         url: https://semgrep.dev/playground/r/jQTgYO6/python.lang.compatibility.python37.python37-compatibility-httpconn
@@ -319,6 +343,8 @@ rules:
     shortlink: https://sg.run/dKwd
     semgrep.dev:
       rule:
+        r_id: 9578
+        rv_id: 110312
         rule_id: gxU1qd
         version_id: 1QTOYgK
         url: https://semgrep.dev/playground/r/1QTOYgK/python.lang.compatibility.python37.python37-compatibility-httpsconn
@@ -340,6 +366,8 @@ rules:
     shortlink: https://sg.run/OPDn
     semgrep.dev:
       rule:
+        r_id: 9575
+        rv_id: 110309
         rule_id: 7KUQOl
         version_id: 2KTzrWz
         url: https://semgrep.dev/playground/r/2KTzrWz/python.lang.compatibility.python37.python37-compatibility-importlib
@@ -361,6 +389,8 @@ rules:
     shortlink: https://sg.run/eL3y
     semgrep.dev:
       rule:
+        r_id: 9576
+        rv_id: 110310
         rule_id: L1Uy0n
         version_id: X0TQxBO
         url: https://semgrep.dev/playground/r/X0TQxBO/python.lang.compatibility.python37.python37-compatibility-importlib2
@@ -382,6 +412,8 @@ rules:
     shortlink: https://sg.run/Zv2o
     semgrep.dev:
       rule:
+        r_id: 9579
+        rv_id: 110313
         rule_id: QrUzJ9
         version_id: 9lTdWDO
         url: https://semgrep.dev/playground/r/9lTdWDO/python.lang.compatibility.python37.python37-compatibility-importlib3
@@ -402,6 +434,8 @@ rules:
     shortlink: https://sg.run/LwRo
     semgrep.dev:
       rule:
+        r_id: 9583
+        rv_id: 110317
         rule_id: JDUyqR
         version_id: NdT3dnB
         url: https://semgrep.dev/playground/r/NdT3dnB/python.lang.compatibility.python37.python37-compatibility-ipv4network1
@@ -422,6 +456,8 @@ rules:
     shortlink: https://sg.run/8y3E
     semgrep.dev:
       rule:
+        r_id: 9584
+        rv_id: 110318
         rule_id: 5rUO61
         version_id: kbTdx4O
         url: https://semgrep.dev/playground/r/kbTdx4O/python.lang.compatibility.python37.python37-compatibility-ipv4network2
@@ -442,6 +478,8 @@ rules:
     shortlink: https://sg.run/EkLe
     semgrep.dev:
       rule:
+        r_id: 9581
+        rv_id: 110315
         rule_id: 4bUko0
         version_id: rxTyLPw
         url: https://semgrep.dev/playground/r/rxTyLPw/python.lang.compatibility.python37.python37-compatibility-ipv6network1
@@ -462,6 +500,8 @@ rules:
     shortlink: https://sg.run/7orW
     semgrep.dev:
       rule:
+        r_id: 9582
+        rv_id: 110316
         rule_id: PeUZYr
         version_id: bZTb10z
         url: https://semgrep.dev/playground/r/bZTb10z/python.lang.compatibility.python37.python37-compatibility-ipv6network2
@@ -483,6 +523,8 @@ rules:
     shortlink: https://sg.run/gLeZ
     semgrep.dev:
       rule:
+        r_id: 9585
+        rv_id: 110319
         rule_id: GdU72R
         version_id: w8T9nQK
         url: https://semgrep.dev/playground/r/w8T9nQK/python.lang.compatibility.python37.python37-compatibility-locale1
@@ -503,6 +545,8 @@ rules:
     shortlink: https://sg.run/Q50Q
     semgrep.dev:
       rule:
+        r_id: 9586
+        rv_id: 110320
         rule_id: ReUgbz
         version_id: xyTKZJZ
         url: https://semgrep.dev/playground/r/xyTKZJZ/python.lang.compatibility.python37.python37-compatibility-math1
@@ -523,6 +567,8 @@ rules:
     shortlink: https://sg.run/3xjp
     semgrep.dev:
       rule:
+        r_id: 9587
+        rv_id: 110321
         rule_id: AbUzRA
         version_id: O9TNOod
         url: https://semgrep.dev/playground/r/O9TNOod/python.lang.compatibility.python37.python37-compatibility-multiprocess1
@@ -543,6 +589,8 @@ rules:
     shortlink: https://sg.run/4x1z
     semgrep.dev:
       rule:
+        r_id: 9588
+        rv_id: 110322
         rule_id: BYUNE9
         version_id: e1T017y
         url: https://semgrep.dev/playground/r/e1T017y/python.lang.compatibility.python37.python37-compatibility-multiprocess2
@@ -563,6 +611,8 @@ rules:
     shortlink: https://sg.run/PJWW
     semgrep.dev:
       rule:
+        r_id: 9589
+        rv_id: 110323
         rule_id: DbUpQQ
         version_id: vdTYNWX
         url: https://semgrep.dev/playground/r/vdTYNWX/python.lang.compatibility.python37.python37-compatibility-os1
@@ -587,6 +637,8 @@ rules:
     shortlink: https://sg.run/5Q9X
     semgrep.dev:
       rule:
+        r_id: 9591
+        rv_id: 110324
         rule_id: 0oU5vW
         version_id: d6TrA98
         url: https://semgrep.dev/playground/r/d6TrA98/python.lang.compatibility.python37.python37-compatibility-os2-ok2
@@ -608,6 +660,8 @@ rules:
     shortlink: https://sg.run/GeA2
     semgrep.dev:
       rule:
+        r_id: 9592
+        rv_id: 110325
         rule_id: KxUby2
         version_id: ZRTQNjx
         url: https://semgrep.dev/playground/r/ZRTQNjx/python.lang.compatibility.python37.python37-compatibility-pdb
@@ -629,6 +683,8 @@ rules:
     shortlink: https://sg.run/ndL2
     semgrep.dev:
       rule:
+        r_id: 9580
+        rv_id: 110314
         rule_id: 3qUPdy
         version_id: yeTR2wy
         url: https://semgrep.dev/playground/r/yeTR2wy/python.lang.compatibility.python37.python37-compatibility-textiowrapper
@@ -651,6 +707,8 @@ rules:
     shortlink: https://sg.run/PprN
     semgrep.dev:
       rule:
+        r_id: 9701
+        rv_id: 110496
         rule_id: AbUWjy
         version_id: GxTv8x6
         url: https://semgrep.dev/playground/r/GxTv8x6/python.sqlalchemy.performance.performance-improvements.batch-import
@@ -671,6 +729,8 @@ rules:
     shortlink: https://sg.run/4y8g
     semgrep.dev:
       rule:
+        r_id: 9700
+        rv_id: 110495
         rule_id: ReUPOw
         version_id: 5PTdeP9
         url: https://semgrep.dev/playground/r/5PTdeP9/python.sqlalchemy.performance.performance-improvements.len-all-count
@@ -702,6 +762,8 @@ rules:
     shortlink: https://sg.run/eoAb
     semgrep.dev:
       rule:
+        r_id: 15132
+        rv_id: 110928
         rule_id: 8GUzld
         version_id: e1T0338
         url: https://semgrep.dev/playground/r/e1T0338/terraform.azure.security.keyvault.keyvault-content-type-for-secret.keyvault-content-type-for-secret
@@ -746,6 +808,8 @@ rules:
     shortlink: https://sg.run/okq7
     semgrep.dev:
       rule:
+        r_id: 9760
+        rv_id: 111080
         rule_id: j2Uqg5
         version_id: LjTqARd
         url: https://semgrep.dev/playground/r/LjTqARd/typescript.react.best-practice.define-styled-components-on-module-level.define-styled-components-on-module-level
@@ -775,6 +839,8 @@ rules:
     shortlink: https://sg.run/zkdz
     semgrep.dev:
       rule:
+        r_id: 9761
+        rv_id: 111081
         rule_id: 10UZOv
         version_id: 8KTQy3O
         url: https://semgrep.dev/playground/r/8KTQy3O/typescript.react.best-practice.react-find-dom.react-find-dom
@@ -806,6 +872,8 @@ rules:
     shortlink: https://sg.run/plK3
     semgrep.dev:
       rule:
+        r_id: 9762
+        rv_id: 111082
         rule_id: 9AUOdB
         version_id: gET3Oro
         url: https://semgrep.dev/playground/r/gET3Oro/typescript.react.best-practice.react-legacy-component.react-legacy-component
@@ -869,6 +937,8 @@ rules:
     shortlink: https://sg.run/2bZz
     semgrep.dev:
       rule:
+        r_id: 9763
+        rv_id: 111083
         rule_id: yyUvRJ
         version_id: QkTWwEY
         url: https://semgrep.dev/playground/r/QkTWwEY/typescript.react.best-practice.react-props-in-state.react-props-in-state
@@ -901,6 +971,8 @@ rules:
     shortlink: https://sg.run/XL5l
     semgrep.dev:
       rule:
+        r_id: 9764
+        rv_id: 111084
         rule_id: r6Uky5
         version_id: 3ZTkr2Z
         url: https://semgrep.dev/playground/r/3ZTkr2Z/typescript.react.best-practice.react-props-spreading.react-props-spreading
@@ -966,6 +1038,8 @@ rules:
     shortlink: https://sg.run/Y4oX
     semgrep.dev:
       rule:
+        r_id: 20158
+        rv_id: 111085
         rule_id: oqUKJr
         version_id: 44TR6bp
         url: https://semgrep.dev/playground/r/44TR6bp/typescript.react.portability.i18next.i18next-key-format.i18next-key-format
@@ -1000,6 +1074,8 @@ rules:
     shortlink: https://sg.run/6kv6
     semgrep.dev:
       rule:
+        r_id: 20159
+        rv_id: 111086
         rule_id: zdUGrY
         version_id: PkTJde4
         url: https://semgrep.dev/playground/r/PkTJde4/typescript.react.portability.i18next.jsx-label-not-i18n.jsx-label-not-i18n
@@ -1033,6 +1109,8 @@ rules:
     shortlink: https://sg.run/DeKW
     semgrep.dev:
       rule:
+        r_id: 20052
+        rv_id: 111087
         rule_id: KxUwo1
         version_id: JdTNvnX
         url: https://semgrep.dev/playground/r/JdTNvnX/typescript.react.portability.i18next.jsx-not-internationalized.jsx-not-internationalized
@@ -1061,6 +1139,8 @@ rules:
     shortlink: https://sg.run/WDvz
     semgrep.dev:
       rule:
+        r_id: 20053
+        rv_id: 111088
         rule_id: qNUpO8
         version_id: 5PTde7b
         url: https://semgrep.dev/playground/r/5PTde7b/typescript.react.portability.i18next.mui-snackbar-message.mui-snackbar-message
@@ -1093,6 +1173,8 @@ rules:
     shortlink: https://sg.run/oR37
     semgrep.dev:
       rule:
+        r_id: 24016
+        rv_id: 111089
         rule_id: nJUPJL
         version_id: GxTv8ld
         url: https://semgrep.dev/playground/r/GxTv8ld/typescript.react.portability.i18next.useselect-label-not-i18n.useselect-label-not-i18n

--- a/assets/semgrep_rules/generated/nonfree/security_noaudit_novuln.yaml
+++ b/assets/semgrep_rules/generated/nonfree/security_noaudit_novuln.yaml
@@ -35,6 +35,8 @@ rules:
     shortlink: https://sg.run/oxEN
     semgrep.dev:
       rule:
+        r_id: 9116
+        rv_id: 109599
         rule_id: NbUk4X
         version_id: o5Tglp0
         url: https://semgrep.dev/playground/r/o5Tglp0/go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
@@ -111,6 +113,8 @@ rules:
     shortlink: https://sg.run/Eb5w
     semgrep.dev:
       rule:
+        r_id: 60237
+        rv_id: 109886
         rule_id: QrU96W
         version_id: l4T4vn1
         url: https://semgrep.dev/playground/r/l4T4vn1/javascript.intercom.security.audit.intercom-settings-user-identifier-without-user-hash.intercom-settings-user-identifier-without-user-hash
@@ -153,6 +157,8 @@ rules:
     shortlink: https://sg.run/N0Bp
     semgrep.dev:
       rule:
+        r_id: 73471
+        rv_id: 252099
         rule_id: PeUyYG
         version_id: RGTevKN
         url: https://semgrep.dev/playground/r/RGTevKN/python.django.security.django-no-csrf-token.django-no-csrf-token
@@ -195,6 +201,8 @@ rules:
     shortlink: https://sg.run/kJn7
     semgrep.dev:
       rule:
+        r_id: 73472
+        rv_id: 113534
         rule_id: JDUjqx
         version_id: qkT2RER
         url: https://semgrep.dev/playground/r/qkT2RER/python.django.security.django-using-request-post-after-is-valid.django-using-request-post-after-is-valid
@@ -247,6 +255,8 @@ rules:
     shortlink: https://sg.run/7EjQ
     semgrep.dev:
       rule:
+        r_id: 70982
+        rv_id: 110784
         rule_id: EwUxO1
         version_id: JdTNvlx
         url: https://semgrep.dev/playground/r/JdTNvlx/terraform.aws.security.aws-provisioner-exec.aws-provisioner-exec

--- a/assets/semgrep_rules/generated/nonfree/vulns.yaml
+++ b/assets/semgrep_rules/generated/nonfree/vulns.yaml
@@ -33,6 +33,8 @@ rules:
     shortlink: https://sg.run/0yqJ
     semgrep.dev:
       rule:
+        r_id: 14554
+        rv_id: 108994
         rule_id: KxU7Rq
         version_id: zyTK8D1
         url: https://semgrep.dev/playground/r/zyTK8D1/bash.curl.security.curl-eval.curl-eval
@@ -90,6 +92,8 @@ rules:
     shortlink: https://sg.run/eLl0
     semgrep.dev:
       rule:
+        r_id: 8832
+        rv_id: 257627
         rule_id: JDUyw8
         version_id: ZRT7Q7O
         url: https://semgrep.dev/playground/r/ZRT7Q7O/c.lang.security.double-free.double-free
@@ -135,6 +139,8 @@ rules:
     shortlink: https://sg.run/eWyZ
     semgrep.dev:
       rule:
+        r_id: 57376
+        rv_id: 257628
         rule_id: WAU9Dz
         version_id: nWT8x8G
         url: https://semgrep.dev/playground/r/nWT8x8G/c.lang.security.function-use-after-free.function-use-after-free
@@ -167,6 +173,8 @@ rules:
     shortlink: https://sg.run/ZvJx
     semgrep.dev:
       rule:
+        r_id: 8835
+        rv_id: 257630
         rule_id: ReUgWx
         version_id: 7ZT1g1b
         url: https://semgrep.dev/playground/r/7ZT1g1b/c.lang.security.insecure-use-printf-fn.insecure-use-printf-fn
@@ -228,6 +236,8 @@ rules:
     shortlink: https://sg.run/gL6e
     semgrep.dev:
       rule:
+        r_id: 8841
+        rv_id: 257631
         rule_id: KxUb9l
         version_id: LjT2q2X
         url: https://semgrep.dev/playground/r/LjT2q2X/c.lang.security.use-after-free.use-after-free
@@ -273,6 +283,8 @@ rules:
     shortlink: https://sg.run/v7An
     semgrep.dev:
       rule:
+        r_id: 71533
+        rv_id: 109018
         rule_id: bwU3Gj
         version_id: gET3xOd
         url: https://semgrep.dev/playground/r/gET3xOd/clojure.lang.security.documentbuilderfactory-xxe.documentbuilderfactory-xxe
@@ -342,6 +354,8 @@ rules:
     shortlink: https://sg.run/BgPx
     semgrep.dev:
       rule:
+        r_id: 52195
+        rv_id: 258072
         rule_id: nJU1ep
         version_id: 2KTQz3r
         url: https://semgrep.dev/playground/r/2KTQz3r/clojure.lang.security.use-of-md5.use-of-md5
@@ -387,6 +401,8 @@ rules:
     shortlink: https://sg.run/dvwX
     semgrep.dev:
       rule:
+        r_id: 71534
+        rv_id: 111247
         rule_id: NbUy12
         version_id: GxTv8Wq
         url: https://semgrep.dev/playground/r/GxTv8Wq/clojure.lang.security.use-of-sha1.use-of-sha1
@@ -428,6 +444,8 @@ rules:
     shortlink: https://sg.run/GJ9z
     semgrep.dev:
       rule:
+        r_id: 27692
+        rv_id: 109173
         rule_id: 2ZUv3R
         version_id: BjTXrJe
         url: https://semgrep.dev/playground/r/BjTXrJe/csharp.dotnet.security.audit.ldap-injection.ldap-injection
@@ -481,6 +499,8 @@ rules:
     shortlink: https://sg.run/7B3e
     semgrep.dev:
       rule:
+        r_id: 26838
+        rv_id: 109174
         rule_id: x8Up5B
         version_id: DkT6nX2
         url: https://semgrep.dev/playground/r/DkT6nX2/csharp.dotnet.security.audit.mass-assignment.mass-assignment
@@ -547,6 +567,8 @@ rules:
     shortlink: https://sg.run/Z8GA
     semgrep.dev:
       rule:
+        r_id: 26335
+        rv_id: 113528
         rule_id: eqU32Y
         version_id: A8T9gKe
         url: https://semgrep.dev/playground/r/A8T9gKe/csharp.dotnet.security.audit.missing-or-broken-authorization.missing-or-broken-authorization
@@ -611,6 +633,8 @@ rules:
     shortlink: https://sg.run/n0y1
     semgrep.dev:
       rule:
+        r_id: 26336
+        rv_id: 109177
         rule_id: v8U8Ab
         version_id: K3Tvj8G
         url: https://semgrep.dev/playground/r/K3Tvj8G/csharp.dotnet.security.audit.open-directory-listing.open-directory-listing
@@ -653,6 +677,8 @@ rules:
     shortlink: https://sg.run/4KP7
     semgrep.dev:
       rule:
+        r_id: 27400
+        rv_id: 109179
         rule_id: x8Uj2k
         version_id: l4T4voZ
         url: https://semgrep.dev/playground/r/l4T4voZ/csharp.dotnet.security.audit.xpath-injection.xpath-injection
@@ -705,6 +731,8 @@ rules:
     shortlink: https://sg.run/oyj0
     semgrep.dev:
       rule:
+        r_id: 18216
+        rv_id: 109183
         rule_id: EwUr68
         version_id: GxTv6YJ
         url: https://semgrep.dev/playground/r/GxTv6YJ/csharp.dotnet.security.razor-template-injection.razor-template-injection
@@ -754,6 +782,8 @@ rules:
     shortlink: https://sg.run/k8Qo
     semgrep.dev:
       rule:
+        r_id: 36772
+        rv_id: 109184
         rule_id: WAUJr0
         version_id: RGTDknw
         url: https://semgrep.dev/playground/r/RGTDknw/csharp.dotnet.security.use_deprecated_cipher_algorithm.use_deprecated_cipher_algorithm
@@ -796,6 +826,8 @@ rules:
     shortlink: https://sg.run/wj9n
     semgrep.dev:
       rule:
+        r_id: 36773
+        rv_id: 109185
         rule_id: 0oUqWP
         version_id: A8T950y
         url: https://semgrep.dev/playground/r/A8T950y/csharp.dotnet.security.use_ecb_mode.use_ecb_mode
@@ -846,6 +878,8 @@ rules:
     shortlink: https://sg.run/xjrA
     semgrep.dev:
       rule:
+        r_id: 36774
+        rv_id: 109186
         rule_id: KxU3Nq
         version_id: BjTXrJo
         url: https://semgrep.dev/playground/r/BjTXrJo/csharp.dotnet.security.use_weak_rng_for_keygeneration.use_weak_rng_for_keygeneration
@@ -903,6 +937,8 @@ rules:
     shortlink: https://sg.run/GoJ1
     semgrep.dev:
       rule:
+        r_id: 35492
+        rv_id: 109187
         rule_id: QrU2G5
         version_id: DkT6nXB
         url: https://semgrep.dev/playground/r/DkT6nXB/csharp.dotnet.security.use_weak_rsa_encryption_padding.use_weak_rsa_encryption_padding
@@ -947,6 +983,8 @@ rules:
     shortlink: https://sg.run/pqzN
     semgrep.dev:
       rule:
+        r_id: 26718
+        rv_id: 109196
         rule_id: KxUGLw
         version_id: zyTK8NE
         url: https://semgrep.dev/playground/r/zyTK8NE/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token
@@ -981,6 +1019,8 @@ rules:
     shortlink: https://sg.run/XZ6B
     semgrep.dev:
       rule:
+        r_id: 18220
+        rv_id: 109194
         rule_id: gxUy01
         version_id: 6xTvJGn
         url: https://semgrep.dev/playground/r/6xTvJGn/csharp.lang.security.cryptography.x509-subject-name-validation.X509-subject-name-validation
@@ -1109,6 +1149,8 @@ rules:
     shortlink: https://sg.run/1RvG
     semgrep.dev:
       rule:
+        r_id: 18222
+        rv_id: 109197
         rule_id: 3qU3bE
         version_id: pZT1ye7
         url: https://semgrep.dev/playground/r/pZT1ye7/csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
@@ -1139,6 +1181,8 @@ rules:
     shortlink: https://sg.run/9LJr
     semgrep.dev:
       rule:
+        r_id: 18223
+        rv_id: 109198
         rule_id: 4bUQ81
         version_id: 2KTzr5x
         url: https://semgrep.dev/playground/r/2KTzr5x/csharp.lang.security.http.http-listener-wildcard-bindings.http-listener-wildcard-bindings
@@ -1184,6 +1228,8 @@ rules:
     shortlink: https://sg.run/ZeXW
     semgrep.dev:
       rule:
+        r_id: 11135
+        rv_id: 109200
         rule_id: bwUOjK
         version_id: jQTgYD5
         url: https://semgrep.dev/playground/r/jQTgYD5/csharp.lang.security.insecure-deserialization.binary-formatter.insecure-binaryformatter-deserialization
@@ -1228,6 +1274,8 @@ rules:
     shortlink: https://sg.run/E5e5
     semgrep.dev:
       rule:
+        r_id: 11137
+        rv_id: 109203
         rule_id: kxURnR
         version_id: yeTR2GJ
         url: https://semgrep.dev/playground/r/yeTR2GJ/csharp.lang.security.insecure-deserialization.fs-pickler.insecure-fspickler-deserialization
@@ -1270,6 +1318,8 @@ rules:
     shortlink: https://sg.run/70pG
     semgrep.dev:
       rule:
+        r_id: 11138
+        rv_id: 109206
         rule_id: wdU87G
         version_id: NdT3dGO
         url: https://semgrep.dev/playground/r/NdT3dGO/csharp.lang.security.insecure-deserialization.los-formatter.insecure-losformatter-deserialization
@@ -1314,6 +1364,8 @@ rules:
     shortlink: https://sg.run/L0AX
     semgrep.dev:
       rule:
+        r_id: 11139
+        rv_id: 109207
         rule_id: x8UW7x
         version_id: kbTdx34
         url: https://semgrep.dev/playground/r/kbTdx34/csharp.lang.security.insecure-deserialization.net-data-contract.insecure-netdatacontract-deserialization
@@ -1358,6 +1410,8 @@ rules:
     shortlink: https://sg.run/gJnR
     semgrep.dev:
       rule:
+        r_id: 11141
+        rv_id: 109209
         rule_id: eqUvND
         version_id: xyTKZwK
         url: https://semgrep.dev/playground/r/xyTKZwK/csharp.lang.security.insecure-deserialization.soap-formatter.insecure-soapformatter-deserialization
@@ -1420,6 +1474,8 @@ rules:
     shortlink: https://sg.run/k98P
     semgrep.dev:
       rule:
+        r_id: 18228
+        rv_id: 109221
         rule_id: ReUK9k
         version_id: QkTW02w
         url: https://semgrep.dev/playground/r/QkTW02w/csharp.lang.security.xxe.xmldocument-unsafe-parser-override.xmldocument-unsafe-parser-override
@@ -1473,6 +1529,8 @@ rules:
     shortlink: https://sg.run/wXjA
     semgrep.dev:
       rule:
+        r_id: 18229
+        rv_id: 109222
         rule_id: AbU3pX
         version_id: 3ZTkQb4
         url: https://semgrep.dev/playground/r/3ZTkQb4/csharp.lang.security.xxe.xmlreadersettings-unsafe-parser-override.xmlreadersettings-unsafe-parser-override
@@ -1528,6 +1586,8 @@ rules:
     shortlink: https://sg.run/xXjL
     semgrep.dev:
       rule:
+        r_id: 18230
+        rv_id: 109223
         rule_id: BYUevk
         version_id: 44TRl89
         url: https://semgrep.dev/playground/r/44TRl89/csharp.lang.security.xxe.xmltextreader-unsafe-defaults.xmltextreader-unsafe-defaults
@@ -1567,6 +1627,8 @@ rules:
     shortlink: https://sg.run/rQZe
     semgrep.dev:
       rule:
+        r_id: 44669
+        rv_id: 109354
         rule_id: kxUQj2
         version_id: xyTKZ9j
         url: https://semgrep.dev/playground/r/xyTKZ9j/generic.secrets.gitleaks.adafruit-api-key.adafruit-api-key
@@ -1608,6 +1670,8 @@ rules:
     shortlink: https://sg.run/bYoW
     semgrep.dev:
       rule:
+        r_id: 44670
+        rv_id: 109355
         rule_id: wdUqzk
         version_id: O9TNO48
         url: https://semgrep.dev/playground/r/O9TNO48/generic.secrets.gitleaks.adobe-client-id.adobe-client-id
@@ -1649,6 +1713,8 @@ rules:
     shortlink: https://sg.run/Nzxy
     semgrep.dev:
       rule:
+        r_id: 44671
+        rv_id: 109356
         rule_id: x8UlAq
         version_id: e1T01E4
         url: https://semgrep.dev/playground/r/e1T01E4/generic.secrets.gitleaks.adobe-client-secret.adobe-client-secret
@@ -1690,6 +1756,8 @@ rules:
     shortlink: https://sg.run/k3WP
     semgrep.dev:
       rule:
+        r_id: 44672
+        rv_id: 109357
         rule_id: OrUAnO
         version_id: vdTYNDo
         url: https://semgrep.dev/playground/r/vdTYNDo/generic.secrets.gitleaks.age-secret-key.age-secret-key
@@ -1731,6 +1799,8 @@ rules:
     shortlink: https://sg.run/wQpA
     semgrep.dev:
       rule:
+        r_id: 44673
+        rv_id: 109358
         rule_id: eqUYL3
         version_id: d6TrAnL
         url: https://semgrep.dev/playground/r/d6TrAnL/generic.secrets.gitleaks.airtable-api-key.airtable-api-key
@@ -1772,6 +1842,8 @@ rules:
     shortlink: https://sg.run/xQxL
     semgrep.dev:
       rule:
+        r_id: 44674
+        rv_id: 109359
         rule_id: v8UKp0
         version_id: ZRTQNBX
         url: https://semgrep.dev/playground/r/ZRTQNBX/generic.secrets.gitleaks.algolia-api-key.algolia-api-key
@@ -1813,6 +1885,8 @@ rules:
     shortlink: https://sg.run/OpkL
     semgrep.dev:
       rule:
+        r_id: 44675
+        rv_id: 109360
         rule_id: d8UOQ3
         version_id: nWTxPdw
         url: https://semgrep.dev/playground/r/nWTxPdw/generic.secrets.gitleaks.alibaba-access-key-id.alibaba-access-key-id
@@ -1854,6 +1928,8 @@ rules:
     shortlink: https://sg.run/ezr8
     semgrep.dev:
       rule:
+        r_id: 44676
+        rv_id: 109361
         rule_id: ZqUk7D
         version_id: ExTjNdd
         url: https://semgrep.dev/playground/r/ExTjNdd/generic.secrets.gitleaks.alibaba-secret-key.alibaba-secret-key
@@ -1895,6 +1971,8 @@ rules:
     shortlink: https://sg.run/vQZY
     semgrep.dev:
       rule:
+        r_id: 44677
+        rv_id: 109362
         rule_id: nJU58J
         version_id: 7ZTgo5w
         url: https://semgrep.dev/playground/r/7ZTgo5w/generic.secrets.gitleaks.asana-client-id.asana-client-id
@@ -1936,6 +2014,8 @@ rules:
     shortlink: https://sg.run/do7E
     semgrep.dev:
       rule:
+        r_id: 44678
+        rv_id: 109363
         rule_id: EwUyp6
         version_id: LjTqQxL
         url: https://semgrep.dev/playground/r/LjTqQxL/generic.secrets.gitleaks.asana-client-secret.asana-client-secret
@@ -1977,6 +2057,8 @@ rules:
     shortlink: https://sg.run/ZAWw
     semgrep.dev:
       rule:
+        r_id: 44679
+        rv_id: 109364
         rule_id: 7KUJ1X
         version_id: 8KTQ9Wo
         url: https://semgrep.dev/playground/r/8KTQ9Wo/generic.secrets.gitleaks.atlassian-api-token.atlassian-api-token
@@ -2018,6 +2100,8 @@ rules:
     shortlink: https://sg.run/bpnE
     semgrep.dev:
       rule:
+        r_id: 66770
+        rv_id: 109365
         rule_id: 0oUbQZ
         version_id: gET3xLG
         url: https://semgrep.dev/playground/r/gET3xLG/generic.secrets.gitleaks.authress-service-client-access-key.authress-service-client-access-key
@@ -2059,6 +2143,8 @@ rules:
     shortlink: https://sg.run/EDrN
     semgrep.dev:
       rule:
+        r_id: 44681
+        rv_id: 109367
         rule_id: 8GUPqW
         version_id: 3ZTkQ7G
         url: https://semgrep.dev/playground/r/3ZTkQ7G/generic.secrets.gitleaks.beamer-api-token.beamer-api-token
@@ -2100,6 +2186,8 @@ rules:
     shortlink: https://sg.run/7zg2
     semgrep.dev:
       rule:
+        r_id: 44682
+        rv_id: 109368
         rule_id: gxUvAp
         version_id: 44TRlxB
         url: https://semgrep.dev/playground/r/44TRlxB/generic.secrets.gitleaks.bitbucket-client-id.bitbucket-client-id
@@ -2141,6 +2229,8 @@ rules:
     shortlink: https://sg.run/L6r6
     semgrep.dev:
       rule:
+        r_id: 44683
+        rv_id: 109369
         rule_id: QrUR7R
         version_id: PkTJ1Ev
         url: https://semgrep.dev/playground/r/PkTJ1Ev/generic.secrets.gitleaks.bitbucket-client-secret.bitbucket-client-secret
@@ -2182,6 +2272,8 @@ rules:
     shortlink: https://sg.run/8pxN
     semgrep.dev:
       rule:
+        r_id: 44684
+        rv_id: 109370
         rule_id: 3qU5pK
         version_id: JdTNp20
         url: https://semgrep.dev/playground/r/JdTNp20/generic.secrets.gitleaks.bittrex-access-key.bittrex-access-key
@@ -2223,6 +2315,8 @@ rules:
     shortlink: https://sg.run/g2p0
     semgrep.dev:
       rule:
+        r_id: 44685
+        rv_id: 109371
         rule_id: 4bUKAW
         version_id: 5PTdABZ
         url: https://semgrep.dev/playground/r/5PTdABZ/generic.secrets.gitleaks.bittrex-secret-key.bittrex-secret-key
@@ -2264,12 +2358,143 @@ rules:
     shortlink: https://sg.run/QXwZ
     semgrep.dev:
       rule:
+        r_id: 44686
+        rv_id: 109372
         rule_id: PeU7WX
         version_id: GxTv64p
         url: https://semgrep.dev/playground/r/GxTv64p/generic.secrets.gitleaks.clojars-api-token.clojars-api-token
         origin: community
   patterns:
   - pattern-regex: "(?i)(CLOJARS_)[a-z0-9]{60}"
+- id: generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
+  message: A gitleaks cloudflare-api-key was detected which attempts to identify hard-coded
+    credentials. It is not recommended to store credentials in source-code, as this
+    risks secrets being leaked and used by either an internal or external malicious
+    adversary. It is recommended to use environment variables to securely provide
+    credentials or retrieve credentials from a secure vault or HSM (Hardware Security
+    Module).
+  languages:
+  - regex
+  severity: INFO
+  metadata:
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    cwe2021-top25: true
+    cwe2022-top25: true
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+    source-rule-url: https://github.com/zricethezav/gitleaks/tree/master/cmd/generate/config/rules
+    subcategory:
+    - vuln
+    technology:
+    - gitleaks
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Hard-coded Secrets
+    source: https://semgrep.dev/r/generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
+    shortlink: https://sg.run/WA9P4
+    semgrep.dev:
+      rule:
+        r_id: 132809
+        rv_id: 750521
+        rule_id: DbU6oZX
+        version_id: RGTqx7R
+        url: https://semgrep.dev/playground/r/RGTqx7R/generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
+        origin: community
+  patterns:
+  - pattern-regex: (?i)(?:cloudflare)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
+- id: generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
+  message: A gitleaks cloudflare-global-api-key was detected which attempts to identify
+    hard-coded credentials. It is not recommended to store credentials in source-code,
+    as this risks secrets being leaked and used by either an internal or external
+    malicious adversary. It is recommended to use environment variables to securely
+    provide credentials or retrieve credentials from a secure vault or HSM (Hardware
+    Security Module).
+  languages:
+  - regex
+  severity: INFO
+  metadata:
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    cwe2021-top25: true
+    cwe2022-top25: true
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+    source-rule-url: https://github.com/zricethezav/gitleaks/tree/master/cmd/generate/config/rules
+    subcategory:
+    - vuln
+    technology:
+    - gitleaks
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Hard-coded Secrets
+    source: https://semgrep.dev/r/generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
+    shortlink: https://sg.run/0oxwv
+    semgrep.dev:
+      rule:
+        r_id: 132810
+        rv_id: 750522
+        rule_id: WAUW5AJ
+        version_id: A8Tel8g
+        url: https://semgrep.dev/playground/r/A8Tel8g/generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
+        origin: community
+  patterns:
+  - pattern-regex: (?i)(?:cloudflare)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)
+- id: generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
+  message: A gitleaks cloudflare-origin-ca-key was detected which attempts to identify
+    hard-coded credentials. It is not recommended to store credentials in source-code,
+    as this risks secrets being leaked and used by either an internal or external
+    malicious adversary. It is recommended to use environment variables to securely
+    provide credentials or retrieve credentials from a secure vault or HSM (Hardware
+    Security Module).
+  languages:
+  - regex
+  severity: INFO
+  metadata:
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    cwe2021-top25: true
+    cwe2022-top25: true
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+    source-rule-url: https://github.com/zricethezav/gitleaks/tree/master/cmd/generate/config/rules
+    subcategory:
+    - vuln
+    technology:
+    - gitleaks
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Hard-coded Secrets
+    source: https://semgrep.dev/r/generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
+    shortlink: https://sg.run/KxKZ7
+    semgrep.dev:
+      rule:
+        r_id: 132811
+        rv_id: 750523
+        rule_id: 0oULkY9
+        version_id: BjTzL5b
+        url: https://semgrep.dev/playground/r/BjTzL5b/generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
+        origin: community
+  patterns:
+  - pattern-regex: \b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['|\"|\n|\r|\s|\x60|;]|$)
 - id: generic.secrets.gitleaks.codecov-access-token.codecov-access-token
   message: A gitleaks codecov-access-token was detected which attempts to identify
     hard-coded credentials. It is not recommended to store credentials in source-code,
@@ -2305,6 +2530,8 @@ rules:
     shortlink: https://sg.run/3leK
     semgrep.dev:
       rule:
+        r_id: 44687
+        rv_id: 109373
         rule_id: JDUO3B
         version_id: RGTDkB4
         url: https://semgrep.dev/playground/r/RGTDkB4/generic.secrets.gitleaks.codecov-access-token.codecov-access-token
@@ -2346,6 +2573,8 @@ rules:
     shortlink: https://sg.run/4YB5
     semgrep.dev:
       rule:
+        r_id: 44688
+        rv_id: 109374
         rule_id: 5rUKPQ
         version_id: A8T95y7
         url: https://semgrep.dev/playground/r/A8T95y7/generic.secrets.gitleaks.coinbase-access-token.coinbase-access-token
@@ -2387,6 +2616,8 @@ rules:
     shortlink: https://sg.run/P29z
     semgrep.dev:
       rule:
+        r_id: 44689
+        rv_id: 109375
         rule_id: GdUbxy
         version_id: BjTXrQL
         url: https://semgrep.dev/playground/r/BjTXrQL/generic.secrets.gitleaks.confluent-access-token.confluent-access-token
@@ -2428,6 +2659,8 @@ rules:
     shortlink: https://sg.run/Jlqy
     semgrep.dev:
       rule:
+        r_id: 44690
+        rv_id: 109376
         rule_id: ReUNQJ
         version_id: DkT6n3b
         url: https://semgrep.dev/playground/r/DkT6n3b/generic.secrets.gitleaks.confluent-secret-key.confluent-secret-key
@@ -2469,6 +2702,8 @@ rules:
     shortlink: https://sg.run/56W0
     semgrep.dev:
       rule:
+        r_id: 44691
+        rv_id: 109377
         rule_id: AbUvrB
         version_id: WrTWQkw
         url: https://semgrep.dev/playground/r/WrTWQkw/generic.secrets.gitleaks.contentful-delivery-api-token.contentful-delivery-api-token
@@ -2510,6 +2745,8 @@ rules:
     shortlink: https://sg.run/G0Rq
     semgrep.dev:
       rule:
+        r_id: 44692
+        rv_id: 109378
         rule_id: BYU4D6
         version_id: 0bTLlQd
         url: https://semgrep.dev/playground/r/0bTLlQd/generic.secrets.gitleaks.databricks-api-token.databricks-api-token
@@ -2551,6 +2788,8 @@ rules:
     shortlink: https://sg.run/Rjrq
     semgrep.dev:
       rule:
+        r_id: 44693
+        rv_id: 109379
         rule_id: DbUB9r
         version_id: K3TvjPd
         url: https://semgrep.dev/playground/r/K3TvjPd/generic.secrets.gitleaks.datadog-access-token.datadog-access-token
@@ -2592,6 +2831,8 @@ rules:
     shortlink: https://sg.run/Ne3z
     semgrep.dev:
       rule:
+        r_id: 66771
+        rv_id: 109380
         rule_id: KxUqPA
         version_id: qkT2x90
         url: https://semgrep.dev/playground/r/qkT2x90/generic.secrets.gitleaks.defined-networking-api-token.defined-networking-api-token
@@ -2633,6 +2874,8 @@ rules:
     shortlink: https://sg.run/AGj2
     semgrep.dev:
       rule:
+        r_id: 44694
+        rv_id: 109381
         rule_id: WAUelp
         version_id: l4T4ve5
         url: https://semgrep.dev/playground/r/l4T4ve5/generic.secrets.gitleaks.digitalocean-access-token.digitalocean-access-token
@@ -2674,6 +2917,8 @@ rules:
     shortlink: https://sg.run/BR2A
     semgrep.dev:
       rule:
+        r_id: 44695
+        rv_id: 109382
         rule_id: 0oU073
         version_id: YDTp2zP
         url: https://semgrep.dev/playground/r/YDTp2zP/generic.secrets.gitleaks.digitalocean-pat.digitalocean-pat
@@ -2715,6 +2960,8 @@ rules:
     shortlink: https://sg.run/D38P
     semgrep.dev:
       rule:
+        r_id: 44696
+        rv_id: 109383
         rule_id: KxUAzk
         version_id: JdTNp27
         url: https://semgrep.dev/playground/r/JdTNp27/generic.secrets.gitleaks.digitalocean-refresh-token.digitalocean-refresh-token
@@ -2756,6 +3003,8 @@ rules:
     shortlink: https://sg.run/W5e2
     semgrep.dev:
       rule:
+        r_id: 44697
+        rv_id: 109384
         rule_id: qNUA1y
         version_id: 5PTdAxJ
         url: https://semgrep.dev/playground/r/5PTdAxJ/generic.secrets.gitleaks.discord-api-token.discord-api-token
@@ -2797,6 +3046,8 @@ rules:
     shortlink: https://sg.run/03gj
     semgrep.dev:
       rule:
+        r_id: 44698
+        rv_id: 109385
         rule_id: lBU3rj
         version_id: GxTv6gv
         url: https://semgrep.dev/playground/r/GxTv6gv/generic.secrets.gitleaks.discord-client-id.discord-client-id
@@ -2838,6 +3089,8 @@ rules:
     shortlink: https://sg.run/KYd5
     semgrep.dev:
       rule:
+        r_id: 44699
+        rv_id: 109386
         rule_id: YGUg6J
         version_id: RGTDkde
         url: https://semgrep.dev/playground/r/RGTDkde/generic.secrets.gitleaks.discord-client-secret.discord-client-secret
@@ -2879,6 +3132,8 @@ rules:
     shortlink: https://sg.run/4YBz
     semgrep.dev:
       rule:
+        r_id: 44700
+        rv_id: 109387
         rule_id: 6JU45L
         version_id: A8T95xr
         url: https://semgrep.dev/playground/r/A8T95xr/generic.secrets.gitleaks.doppler-api-token.doppler-api-token
@@ -2920,6 +3175,8 @@ rules:
     shortlink: https://sg.run/P29W
     semgrep.dev:
       rule:
+        r_id: 44701
+        rv_id: 109388
         rule_id: oqUGyn
         version_id: BjTXroN
         url: https://semgrep.dev/playground/r/BjTXroN/generic.secrets.gitleaks.droneci-access-token.droneci-access-token
@@ -2961,6 +3218,8 @@ rules:
     shortlink: https://sg.run/JlqW
     semgrep.dev:
       rule:
+        r_id: 44702
+        rv_id: 109389
         rule_id: zdU6AR
         version_id: DkT6nLW
         url: https://semgrep.dev/playground/r/DkT6nLW/generic.secrets.gitleaks.dropbox-api-token.dropbox-api-token
@@ -3002,6 +3261,8 @@ rules:
     shortlink: https://sg.run/56WX
     semgrep.dev:
       rule:
+        r_id: 44703
+        rv_id: 109390
         rule_id: pKUR69
         version_id: WrTWQgP
         url: https://semgrep.dev/playground/r/WrTWQgP/generic.secrets.gitleaks.dropbox-long-lived-api-token.dropbox-long-lived-api-token
@@ -3043,6 +3304,8 @@ rules:
     shortlink: https://sg.run/G0e2
     semgrep.dev:
       rule:
+        r_id: 44704
+        rv_id: 109391
         rule_id: 2ZUnbl
         version_id: 0bTLlZ2
         url: https://semgrep.dev/playground/r/0bTLlZ2/generic.secrets.gitleaks.dropbox-short-lived-api-token.dropbox-short-lived-api-token
@@ -3084,6 +3347,8 @@ rules:
     shortlink: https://sg.run/Rjoe
     semgrep.dev:
       rule:
+        r_id: 44705
+        rv_id: 109392
         rule_id: X5UG8Q
         version_id: K3TvjR5
         url: https://semgrep.dev/playground/r/K3TvjR5/generic.secrets.gitleaks.duffel-api-token.duffel-api-token
@@ -3125,6 +3390,8 @@ rules:
     shortlink: https://sg.run/AGv8
     semgrep.dev:
       rule:
+        r_id: 44706
+        rv_id: 109393
         rule_id: j2UGvl
         version_id: qkT2xrQ
         url: https://semgrep.dev/playground/r/qkT2xrQ/generic.secrets.gitleaks.dynatrace-api-token.dynatrace-api-token
@@ -3166,6 +3433,8 @@ rules:
     shortlink: https://sg.run/BRk2
     semgrep.dev:
       rule:
+        r_id: 44707
+        rv_id: 109394
         rule_id: 10UJKb
         version_id: l4T4vYX
         url: https://semgrep.dev/playground/r/l4T4vYX/generic.secrets.gitleaks.easypost-api-token.easypost-api-token
@@ -3207,6 +3476,8 @@ rules:
     shortlink: https://sg.run/D3oo
     semgrep.dev:
       rule:
+        r_id: 44708
+        rv_id: 109395
         rule_id: 9AU811
         version_id: YDTp2xv
         url: https://semgrep.dev/playground/r/YDTp2xv/generic.secrets.gitleaks.easypost-test-api-token.easypost-test-api-token
@@ -3248,6 +3519,8 @@ rules:
     shortlink: https://sg.run/W58g
     semgrep.dev:
       rule:
+        r_id: 44709
+        rv_id: 109396
         rule_id: yyUYnv
         version_id: 6xTvJkJ
         url: https://semgrep.dev/playground/r/6xTvJkJ/generic.secrets.gitleaks.etsy-access-token.etsy-access-token
@@ -3289,6 +3562,8 @@ rules:
     shortlink: https://sg.run/Ab0Pg
     semgrep.dev:
       rule:
+        r_id: 121950
+        rv_id: 729092
         rule_id: 4bUR8vw
         version_id: e1TrP21
         url: https://semgrep.dev/playground/r/e1TrP21/generic.secrets.gitleaks.facebook-access-token.facebook-access-token
@@ -3330,6 +3605,8 @@ rules:
     shortlink: https://sg.run/BYK5b
     semgrep.dev:
       rule:
+        r_id: 121951
+        rv_id: 729093
         rule_id: PeUJbAl
         version_id: vdT4bA8
         url: https://semgrep.dev/playground/r/vdT4bA8/generic.secrets.gitleaks.facebook-page-access-token.facebook-page-access-token
@@ -3371,6 +3648,8 @@ rules:
     shortlink: https://sg.run/DblB2
     semgrep.dev:
       rule:
+        r_id: 121952
+        rv_id: 729094
         rule_id: JDUNK7E
         version_id: d6T4N5y
         url: https://semgrep.dev/playground/r/d6T4N5y/generic.secrets.gitleaks.facebook-secret.facebook-secret
@@ -3412,6 +3691,8 @@ rules:
     shortlink: https://sg.run/03Q5
     semgrep.dev:
       rule:
+        r_id: 44710
+        rv_id: 109397
         rule_id: r6UBr9
         version_id: o5TglP9
         url: https://semgrep.dev/playground/r/o5TglP9/generic.secrets.gitleaks.facebook.facebook
@@ -3453,6 +3734,8 @@ rules:
     shortlink: https://sg.run/KYlX
     semgrep.dev:
       rule:
+        r_id: 44711
+        rv_id: 109398
         rule_id: bwUPw8
         version_id: zyTK89b
         url: https://semgrep.dev/playground/r/zyTK89b/generic.secrets.gitleaks.fastly-api-token.fastly-api-token
@@ -3494,6 +3777,8 @@ rules:
     shortlink: https://sg.run/qQxy
     semgrep.dev:
       rule:
+        r_id: 44712
+        rv_id: 109399
         rule_id: NbUvkX
         version_id: pZT1yJn
         url: https://semgrep.dev/playground/r/pZT1yJn/generic.secrets.gitleaks.finicity-api-token.finicity-api-token
@@ -3535,6 +3820,8 @@ rules:
     shortlink: https://sg.run/lQ29
     semgrep.dev:
       rule:
+        r_id: 44713
+        rv_id: 109400
         rule_id: kxUQk2
         version_id: 2KTzrXR
         url: https://semgrep.dev/playground/r/2KTzrXR/generic.secrets.gitleaks.finicity-client-secret.finicity-client-secret
@@ -3576,6 +3863,8 @@ rules:
     shortlink: https://sg.run/YRv4
     semgrep.dev:
       rule:
+        r_id: 44714
+        rv_id: 109401
         rule_id: wdUqJk
         version_id: X0TQxpk
         url: https://semgrep.dev/playground/r/X0TQxpk/generic.secrets.gitleaks.finnhub-access-token.finnhub-access-token
@@ -3617,6 +3906,8 @@ rules:
     shortlink: https://sg.run/6onB
     semgrep.dev:
       rule:
+        r_id: 44715
+        rv_id: 109402
         rule_id: x8Ulnq
         version_id: jQTgYpJ
         url: https://semgrep.dev/playground/r/jQTgYpJ/generic.secrets.gitleaks.flickr-access-token.flickr-access-token
@@ -3658,6 +3949,8 @@ rules:
     shortlink: https://sg.run/oQxR
     semgrep.dev:
       rule:
+        r_id: 44716
+        rv_id: 109403
         rule_id: OrUA3O
         version_id: 1QTOYnk
         url: https://semgrep.dev/playground/r/1QTOYnk/generic.secrets.gitleaks.flutterwave-encryption-key.flutterwave-encryption-key
@@ -3699,6 +3992,8 @@ rules:
     shortlink: https://sg.run/zQvW
     semgrep.dev:
       rule:
+        r_id: 44717
+        rv_id: 109404
         rule_id: eqUY83
         version_id: 9lTdWLn
         url: https://semgrep.dev/playground/r/9lTdWLn/generic.secrets.gitleaks.flutterwave-public-key.flutterwave-public-key
@@ -3740,6 +4035,8 @@ rules:
     shortlink: https://sg.run/pQxL
     semgrep.dev:
       rule:
+        r_id: 44718
+        rv_id: 109405
         rule_id: v8UKn0
         version_id: yeTR2zQ
         url: https://semgrep.dev/playground/r/yeTR2zQ/generic.secrets.gitleaks.flutterwave-secret-key.flutterwave-secret-key
@@ -3781,6 +4078,8 @@ rules:
     shortlink: https://sg.run/2qxD
     semgrep.dev:
       rule:
+        r_id: 44719
+        rv_id: 109406
         rule_id: d8UOj3
         version_id: rxTyLXX
         url: https://semgrep.dev/playground/r/rxTyLXX/generic.secrets.gitleaks.frameio-api-token.frameio-api-token
@@ -3822,6 +4121,8 @@ rules:
     shortlink: https://sg.run/X3Bb
     semgrep.dev:
       rule:
+        r_id: 44720
+        rv_id: 109407
         rule_id: ZqUk5D
         version_id: bZTb1JP
         url: https://semgrep.dev/playground/r/bZTb1JP/generic.secrets.gitleaks.freshbooks-access-token.freshbooks-access-token
@@ -3863,6 +4164,8 @@ rules:
     shortlink: https://sg.run/j1RJ
     semgrep.dev:
       rule:
+        r_id: 44721
+        rv_id: 109408
         rule_id: nJU5zJ
         version_id: NdT3dEW
         url: https://semgrep.dev/playground/r/NdT3dEW/generic.secrets.gitleaks.gcp-api-key.gcp-api-key
@@ -3904,6 +4207,8 @@ rules:
     shortlink: https://sg.run/92o8
     semgrep.dev:
       rule:
+        r_id: 44723
+        rv_id: 109410
         rule_id: 7KUJQX
         version_id: w8T9nvB
         url: https://semgrep.dev/playground/r/w8T9nvB/generic.secrets.gitleaks.github-app-token.github-app-token
@@ -3945,6 +4250,8 @@ rules:
     shortlink: https://sg.run/yQdR
     semgrep.dev:
       rule:
+        r_id: 44724
+        rv_id: 109411
         rule_id: L1ULyp
         version_id: xyTKZ1g
         url: https://semgrep.dev/playground/r/xyTKZ1g/generic.secrets.gitleaks.github-fine-grained-pat.github-fine-grained-pat
@@ -3986,6 +4293,8 @@ rules:
     shortlink: https://sg.run/rQdR
     semgrep.dev:
       rule:
+        r_id: 44725
+        rv_id: 109412
         rule_id: 8GUPjW
         version_id: O9TNOr9
         url: https://semgrep.dev/playground/r/O9TNOr9/generic.secrets.gitleaks.github-oauth.github-oauth
@@ -4027,6 +4336,8 @@ rules:
     shortlink: https://sg.run/bY7E
     semgrep.dev:
       rule:
+        r_id: 44726
+        rv_id: 109413
         rule_id: gxUv1p
         version_id: e1T01w5
         url: https://semgrep.dev/playground/r/e1T01w5/generic.secrets.gitleaks.github-pat.github-pat
@@ -4068,6 +4379,8 @@ rules:
     shortlink: https://sg.run/Nz4z
     semgrep.dev:
       rule:
+        r_id: 44727
+        rv_id: 109414
         rule_id: QrURzR
         version_id: vdTYNJe
         url: https://semgrep.dev/playground/r/vdTYNJe/generic.secrets.gitleaks.github-refresh-token.github-refresh-token
@@ -4109,6 +4422,8 @@ rules:
     shortlink: https://sg.run/k3X2
     semgrep.dev:
       rule:
+        r_id: 44728
+        rv_id: 109415
         rule_id: 3qU5PK
         version_id: d6TrAEY
         url: https://semgrep.dev/playground/r/d6TrAEY/generic.secrets.gitleaks.gitlab-pat.gitlab-pat
@@ -4150,6 +4465,8 @@ rules:
     shortlink: https://sg.run/wQeP
     semgrep.dev:
       rule:
+        r_id: 44729
+        rv_id: 109416
         rule_id: 4bUKkW
         version_id: ZRTQNJo
         url: https://semgrep.dev/playground/r/ZRTQNJo/generic.secrets.gitleaks.gitlab-ptt.gitlab-ptt
@@ -4191,6 +4508,8 @@ rules:
     shortlink: https://sg.run/xQ1g
     semgrep.dev:
       rule:
+        r_id: 44730
+        rv_id: 109417
         rule_id: PeU7ZX
         version_id: nWTxPlg
         url: https://semgrep.dev/playground/r/nWTxPlg/generic.secrets.gitleaks.gitlab-rrt.gitlab-rrt
@@ -4232,6 +4551,8 @@ rules:
     shortlink: https://sg.run/OpPn
     semgrep.dev:
       rule:
+        r_id: 44731
+        rv_id: 109418
         rule_id: JDUOyB
         version_id: ExTjNbD
         url: https://semgrep.dev/playground/r/ExTjNbD/generic.secrets.gitleaks.gitter-access-token.gitter-access-token
@@ -4273,6 +4594,8 @@ rules:
     shortlink: https://sg.run/ezLy
     semgrep.dev:
       rule:
+        r_id: 44732
+        rv_id: 109419
         rule_id: 5rUKOQ
         version_id: 7ZTgowR
         url: https://semgrep.dev/playground/r/7ZTgowR/generic.secrets.gitleaks.gocardless-api-token.gocardless-api-token
@@ -4314,6 +4637,8 @@ rules:
     shortlink: https://sg.run/vQzb
     semgrep.dev:
       rule:
+        r_id: 44733
+        rv_id: 109420
         rule_id: GdUb7y
         version_id: LjTqQJg
         url: https://semgrep.dev/playground/r/LjTqQJg/generic.secrets.gitleaks.grafana-api-key.grafana-api-key
@@ -4355,6 +4680,8 @@ rules:
     shortlink: https://sg.run/doKd
     semgrep.dev:
       rule:
+        r_id: 44734
+        rv_id: 109421
         rule_id: ReUNgJ
         version_id: 8KTQ90Z
         url: https://semgrep.dev/playground/r/8KTQ90Z/generic.secrets.gitleaks.grafana-cloud-api-token.grafana-cloud-api-token
@@ -4396,6 +4723,8 @@ rules:
     shortlink: https://sg.run/ZAvo
     semgrep.dev:
       rule:
+        r_id: 44735
+        rv_id: 109422
         rule_id: AbUvzB
         version_id: gET3xpl
         url: https://semgrep.dev/playground/r/gET3xpl/generic.secrets.gitleaks.grafana-service-account-token.grafana-service-account-token
@@ -4437,6 +4766,8 @@ rules:
     shortlink: https://sg.run/nQd2
     semgrep.dev:
       rule:
+        r_id: 44736
+        rv_id: 109423
         rule_id: BYU4N6
         version_id: QkTW0Lb
         url: https://semgrep.dev/playground/r/QkTW0Lb/generic.secrets.gitleaks.hashicorp-tf-api-token.hashicorp-tf-api-token
@@ -4478,6 +4809,8 @@ rules:
     shortlink: https://sg.run/bw7lv
     semgrep.dev:
       rule:
+        r_id: 92970
+        rv_id: 230003
         rule_id: BYUXNWY
         version_id: kbTgNPD
         url: https://semgrep.dev/playground/r/kbTgNPD/generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
@@ -4519,6 +4852,8 @@ rules:
     shortlink: https://sg.run/EDke
     semgrep.dev:
       rule:
+        r_id: 44737
+        rv_id: 109424
         rule_id: DbUBpr
         version_id: 3ZTkQgo
         url: https://semgrep.dev/playground/r/3ZTkQgo/generic.secrets.gitleaks.heroku-api-key.heroku-api-key
@@ -4560,6 +4895,8 @@ rules:
     shortlink: https://sg.run/7zoW
     semgrep.dev:
       rule:
+        r_id: 44738
+        rv_id: 109425
         rule_id: WAUeop
         version_id: 44TRlJo
         url: https://semgrep.dev/playground/r/44TRlJo/generic.secrets.gitleaks.hubspot-api-key.hubspot-api-key
@@ -4601,6 +4938,8 @@ rules:
     shortlink: https://sg.run/n6dX
     semgrep.dev:
       rule:
+        r_id: 67936
+        rv_id: 109426
         rule_id: j2Ujvk
         version_id: PkTJ1KL
         url: https://semgrep.dev/playground/r/PkTJ1KL/generic.secrets.gitleaks.huggingface-access-token.huggingface-access-token
@@ -4642,6 +4981,8 @@ rules:
     shortlink: https://sg.run/E3kw
     semgrep.dev:
       rule:
+        r_id: 67937
+        rv_id: 109427
         rule_id: 10UNKO
         version_id: JdTNp47
         url: https://semgrep.dev/playground/r/JdTNp47/generic.secrets.gitleaks.huggingface-organization-api-token.huggingface-organization-api-token
@@ -4683,6 +5024,8 @@ rules:
     shortlink: https://sg.run/KByn
     semgrep.dev:
       rule:
+        r_id: 72099
+        rv_id: 109428
         rule_id: 3qU1LG
         version_id: 5PTdAKJ
         url: https://semgrep.dev/playground/r/5PTdAKJ/generic.secrets.gitleaks.infracost-api-token.infracost-api-token
@@ -4724,6 +5067,8 @@ rules:
     shortlink: https://sg.run/L6wo
     semgrep.dev:
       rule:
+        r_id: 44739
+        rv_id: 109429
         rule_id: 0oU053
         version_id: GxTv6bv
         url: https://semgrep.dev/playground/r/GxTv6bv/generic.secrets.gitleaks.intercom-api-key.intercom-api-key
@@ -4765,6 +5110,8 @@ rules:
     shortlink: https://sg.run/kNy2
     semgrep.dev:
       rule:
+        r_id: 66772
+        rv_id: 109430
         rule_id: qNUn9g
         version_id: RGTDkNe
         url: https://semgrep.dev/playground/r/RGTDkNe/generic.secrets.gitleaks.jfrog-api-key.jfrog-api-key
@@ -4806,6 +5153,8 @@ rules:
     shortlink: https://sg.run/wR0P
     semgrep.dev:
       rule:
+        r_id: 66773
+        rv_id: 109431
         rule_id: lBUOew
         version_id: A8T95vr
         url: https://semgrep.dev/playground/r/A8T95vr/generic.secrets.gitleaks.jfrog-identity-token.jfrog-identity-token
@@ -4847,6 +5196,8 @@ rules:
     shortlink: https://sg.run/7xoZ
     semgrep.dev:
       rule:
+        r_id: 67938
+        rv_id: 109432
         rule_id: 9AU71e
         version_id: BjTXr4N
         url: https://semgrep.dev/playground/r/BjTXr4N/generic.secrets.gitleaks.jwt-base64.jwt-base64
@@ -4887,6 +5238,8 @@ rules:
     shortlink: https://sg.run/8pyE
     semgrep.dev:
       rule:
+        r_id: 44740
+        rv_id: 109433
         rule_id: KxUAbk
         version_id: DkT6nBW
         url: https://semgrep.dev/playground/r/DkT6nBW/generic.secrets.gitleaks.jwt.jwt
@@ -4928,6 +5281,8 @@ rules:
     shortlink: https://sg.run/g2LZ
     semgrep.dev:
       rule:
+        r_id: 44741
+        rv_id: 109434
         rule_id: qNUAjy
         version_id: WrTWQeP
         url: https://semgrep.dev/playground/r/WrTWQeP/generic.secrets.gitleaks.kraken-access-token.kraken-access-token
@@ -4969,6 +5324,8 @@ rules:
     shortlink: https://sg.run/QX5Q
     semgrep.dev:
       rule:
+        r_id: 44742
+        rv_id: 109435
         rule_id: lBU39j
         version_id: 0bTLl02
         url: https://semgrep.dev/playground/r/0bTLl02/generic.secrets.gitleaks.kucoin-access-token.kucoin-access-token
@@ -5010,6 +5367,8 @@ rules:
     shortlink: https://sg.run/3lxp
     semgrep.dev:
       rule:
+        r_id: 44743
+        rv_id: 109436
         rule_id: PeU7Zg
         version_id: K3TvjA5
         url: https://semgrep.dev/playground/r/K3TvjA5/generic.secrets.gitleaks.kucoin-secret-key.kucoin-secret-key
@@ -5051,6 +5410,8 @@ rules:
     shortlink: https://sg.run/4Yxz
     semgrep.dev:
       rule:
+        r_id: 44744
+        rv_id: 109437
         rule_id: JDUOyJ
         version_id: qkT2xAQ
         url: https://semgrep.dev/playground/r/qkT2xAQ/generic.secrets.gitleaks.launchdarkly-access-token.launchdarkly-access-token
@@ -5092,6 +5453,8 @@ rules:
     shortlink: https://sg.run/P2JW
     semgrep.dev:
       rule:
+        r_id: 44745
+        rv_id: 109438
         rule_id: 5rUKO6
         version_id: l4T4v3X
         url: https://semgrep.dev/playground/r/l4T4v3X/generic.secrets.gitleaks.linear-api-key.linear-api-key
@@ -5133,6 +5496,8 @@ rules:
     shortlink: https://sg.run/Jl9W
     semgrep.dev:
       rule:
+        r_id: 44746
+        rv_id: 109439
         rule_id: GdUb7w
         version_id: YDTp2gv
         url: https://semgrep.dev/playground/r/YDTp2gv/generic.secrets.gitleaks.linear-client-secret.linear-client-secret
@@ -5174,6 +5539,8 @@ rules:
     shortlink: https://sg.run/56QX
     semgrep.dev:
       rule:
+        r_id: 44747
+        rv_id: 109440
         rule_id: ReUNg1
         version_id: 6xTvJ4J
         url: https://semgrep.dev/playground/r/6xTvJ4J/generic.secrets.gitleaks.linkedin-client-id.linkedin-client-id
@@ -5215,6 +5582,8 @@ rules:
     shortlink: https://sg.run/G0W2
     semgrep.dev:
       rule:
+        r_id: 44748
+        rv_id: 109441
         rule_id: AbUvWj
         version_id: o5TglG9
         url: https://semgrep.dev/playground/r/o5TglG9/generic.secrets.gitleaks.linkedin-client-secret.linkedin-client-secret
@@ -5256,6 +5625,8 @@ rules:
     shortlink: https://sg.run/Rj8e
     semgrep.dev:
       rule:
+        r_id: 44749
+        rv_id: 109442
         rule_id: BYU4BX
         version_id: zyTK86b
         url: https://semgrep.dev/playground/r/zyTK86b/generic.secrets.gitleaks.lob-api-key.lob-api-key
@@ -5297,6 +5668,8 @@ rules:
     shortlink: https://sg.run/AGl8
     semgrep.dev:
       rule:
+        r_id: 44750
+        rv_id: 109443
         rule_id: DbUBWq
         version_id: pZT1yRn
         url: https://semgrep.dev/playground/r/pZT1yRn/generic.secrets.gitleaks.lob-pub-api-key.lob-pub-api-key
@@ -5338,6 +5711,8 @@ rules:
     shortlink: https://sg.run/BR42
     semgrep.dev:
       rule:
+        r_id: 44751
+        rv_id: 729095
         rule_id: WAUeZl
         version_id: ZRTGRv2
         url: https://semgrep.dev/playground/r/ZRTGRv2/generic.secrets.gitleaks.mailchimp-api-key.mailchimp-api-key
@@ -5379,6 +5754,8 @@ rules:
     shortlink: https://sg.run/D3Jo
     semgrep.dev:
       rule:
+        r_id: 44752
+        rv_id: 109445
         rule_id: 0oU0E5
         version_id: X0TQxGk
         url: https://semgrep.dev/playground/r/X0TQxGk/generic.secrets.gitleaks.mailgun-private-api-token.mailgun-private-api-token
@@ -5420,6 +5797,8 @@ rules:
     shortlink: https://sg.run/W5gg
     semgrep.dev:
       rule:
+        r_id: 44753
+        rv_id: 109446
         rule_id: KxUA44
         version_id: jQTgYGJ
         url: https://semgrep.dev/playground/r/jQTgYGJ/generic.secrets.gitleaks.mailgun-pub-key.mailgun-pub-key
@@ -5461,6 +5840,8 @@ rules:
     shortlink: https://sg.run/03n5
     semgrep.dev:
       rule:
+        r_id: 44754
+        rv_id: 109447
         rule_id: qNUAob
         version_id: 1QTOYJk
         url: https://semgrep.dev/playground/r/1QTOYJk/generic.secrets.gitleaks.mailgun-signing-key.mailgun-signing-key
@@ -5502,6 +5883,8 @@ rules:
     shortlink: https://sg.run/KYWX
     semgrep.dev:
       rule:
+        r_id: 44755
+        rv_id: 109448
         rule_id: lBU3d8
         version_id: 9lTdW8n
         url: https://semgrep.dev/playground/r/9lTdW8n/generic.secrets.gitleaks.mapbox-api-token.mapbox-api-token
@@ -5543,6 +5926,8 @@ rules:
     shortlink: https://sg.run/qQry
     semgrep.dev:
       rule:
+        r_id: 44756
+        rv_id: 109449
         rule_id: YGUgrA
         version_id: yeTR2YQ
         url: https://semgrep.dev/playground/r/yeTR2YQ/generic.secrets.gitleaks.mattermost-access-token.mattermost-access-token
@@ -5584,6 +5969,8 @@ rules:
     shortlink: https://sg.run/lQj9
     semgrep.dev:
       rule:
+        r_id: 44757
+        rv_id: 109450
         rule_id: 6JU4qD
         version_id: rxTyLBX
         url: https://semgrep.dev/playground/r/rxTyLBX/generic.secrets.gitleaks.messagebird-api-token.messagebird-api-token
@@ -5625,6 +6012,8 @@ rules:
     shortlink: https://sg.run/YRg4
     semgrep.dev:
       rule:
+        r_id: 44758
+        rv_id: 109451
         rule_id: oqUGzK
         version_id: bZTb1PP
         url: https://semgrep.dev/playground/r/bZTb1PP/generic.secrets.gitleaks.messagebird-client-id.messagebird-client-id
@@ -5666,6 +6055,8 @@ rules:
     shortlink: https://sg.run/6orB
     semgrep.dev:
       rule:
+        r_id: 44759
+        rv_id: 109452
         rule_id: zdU6yl
         version_id: NdT3dvW
         url: https://semgrep.dev/playground/r/NdT3dvW/generic.secrets.gitleaks.microsoft-teams-webhook.microsoft-teams-webhook
@@ -5707,6 +6098,8 @@ rules:
     shortlink: https://sg.run/oQkR
     semgrep.dev:
       rule:
+        r_id: 44760
+        rv_id: 109453
         rule_id: pKURGy
         version_id: kbTdxQ0
         url: https://semgrep.dev/playground/r/kbTdxQ0/generic.secrets.gitleaks.netlify-access-token.netlify-access-token
@@ -5748,6 +6141,8 @@ rules:
     shortlink: https://sg.run/zQkW
     semgrep.dev:
       rule:
+        r_id: 44761
+        rv_id: 109454
         rule_id: 2ZUn43
         version_id: w8T9nqB
         url: https://semgrep.dev/playground/r/w8T9nqB/generic.secrets.gitleaks.new-relic-browser-api-token.new-relic-browser-api-token
@@ -5789,6 +6184,8 @@ rules:
     shortlink: https://sg.run/pQlL
     semgrep.dev:
       rule:
+        r_id: 44762
+        rv_id: 109455
         rule_id: X5UGZz
         version_id: xyTKZlg
         url: https://semgrep.dev/playground/r/xyTKZlg/generic.secrets.gitleaks.new-relic-user-api-id.new-relic-user-api-id
@@ -5830,6 +6227,8 @@ rules:
     shortlink: https://sg.run/2qbD
     semgrep.dev:
       rule:
+        r_id: 44763
+        rv_id: 109456
         rule_id: j2UGqB
         version_id: O9TNOA9
         url: https://semgrep.dev/playground/r/O9TNOA9/generic.secrets.gitleaks.new-relic-user-api-key.new-relic-user-api-key
@@ -5871,6 +6270,8 @@ rules:
     shortlink: https://sg.run/X3Lb
     semgrep.dev:
       rule:
+        r_id: 44764
+        rv_id: 109457
         rule_id: 10UJZE
         version_id: e1T01Y5
         url: https://semgrep.dev/playground/r/e1T01Y5/generic.secrets.gitleaks.npm-access-token.npm-access-token
@@ -5912,6 +6313,8 @@ rules:
     shortlink: https://sg.run/j1NJ
     semgrep.dev:
       rule:
+        r_id: 44765
+        rv_id: 109458
         rule_id: 9AU8Oq
         version_id: vdTYNKe
         url: https://semgrep.dev/playground/r/vdTYNKe/generic.secrets.gitleaks.nytimes-access-token.nytimes-access-token
@@ -5953,6 +6356,8 @@ rules:
     shortlink: https://sg.run/1Knv
     semgrep.dev:
       rule:
+        r_id: 44766
+        rv_id: 109459
         rule_id: yyUYve
         version_id: d6TrAOY
         url: https://semgrep.dev/playground/r/d6TrAOY/generic.secrets.gitleaks.okta-access-token.okta-access-token
@@ -5994,6 +6399,8 @@ rules:
     shortlink: https://sg.run/xAKg
     semgrep.dev:
       rule:
+        r_id: 66774
+        rv_id: 109460
         rule_id: YGU0zK
         version_id: ZRTQNko
         url: https://semgrep.dev/playground/r/ZRTQNko/generic.secrets.gitleaks.openai-api-key.openai-api-key
@@ -6035,6 +6442,8 @@ rules:
     shortlink: https://sg.run/92q8
     semgrep.dev:
       rule:
+        r_id: 44767
+        rv_id: 109461
         rule_id: r6UBkG
         version_id: nWTxP5g
         url: https://semgrep.dev/playground/r/nWTxP5g/generic.secrets.gitleaks.plaid-api-token.plaid-api-token
@@ -6076,6 +6485,8 @@ rules:
     shortlink: https://sg.run/yQzR
     semgrep.dev:
       rule:
+        r_id: 44768
+        rv_id: 109462
         rule_id: bwUPO4
         version_id: ExTjNyD
         url: https://semgrep.dev/playground/r/ExTjNyD/generic.secrets.gitleaks.plaid-client-id.plaid-client-id
@@ -6117,6 +6528,8 @@ rules:
     shortlink: https://sg.run/rQAR
     semgrep.dev:
       rule:
+        r_id: 44769
+        rv_id: 109463
         rule_id: NbUvA5
         version_id: 7ZTgoJR
         url: https://semgrep.dev/playground/r/7ZTgoJR/generic.secrets.gitleaks.plaid-secret-key.plaid-secret-key
@@ -6158,6 +6571,8 @@ rules:
     shortlink: https://sg.run/bYDE
     semgrep.dev:
       rule:
+        r_id: 44770
+        rv_id: 109464
         rule_id: kxUQR9
         version_id: LjTqQLg
         url: https://semgrep.dev/playground/r/LjTqQLg/generic.secrets.gitleaks.planetscale-api-token.planetscale-api-token
@@ -6199,6 +6614,8 @@ rules:
     shortlink: https://sg.run/Nzrz
     semgrep.dev:
       rule:
+        r_id: 44771
+        rv_id: 109465
         rule_id: wdUq8q
         version_id: 8KTQ9PZ
         url: https://semgrep.dev/playground/r/8KTQ9PZ/generic.secrets.gitleaks.planetscale-oauth-token.planetscale-oauth-token
@@ -6240,6 +6657,8 @@ rules:
     shortlink: https://sg.run/k3L2
     semgrep.dev:
       rule:
+        r_id: 44772
+        rv_id: 109466
         rule_id: x8UlWb
         version_id: gET3xvl
         url: https://semgrep.dev/playground/r/gET3xvl/generic.secrets.gitleaks.planetscale-password.planetscale-password
@@ -6281,6 +6700,8 @@ rules:
     shortlink: https://sg.run/wQxP
     semgrep.dev:
       rule:
+        r_id: 44773
+        rv_id: 109467
         rule_id: OrUAGK
         version_id: QkTW0Rb
         url: https://semgrep.dev/playground/r/QkTW0Rb/generic.secrets.gitleaks.postman-api-token.postman-api-token
@@ -6322,6 +6743,8 @@ rules:
     shortlink: https://sg.run/xQYg
     semgrep.dev:
       rule:
+        r_id: 44774
+        rv_id: 109468
         rule_id: eqUYv2
         version_id: 3ZTkQ5o
         url: https://semgrep.dev/playground/r/3ZTkQ5o/generic.secrets.gitleaks.prefect-api-token.prefect-api-token
@@ -6363,6 +6786,8 @@ rules:
     shortlink: https://sg.run/Op1n
     semgrep.dev:
       rule:
+        r_id: 44775
+        rv_id: 109469
         rule_id: v8UK5w
         version_id: 44TRlKo
         url: https://semgrep.dev/playground/r/44TRlKo/generic.secrets.gitleaks.private-key.private-key
@@ -6405,6 +6830,8 @@ rules:
     shortlink: https://sg.run/ez4y
     semgrep.dev:
       rule:
+        r_id: 44776
+        rv_id: 109470
         rule_id: d8UOzo
         version_id: PkTJ17L
         url: https://semgrep.dev/playground/r/PkTJ17L/generic.secrets.gitleaks.pulumi-api-token.pulumi-api-token
@@ -6446,6 +6873,8 @@ rules:
     shortlink: https://sg.run/vQ0b
     semgrep.dev:
       rule:
+        r_id: 44777
+        rv_id: 109471
         rule_id: ZqUkqn
         version_id: JdTNpO7
         url: https://semgrep.dev/playground/r/JdTNpO7/generic.secrets.gitleaks.pypi-upload-token.pypi-upload-token
@@ -6487,6 +6916,8 @@ rules:
     shortlink: https://sg.run/dogd
     semgrep.dev:
       rule:
+        r_id: 44778
+        rv_id: 109472
         rule_id: nJU5YX
         version_id: 5PTdAlJ
         url: https://semgrep.dev/playground/r/5PTdAlJ/generic.secrets.gitleaks.rapidapi-access-token.rapidapi-access-token
@@ -6528,6 +6959,8 @@ rules:
     shortlink: https://sg.run/ZAeo
     semgrep.dev:
       rule:
+        r_id: 44779
+        rv_id: 109473
         rule_id: EwUy4Z
         version_id: GxTv6Ov
         url: https://semgrep.dev/playground/r/GxTv6Ov/generic.secrets.gitleaks.readme-api-token.readme-api-token
@@ -6569,6 +7002,8 @@ rules:
     shortlink: https://sg.run/nQq2
     semgrep.dev:
       rule:
+        r_id: 44780
+        rv_id: 109474
         rule_id: 7KUJek
         version_id: RGTDkWe
         url: https://semgrep.dev/playground/r/RGTDkWe/generic.secrets.gitleaks.rubygems-api-token.rubygems-api-token
@@ -6610,12 +7045,14 @@ rules:
     shortlink: https://sg.run/Lowr
     semgrep.dev:
       rule:
+        r_id: 67939
+        rv_id: 750524
         rule_id: yyUgnB
-        version_id: A8T95Pr
-        url: https://semgrep.dev/playground/r/A8T95Pr/generic.secrets.gitleaks.scalingo-api-token.scalingo-api-token
+        version_id: DkTxyJw
+        url: https://semgrep.dev/playground/r/DkTxyJw/generic.secrets.gitleaks.scalingo-api-token.scalingo-api-token
         origin: community
   patterns:
-  - pattern-regex: "\\btk-us-[a-zA-Z0-9-_]{48}\\b"
+  - pattern-regex: \b(tk-us-[a-zA-Z0-9-_]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)
 - id: generic.secrets.gitleaks.sendbird-access-id.sendbird-access-id
   message: A gitleaks sendbird-access-id was detected which attempts to identify hard-coded
     credentials. It is not recommended to store credentials in source-code, as this
@@ -6651,6 +7088,8 @@ rules:
     shortlink: https://sg.run/ED5e
     semgrep.dev:
       rule:
+        r_id: 44781
+        rv_id: 109476
         rule_id: L1UL48
         version_id: BjTXrjN
         url: https://semgrep.dev/playground/r/BjTXrjN/generic.secrets.gitleaks.sendbird-access-id.sendbird-access-id
@@ -6692,6 +7131,8 @@ rules:
     shortlink: https://sg.run/7z0W
     semgrep.dev:
       rule:
+        r_id: 44782
+        rv_id: 109477
         rule_id: 8GUPEk
         version_id: DkT6noW
         url: https://semgrep.dev/playground/r/DkT6noW/generic.secrets.gitleaks.sendbird-access-token.sendbird-access-token
@@ -6733,6 +7174,8 @@ rules:
     shortlink: https://sg.run/L60o
     semgrep.dev:
       rule:
+        r_id: 44783
+        rv_id: 109478
         rule_id: gxUvWX
         version_id: WrTWQ5P
         url: https://semgrep.dev/playground/r/WrTWQ5P/generic.secrets.gitleaks.sendgrid-api-token.sendgrid-api-token
@@ -6774,6 +7217,8 @@ rules:
     shortlink: https://sg.run/8pnE
     semgrep.dev:
       rule:
+        r_id: 44784
+        rv_id: 109479
         rule_id: QrUR6q
         version_id: 0bTLlk2
         url: https://semgrep.dev/playground/r/0bTLlk2/generic.secrets.gitleaks.sendinblue-api-token.sendinblue-api-token
@@ -6815,6 +7260,8 @@ rules:
     shortlink: https://sg.run/g2JZ
     semgrep.dev:
       rule:
+        r_id: 44785
+        rv_id: 109480
         rule_id: 3qU5B1
         version_id: K3Tvj95
         url: https://semgrep.dev/playground/r/K3Tvj95/generic.secrets.gitleaks.sentry-access-token.sentry-access-token
@@ -6856,6 +7303,8 @@ rules:
     shortlink: https://sg.run/QX8Q
     semgrep.dev:
       rule:
+        r_id: 44786
+        rv_id: 109481
         rule_id: 4bUKzO
         version_id: qkT2xgQ
         url: https://semgrep.dev/playground/r/qkT2xgQ/generic.secrets.gitleaks.shippo-api-token.shippo-api-token
@@ -6897,6 +7346,8 @@ rules:
     shortlink: https://sg.run/3lAp
     semgrep.dev:
       rule:
+        r_id: 44787
+        rv_id: 109482
         rule_id: PeU7kg
         version_id: l4T4vqX
         url: https://semgrep.dev/playground/r/l4T4vqX/generic.secrets.gitleaks.shopify-access-token.shopify-access-token
@@ -6938,6 +7389,8 @@ rules:
     shortlink: https://sg.run/4Yyz
     semgrep.dev:
       rule:
+        r_id: 44788
+        rv_id: 109483
         rule_id: JDUOPJ
         version_id: YDTp2Gv
         url: https://semgrep.dev/playground/r/YDTp2Gv/generic.secrets.gitleaks.shopify-custom-access-token.shopify-custom-access-token
@@ -6979,6 +7432,8 @@ rules:
     shortlink: https://sg.run/P2pW
     semgrep.dev:
       rule:
+        r_id: 44789
+        rv_id: 109484
         rule_id: 5rUK46
         version_id: JdTNpwp
         url: https://semgrep.dev/playground/r/JdTNpwp/generic.secrets.gitleaks.shopify-private-app-access-token.shopify-private-app-access-token
@@ -7020,6 +7475,8 @@ rules:
     shortlink: https://sg.run/Jl3W
     semgrep.dev:
       rule:
+        r_id: 44790
+        rv_id: 109485
         rule_id: GdUb0w
         version_id: 5PTdAle
         url: https://semgrep.dev/playground/r/5PTdAle/generic.secrets.gitleaks.shopify-shared-secret.shopify-shared-secret
@@ -7061,6 +7518,8 @@ rules:
     shortlink: https://sg.run/568X
     semgrep.dev:
       rule:
+        r_id: 44791
+        rv_id: 109486
         rule_id: ReUNP1
         version_id: GxTv6Ok
         url: https://semgrep.dev/playground/r/GxTv6Ok/generic.secrets.gitleaks.sidekiq-secret.sidekiq-secret
@@ -7103,6 +7562,8 @@ rules:
     shortlink: https://sg.run/G0w2
     semgrep.dev:
       rule:
+        r_id: 44792
+        rv_id: 109487
         rule_id: AbUvGj
         version_id: RGTDkWp
         url: https://semgrep.dev/playground/r/RGTDkWp/generic.secrets.gitleaks.sidekiq-sensitive-url.sidekiq-sensitive-url
@@ -7144,6 +7605,8 @@ rules:
     shortlink: https://sg.run/OvNn
     semgrep.dev:
       rule:
+        r_id: 66775
+        rv_id: 109488
         rule_id: 6JUgAl
         version_id: A8T95PE
         url: https://semgrep.dev/playground/r/A8T95PE/generic.secrets.gitleaks.slack-app-token.slack-app-token
@@ -7185,6 +7648,8 @@ rules:
     shortlink: https://sg.run/ejky
     semgrep.dev:
       rule:
+        r_id: 66776
+        rv_id: 109489
         rule_id: oqUEWO
         version_id: BjTXrjJ
         url: https://semgrep.dev/playground/r/BjTXrjJ/generic.secrets.gitleaks.slack-bot-token.slack-bot-token
@@ -7226,6 +7691,8 @@ rules:
     shortlink: https://sg.run/vGWb
     semgrep.dev:
       rule:
+        r_id: 66777
+        rv_id: 109490
         rule_id: zdUJXd
         version_id: DkT6no7
         url: https://semgrep.dev/playground/r/DkT6no7/generic.secrets.gitleaks.slack-config-access-token.slack-config-access-token
@@ -7267,6 +7734,8 @@ rules:
     shortlink: https://sg.run/dXyd
     semgrep.dev:
       rule:
+        r_id: 66778
+        rv_id: 109491
         rule_id: pKUjqZ
         version_id: WrTWQ5j
         url: https://semgrep.dev/playground/r/WrTWQ5j/generic.secrets.gitleaks.slack-config-refresh-token.slack-config-refresh-token
@@ -7308,6 +7777,8 @@ rules:
     shortlink: https://sg.run/Z0yo
     semgrep.dev:
       rule:
+        r_id: 66779
+        rv_id: 109492
         rule_id: 2ZUxA8
         version_id: 0bTLlk6
         url: https://semgrep.dev/playground/r/0bTLlk6/generic.secrets.gitleaks.slack-legacy-bot-token.slack-legacy-bot-token
@@ -7349,6 +7820,8 @@ rules:
     shortlink: https://sg.run/nxP2
     semgrep.dev:
       rule:
+        r_id: 66780
+        rv_id: 109493
         rule_id: X5UNor
         version_id: K3Tvj9P
         url: https://semgrep.dev/playground/r/K3Tvj9P/generic.secrets.gitleaks.slack-legacy-token.slack-legacy-token
@@ -7390,6 +7863,8 @@ rules:
     shortlink: https://sg.run/E9Ne
     semgrep.dev:
       rule:
+        r_id: 66781
+        rv_id: 109494
         rule_id: j2UXL7
         version_id: qkT2xgr
         url: https://semgrep.dev/playground/r/qkT2xgr/generic.secrets.gitleaks.slack-legacy-workspace-token.slack-legacy-workspace-token
@@ -7431,6 +7906,8 @@ rules:
     shortlink: https://sg.run/7WdW
     semgrep.dev:
       rule:
+        r_id: 66782
+        rv_id: 109495
         rule_id: 10UL0L
         version_id: l4T4vq3
         url: https://semgrep.dev/playground/r/l4T4vq3/generic.secrets.gitleaks.slack-user-token.slack-user-token
@@ -7472,6 +7949,8 @@ rules:
     shortlink: https://sg.run/Lxko
     semgrep.dev:
       rule:
+        r_id: 66783
+        rv_id: 109496
         rule_id: 9AU0E7
         version_id: YDTp2GG
         url: https://semgrep.dev/playground/r/YDTp2GG/generic.secrets.gitleaks.slack-webhook-url.slack-webhook-url
@@ -7513,6 +7992,8 @@ rules:
     shortlink: https://sg.run/80dE
     semgrep.dev:
       rule:
+        r_id: 66784
+        rv_id: 109497
         rule_id: yyU1Qp
         version_id: 6xTvJ7O
         url: https://semgrep.dev/playground/r/6xTvJ7O/generic.secrets.gitleaks.snyk-api-token.snyk-api-token
@@ -7555,6 +8036,8 @@ rules:
     shortlink: https://sg.run/BRL2
     semgrep.dev:
       rule:
+        r_id: 44795
+        rv_id: 729096
         rule_id: WAUePl
         version_id: nWTGD1Q
         url: https://semgrep.dev/playground/r/nWTGD1Q/generic.secrets.gitleaks.square-access-token.square-access-token
@@ -7596,6 +8079,8 @@ rules:
     shortlink: https://sg.run/D3wo
     semgrep.dev:
       rule:
+        r_id: 44796
+        rv_id: 109499
         rule_id: 0oU0J5
         version_id: zyTK8gw
         url: https://semgrep.dev/playground/r/zyTK8gw/generic.secrets.gitleaks.squarespace-access-token.squarespace-access-token
@@ -7637,12 +8122,14 @@ rules:
     shortlink: https://sg.run/W5Og
     semgrep.dev:
       rule:
+        r_id: 44797
+        rv_id: 750525
         rule_id: KxUAY4
-        version_id: jQT6gyn
-        url: https://semgrep.dev/playground/r/jQT6gyn/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
+        version_id: WrTNn9G
+        url: https://semgrep.dev/playground/r/WrTNn9G/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
         origin: community
   patterns:
-  - pattern-regex: (?i)\b((sk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)
+  - pattern-regex: (?i)\b((sk|rk)_(test|live|prod)_[0-9a-z]{10,99})(?:['|\"|\n|\r|\s|\x60|;]|$)
 - id: generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id
   message: A gitleaks sumologic-access-id was detected which attempts to identify
     hard-coded credentials. It is not recommended to store credentials in source-code,
@@ -7678,6 +8165,8 @@ rules:
     shortlink: https://sg.run/0355
     semgrep.dev:
       rule:
+        r_id: 44798
+        rv_id: 109501
         rule_id: qNUAbb
         version_id: 2KTzrNe
         url: https://semgrep.dev/playground/r/2KTzrNe/generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id
@@ -7719,6 +8208,8 @@ rules:
     shortlink: https://sg.run/KY8X
     semgrep.dev:
       rule:
+        r_id: 44799
+        rv_id: 109502
         rule_id: lBU3z8
         version_id: X0TQxeD
         url: https://semgrep.dev/playground/r/X0TQxeD/generic.secrets.gitleaks.sumologic-access-token.sumologic-access-token
@@ -7760,6 +8251,8 @@ rules:
     shortlink: https://sg.run/4YPl
     semgrep.dev:
       rule:
+        r_id: 44800
+        rv_id: 109503
         rule_id: YGUgQA
         version_id: jQTgYeP
         url: https://semgrep.dev/playground/r/jQTgYeP/generic.secrets.gitleaks.telegram-bot-api-token.telegram-bot-api-token
@@ -7801,6 +8294,8 @@ rules:
     shortlink: https://sg.run/P28Y
     semgrep.dev:
       rule:
+        r_id: 44801
+        rv_id: 109504
         rule_id: 6JU46D
         version_id: 1QTOYW1
         url: https://semgrep.dev/playground/r/1QTOYW1/generic.secrets.gitleaks.travisci-access-token.travisci-access-token
@@ -7842,6 +8337,8 @@ rules:
     shortlink: https://sg.run/Jljw
     semgrep.dev:
       rule:
+        r_id: 44802
+        rv_id: 109505
         rule_id: oqUGrK
         version_id: 9lTdWNP
         url: https://semgrep.dev/playground/r/9lTdWNP/generic.secrets.gitleaks.twilio-api-key.twilio-api-key
@@ -7883,6 +8380,8 @@ rules:
     shortlink: https://sg.run/56JA
     semgrep.dev:
       rule:
+        r_id: 44803
+        rv_id: 109506
         rule_id: zdU61l
         version_id: yeTR2b1
         url: https://semgrep.dev/playground/r/yeTR2b1/generic.secrets.gitleaks.twitch-api-token.twitch-api-token
@@ -7924,6 +8423,8 @@ rules:
     shortlink: https://sg.run/G0wp
     semgrep.dev:
       rule:
+        r_id: 44804
+        rv_id: 109507
         rule_id: pKURwy
         version_id: rxTyLgv
         url: https://semgrep.dev/playground/r/rxTyLgv/generic.secrets.gitleaks.twitter-access-secret.twitter-access-secret
@@ -7965,6 +8466,8 @@ rules:
     shortlink: https://sg.run/RjPO
     semgrep.dev:
       rule:
+        r_id: 44805
+        rv_id: 109508
         rule_id: 2ZUnK3
         version_id: bZTb1W3
         url: https://semgrep.dev/playground/r/bZTb1W3/generic.secrets.gitleaks.twitter-access-token.twitter-access-token
@@ -8006,6 +8509,8 @@ rules:
     shortlink: https://sg.run/AGwp
     semgrep.dev:
       rule:
+        r_id: 44806
+        rv_id: 109509
         rule_id: X5UG7z
         version_id: NdT3dWj
         url: https://semgrep.dev/playground/r/NdT3dWj/generic.secrets.gitleaks.twitter-api-key.twitter-api-key
@@ -8047,6 +8552,8 @@ rules:
     shortlink: https://sg.run/BRLW
     semgrep.dev:
       rule:
+        r_id: 44807
+        rv_id: 109510
         rule_id: j2UGRB
         version_id: kbTdxvX
         url: https://semgrep.dev/playground/r/kbTdxvX/generic.secrets.gitleaks.twitter-api-secret.twitter-api-secret
@@ -8088,6 +8595,8 @@ rules:
     shortlink: https://sg.run/D3wY
     semgrep.dev:
       rule:
+        r_id: 44808
+        rv_id: 109511
         rule_id: 10UJeE
         version_id: w8T9ngZ
         url: https://semgrep.dev/playground/r/w8T9ngZ/generic.secrets.gitleaks.twitter-bearer-token.twitter-bearer-token
@@ -8129,6 +8638,8 @@ rules:
     shortlink: https://sg.run/W5O4
     semgrep.dev:
       rule:
+        r_id: 44809
+        rv_id: 109512
         rule_id: 9AU8kq
         version_id: xyTKZbY
         url: https://semgrep.dev/playground/r/xyTKZbY/generic.secrets.gitleaks.typeform-api-token.typeform-api-token
@@ -8170,6 +8681,8 @@ rules:
     shortlink: https://sg.run/035v
     semgrep.dev:
       rule:
+        r_id: 44810
+        rv_id: 109513
         rule_id: yyUYye
         version_id: O9TNOLy
         url: https://semgrep.dev/playground/r/O9TNOLy/generic.secrets.gitleaks.vault-batch-token.vault-batch-token
@@ -8211,6 +8724,8 @@ rules:
     shortlink: https://sg.run/KY87
     semgrep.dev:
       rule:
+        r_id: 44811
+        rv_id: 109514
         rule_id: r6UB9G
         version_id: e1T01Pd
         url: https://semgrep.dev/playground/r/e1T01Pd/generic.secrets.gitleaks.vault-service-token.vault-service-token
@@ -8252,6 +8767,8 @@ rules:
     shortlink: https://sg.run/qQqz
     semgrep.dev:
       rule:
+        r_id: 44812
+        rv_id: 109515
         rule_id: bwUPN4
         version_id: vdTYNbW
         url: https://semgrep.dev/playground/r/vdTYNbW/generic.secrets.gitleaks.yandex-access-token.yandex-access-token
@@ -8293,6 +8810,8 @@ rules:
     shortlink: https://sg.run/lQxy
     semgrep.dev:
       rule:
+        r_id: 44813
+        rv_id: 109516
         rule_id: NbUvY5
         version_id: d6TrA2w
         url: https://semgrep.dev/playground/r/d6TrA2w/generic.secrets.gitleaks.yandex-api-key.yandex-api-key
@@ -8334,6 +8853,8 @@ rules:
     shortlink: https://sg.run/YRXe
     semgrep.dev:
       rule:
+        r_id: 44814
+        rv_id: 109517
         rule_id: kxUQ89
         version_id: ZRTQN1Q
         url: https://semgrep.dev/playground/r/ZRTQN1Q/generic.secrets.gitleaks.yandex-aws-access-token.yandex-aws-access-token
@@ -8375,6 +8896,8 @@ rules:
     shortlink: https://sg.run/6o5o
     semgrep.dev:
       rule:
+        r_id: 44815
+        rv_id: 109518
         rule_id: wdUqGq
         version_id: nWTxPAO
         url: https://semgrep.dev/playground/r/nWTxPAO/generic.secrets.gitleaks.zendesk-secret-key.zendesk-secret-key
@@ -8421,6 +8944,8 @@ rules:
     shortlink: https://sg.run/8yA4
     semgrep.dev:
       rule:
+        r_id: 9084
+        rv_id: 109566
         rule_id: DbUple
         version_id: 8KTQ97x
         url: https://semgrep.dev/playground/r/8KTQ97x/generic.secrets.security.detected-username-and-password-in-uri.detected-username-and-password-in-uri
@@ -8463,6 +8988,8 @@ rules:
     shortlink: https://sg.run/1pXb
     semgrep.dev:
       rule:
+        r_id: 72422
+        rv_id: 109569
         rule_id: AbU20Y
         version_id: 3ZTkQz3
         url: https://semgrep.dev/playground/r/3ZTkQz3/generic.visualforce.security.ncino.html.usesriforcdns.use-SRI-for-CDNs
@@ -8521,6 +9048,8 @@ rules:
     shortlink: https://sg.run/9bGk
     semgrep.dev:
       rule:
+        r_id: 72423
+        rv_id: 109570
         rule_id: BYUAJ2
         version_id: 44TRlwe
         url: https://semgrep.dev/playground/r/44TRlwe/generic.visualforce.security.ncino.vf.xssfromunescapedurlparam.xss-from-unescaped-url-param
@@ -8568,6 +9097,8 @@ rules:
     shortlink: https://sg.run/yoj8
     semgrep.dev:
       rule:
+        r_id: 72424
+        rv_id: 109571
         rule_id: DbUj7d
         version_id: PkTJ1XQ
         url: https://semgrep.dev/playground/r/PkTJ1XQ/generic.visualforce.security.ncino.xml.cspheaderattribute.csp-header-attribute
@@ -8613,6 +9144,8 @@ rules:
     shortlink: https://sg.run/rWr6
     semgrep.dev:
       rule:
+        r_id: 72425
+        rv_id: 109572
         rule_id: WAUwJW
         version_id: JdTNpYp
         url: https://semgrep.dev/playground/r/JdTNpYp/generic.visualforce.security.ncino.xml.visualforceapiversion.visualforce-page-api-version
@@ -8663,6 +9196,8 @@ rules:
     shortlink: https://sg.run/e5e8
     semgrep.dev:
       rule:
+        r_id: 18232
+        rv_id: 109573
         rule_id: WAUdJ7
         version_id: 5PTdA2e
         url: https://semgrep.dev/playground/r/5PTdA2e/go.aws-lambda.security.database-sqli.database-sqli
@@ -8734,6 +9269,8 @@ rules:
     shortlink: https://sg.run/vX3Y
     semgrep.dev:
       rule:
+        r_id: 18233
+        rv_id: 109574
         rule_id: 0oUwqg
         version_id: GxTv6Kk
         url: https://semgrep.dev/playground/r/GxTv6Kk/go.aws-lambda.security.tainted-sql-string.tainted-sql-string
@@ -8850,6 +9387,8 @@ rules:
     shortlink: https://sg.run/R4qg
     semgrep.dev:
       rule:
+        r_id: 24693
+        rv_id: 109579
         rule_id: AbU5o3
         version_id: WrTWQAj
         url: https://semgrep.dev/playground/r/WrTWQAj/go.gorm.security.audit.gorm-dangerous-methods-usage.gorm-dangerous-method-usage
@@ -8888,6 +9427,8 @@ rules:
     shortlink: https://sg.run/Rod2
     semgrep.dev:
       rule:
+        r_id: 9093
+        rv_id: 109584
         rule_id: GdU7Ny
         version_id: YDTp2KG
         url: https://semgrep.dev/playground/r/YDTp2KG/go.jwt-go.security.jwt.hardcoded-jwt-key
@@ -8929,6 +9470,8 @@ rules:
     shortlink: https://sg.run/6nK6
     semgrep.dev:
       rule:
+        r_id: 9115
+        rv_id: 109598
         rule_id: bwUwy8
         version_id: 6xTvJwY
         url: https://semgrep.dev/playground/r/6xTvJwY/go.lang.security.audit.crypto.math_random.math-random-used
@@ -8988,6 +9531,8 @@ rules:
     shortlink: https://sg.run/zvE1
     semgrep.dev:
       rule:
+        r_id: 9117
+        rv_id: 109600
         rule_id: kxUkJ2
         version_id: zyTK80x
         url: https://semgrep.dev/playground/r/zyTK80x/go.lang.security.audit.crypto.ssl.ssl-v3-is-insecure
@@ -9028,6 +9573,8 @@ rules:
     shortlink: https://sg.run/px8N
     semgrep.dev:
       rule:
+        r_id: 9118
+        rv_id: 109601
         rule_id: wdUJYk
         version_id: pZT1y4r
         url: https://semgrep.dev/playground/r/pZT1y4r/go.lang.security.audit.crypto.tls.tls-with-insecure-cipher
@@ -9122,6 +9669,8 @@ rules:
     shortlink: https://sg.run/jREA
     semgrep.dev:
       rule:
+        r_id: 9121
+        rv_id: 109604
         rule_id: eqU8B3
         version_id: jQTgY4k
         url: https://semgrep.dev/playground/r/jQTgY4k/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-DES
@@ -9168,6 +9717,8 @@ rules:
     shortlink: https://sg.run/2xB5
     semgrep.dev:
       rule:
+        r_id: 9119
+        rv_id: 258075
         rule_id: x8Un6q
         version_id: 1QTbO72
         url: https://semgrep.dev/playground/r/1QTbO72/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
@@ -9213,6 +9764,8 @@ rules:
     shortlink: https://sg.run/1ZAD
     semgrep.dev:
       rule:
+        r_id: 9122
+        rv_id: 109605
         rule_id: v8Unl0
         version_id: 1QTOYRO
         url: https://semgrep.dev/playground/r/1QTOYRO/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-rc4
@@ -9253,6 +9806,8 @@ rules:
     shortlink: https://sg.run/XBYA
     semgrep.dev:
       rule:
+        r_id: 9120
+        rv_id: 258076
         rule_id: OrU31O
         version_id: 9lTod53
         url: https://semgrep.dev/playground/r/9lTod53/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
@@ -9305,6 +9860,8 @@ rules:
     shortlink: https://sg.run/4eOE
     semgrep.dev:
       rule:
+        r_id: 14688
+        rv_id: 109612
         rule_id: 4bU1Wj
         version_id: w8T9nPl
         url: https://semgrep.dev/playground/r/w8T9nPl/go.lang.security.audit.md5-used-as-password.md5-used-as-password
@@ -9360,6 +9917,8 @@ rules:
     shortlink: https://sg.run/b73e
     semgrep.dev:
       rule:
+        r_id: 9126
+        rv_id: 109614
         rule_id: EwU2Z6
         version_id: O9TNOqv
         url: https://semgrep.dev/playground/r/O9TNOqv/go.lang.security.audit.net.cookie-missing-httponly.cookie-missing-httponly
@@ -9409,6 +9968,8 @@ rules:
     shortlink: https://sg.run/N4G7
     semgrep.dev:
       rule:
+        r_id: 9127
+        rv_id: 109615
         rule_id: 7KUQ8X
         version_id: e1T01o9
         url: https://semgrep.dev/playground/r/e1T01o9/go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
@@ -9447,6 +10008,8 @@ rules:
     shortlink: https://sg.run/kXEK
     semgrep.dev:
       rule:
+        r_id: 9128
+        rv_id: 109616
         rule_id: L1Uyjp
         version_id: vdTYNwN
         url: https://semgrep.dev/playground/r/vdTYNwN/go.lang.security.audit.net.dynamic-httptrace-clienttrace.dynamic-httptrace-clienttrace
@@ -9518,6 +10081,8 @@ rules:
     shortlink: https://sg.run/4R8x
     semgrep.dev:
       rule:
+        r_id: 21300
+        rv_id: 109618
         rule_id: 5rU9JO
         version_id: ZRTQN9K
         url: https://semgrep.dev/playground/r/ZRTQN9K/go.lang.security.audit.net.fs-directory-listing.fs-directory-listing
@@ -9596,6 +10161,8 @@ rules:
     shortlink: https://sg.run/Zvon
     semgrep.dev:
       rule:
+        r_id: 9135
+        rv_id: 109624
         rule_id: JDUyXB
         version_id: gET3xR5
         url: https://semgrep.dev/playground/r/gET3xR5/go.lang.security.audit.net.wip-xss-using-responsewriter-and-printf.wip-xss-using-responsewriter-and-printf
@@ -9671,6 +10238,8 @@ rules:
     shortlink: https://sg.run/YgOX
     semgrep.dev:
       rule:
+        r_id: 10258
+        rv_id: 109626
         rule_id: YGUrnQ
         version_id: 3ZTkQGg
         url: https://semgrep.dev/playground/r/3ZTkQGg/go.lang.security.audit.sqli.gosql-sqli.gosql-sqli
@@ -9770,6 +10339,8 @@ rules:
     shortlink: https://sg.run/6rA6
     semgrep.dev:
       rule:
+        r_id: 10259
+        rv_id: 109627
         rule_id: 6JUqQ1
         version_id: 44TRlLK
         url: https://semgrep.dev/playground/r/44TRlLK/go.lang.security.audit.sqli.pg-orm-sqli.pg-orm-sqli
@@ -9810,6 +10381,8 @@ rules:
     shortlink: https://sg.run/Al94
     semgrep.dev:
       rule:
+        r_id: 10294
+        rv_id: 109628
         rule_id: AbUWXY
         version_id: PkTJ1lw
         url: https://semgrep.dev/playground/r/PkTJ1lw/go.lang.security.audit.sqli.pg-sqli.pg-sqli
@@ -9884,6 +10457,8 @@ rules:
     shortlink: https://sg.run/okKN
     semgrep.dev:
       rule:
+        r_id: 10260
+        rv_id: 109629
         rule_id: oqUz92
         version_id: JdTNpBA
         url: https://semgrep.dev/playground/r/JdTNpBA/go.lang.security.audit.sqli.pgx-sqli.pgx-sqli
@@ -9993,6 +10568,8 @@ rules:
     shortlink: https://sg.run/ZKzw
     semgrep.dev:
       rule:
+        r_id: 18235
+        rv_id: 109643
         rule_id: qNUQJe
         version_id: o5Tgl30
         url: https://semgrep.dev/playground/r/o5Tgl30/go.lang.security.filepath-clean-misuse.filepath-clean-misuse
@@ -10032,6 +10609,8 @@ rules:
     shortlink: https://sg.run/2ZW45
     semgrep.dev:
       rule:
+        r_id: 113619
+        rv_id: 254642
         rule_id: DbU6RlN
         version_id: 9lTeD84
         url: https://semgrep.dev/playground/r/9lTeD84/go.lang.security.injection.open-redirect.open-redirect
@@ -10101,6 +10680,8 @@ rules:
     shortlink: https://sg.run/3r1G
     semgrep.dev:
       rule:
+        r_id: 14443
+        rv_id: 109644
         rule_id: PeUonQ
         version_id: zyTK8wx
         url: https://semgrep.dev/playground/r/zyTK8wx/go.lang.security.injection.raw-html-format.raw-html-format
@@ -10166,6 +10747,8 @@ rules:
     shortlink: https://sg.run/PbEq
     semgrep.dev:
       rule:
+        r_id: 14689
+        rv_id: 109645
         rule_id: PeUoqy
         version_id: pZT1ydr
         url: https://semgrep.dev/playground/r/pZT1ydr/go.lang.security.injection.tainted-sql-string.tainted-sql-string
@@ -10253,6 +10836,8 @@ rules:
     shortlink: https://sg.run/5DjW
     semgrep.dev:
       rule:
+        r_id: 14391
+        rv_id: 254643
         rule_id: AbUQLr
         version_id: yeT3wYO
         url: https://semgrep.dev/playground/r/yeT3wYO/go.lang.security.injection.tainted-url-host.tainted-url-host
@@ -10330,6 +10915,8 @@ rules:
     shortlink: https://sg.run/RA5q
     semgrep.dev:
       rule:
+        r_id: 39193
+        rv_id: 109656
         rule_id: AbUnNo
         version_id: w8T9nEl
         url: https://semgrep.dev/playground/r/w8T9nEl/html.security.plaintext-http-link.plaintext-http-link
@@ -10389,6 +10976,8 @@ rules:
     shortlink: https://sg.run/eNGZ
     semgrep.dev:
       rule:
+        r_id: 60632
+        rv_id: 109664
         rule_id: v8Ul0r
         version_id: ExTjNle
         url: https://semgrep.dev/playground/r/ExTjNle/java.android.security.exported_activity.exported_activity
@@ -10432,6 +11021,8 @@ rules:
     shortlink: https://sg.run/EBYN
     semgrep.dev:
       rule:
+        r_id: 18237
+        rv_id: 109665
         rule_id: YGUl4z
         version_id: 7ZTgoGZ
         url: https://semgrep.dev/playground/r/7ZTgoGZ/java.aws-lambda.security.tainted-sql-string.tainted-sql-string
@@ -10547,6 +11138,8 @@ rules:
     shortlink: https://sg.run/7942
     semgrep.dev:
       rule:
+        r_id: 18238
+        rv_id: 109666
         rule_id: 6JUDWk
         version_id: LjTqQnB
         url: https://semgrep.dev/playground/r/LjTqQnB/java.aws-lambda.security.tainted-sqli.tainted-sqli
@@ -10579,6 +11172,8 @@ rules:
     shortlink: https://sg.run/Bk95
     semgrep.dev:
       rule:
+        r_id: 9151
+        rv_id: 109667
         rule_id: pKUOE9
         version_id: 8KTQ96B
         url: https://semgrep.dev/playground/r/8KTQ96B/java.java-jwt.security.audit.jwt-decode-without-verify.java-jwt-decode-without-verify
@@ -10631,6 +11226,8 @@ rules:
     shortlink: https://sg.run/RoDK
     semgrep.dev:
       rule:
+        r_id: 9149
+        rv_id: 109668
         rule_id: oqUeAn
         version_id: gET3xz5
         url: https://semgrep.dev/playground/r/gET3xz5/java.java-jwt.security.jwt-hardcode.java-jwt-hardcoded-secret
@@ -10692,6 +11289,8 @@ rules:
     shortlink: https://sg.run/Av14
     semgrep.dev:
       rule:
+        r_id: 9150
+        rv_id: 109669
         rule_id: zdUkzR
         version_id: QkTW05B
         url: https://semgrep.dev/playground/r/QkTW05B/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg
@@ -10745,6 +11344,8 @@ rules:
     shortlink: https://sg.run/DoWj
     semgrep.dev:
       rule:
+        r_id: 9152
+        rv_id: 109672
         rule_id: 2ZUb9l
         version_id: PkTJ19w
         url: https://semgrep.dev/playground/r/PkTJ19w/java.jax-rs.security.jax-rs-path-traversal.jax-rs-path-traversal
@@ -10826,6 +11427,8 @@ rules:
     shortlink: https://sg.run/W8kA
     semgrep.dev:
       rule:
+        r_id: 9153
+        rv_id: 109674
         rule_id: X5U8rQ
         version_id: 5PTdAQ2
         url: https://semgrep.dev/playground/r/5PTdAQ2/java.jboss.security.session_sqli.find-sql-string-concatenation
@@ -10856,6 +11459,8 @@ rules:
     shortlink: https://sg.run/wek0
     semgrep.dev:
       rule:
+        r_id: 9173
+        rv_id: 109689
         rule_id: 8GUjwW
         version_id: RGTDk8b
         url: https://semgrep.dev/playground/r/RGTDk8b/java.lang.security.audit.crlf-injection-logs.crlf-injection-logs
@@ -10956,6 +11561,8 @@ rules:
     shortlink: https://sg.run/5Q73
     semgrep.dev:
       rule:
+        r_id: 9191
+        rv_id: 109690
         rule_id: PeUZNg
         version_id: A8T95KY
         url: https://semgrep.dev/playground/r/A8T95KY/java.lang.security.audit.crypto.des-is-deprecated.des-is-deprecated
@@ -11007,6 +11614,8 @@ rules:
     shortlink: https://sg.run/Geqn
     semgrep.dev:
       rule:
+        r_id: 9192
+        rv_id: 109691
         rule_id: JDUy8J
         version_id: BjTXrl2
         url: https://semgrep.dev/playground/r/BjTXrl2/java.lang.security.audit.crypto.desede-is-deprecated.desede-is-deprecated
@@ -11050,6 +11659,8 @@ rules:
     shortlink: https://sg.run/Ro9K
     semgrep.dev:
       rule:
+        r_id: 9193
+        rv_id: 109692
         rule_id: 5rUOb6
         version_id: DkT6nJd
         url: https://semgrep.dev/playground/r/DkT6nJd/java.lang.security.audit.crypto.ecb-cipher.ecb-cipher
@@ -11093,6 +11704,8 @@ rules:
     shortlink: https://sg.run/Dww2
     semgrep.dev:
       rule:
+        r_id: 11908
+        rv_id: 109694
         rule_id: GdUZZ3
         version_id: 0bTLlBy
         url: https://semgrep.dev/playground/r/0bTLlBy/java.lang.security.audit.crypto.gcm-nonce-reuse.gcm-nonce-reuse
@@ -11140,6 +11753,8 @@ rules:
     shortlink: https://sg.run/AvA4
     semgrep.dev:
       rule:
+        r_id: 9194
+        rv_id: 109695
         rule_id: GdU7pw
         version_id: K3Tvjez
         url: https://semgrep.dev/playground/r/K3Tvjez/java.lang.security.audit.crypto.no-null-cipher.no-null-cipher
@@ -11183,6 +11798,8 @@ rules:
     shortlink: https://sg.run/BkB5
     semgrep.dev:
       rule:
+        r_id: 9195
+        rv_id: 109696
         rule_id: ReUgj1
         version_id: qkT2xGj
         url: https://semgrep.dev/playground/r/qkT2xGj/java.lang.security.audit.crypto.no-static-initialization-vector.no-static-initialization-vector
@@ -11242,6 +11859,8 @@ rules:
     shortlink: https://sg.run/DoOj
     semgrep.dev:
       rule:
+        r_id: 9196
+        rv_id: 109697
         rule_id: AbUzoj
         version_id: l4T4vbd
         url: https://semgrep.dev/playground/r/l4T4vbd/java.lang.security.audit.crypto.rsa-no-padding.rsa-no-padding
@@ -11284,6 +11903,8 @@ rules:
     shortlink: https://sg.run/W8zA
     semgrep.dev:
       rule:
+        r_id: 9197
+        rv_id: 109702
         rule_id: BYUN3X
         version_id: pZT1yob
         url: https://semgrep.dev/playground/r/pZT1yob/java.lang.security.audit.crypto.unencrypted-socket.unencrypted-socket
@@ -11325,6 +11946,8 @@ rules:
     shortlink: https://sg.run/dB2Y
     semgrep.dev:
       rule:
+        r_id: 48734
+        rv_id: 109703
         rule_id: WAU2yA
         version_id: 2KTzreY
         url: https://semgrep.dev/playground/r/2KTzreY/java.lang.security.audit.crypto.use-of-aes-ecb.use-of-aes-ecb
@@ -11364,6 +11987,8 @@ rules:
     shortlink: https://sg.run/ZE4n
     semgrep.dev:
       rule:
+        r_id: 48735
+        rv_id: 109704
         rule_id: 0oUR28
         version_id: X0TQxEx
         url: https://semgrep.dev/playground/r/X0TQxEx/java.lang.security.audit.crypto.use-of-blowfish.use-of-blowfish
@@ -11433,6 +12058,8 @@ rules:
     shortlink: https://sg.run/nzKO
     semgrep.dev:
       rule:
+        r_id: 48736
+        rv_id: 109705
         rule_id: KxUB7Z
         version_id: jQTgYWy
         url: https://semgrep.dev/playground/r/jQTgYWy/java.lang.security.audit.crypto.use-of-default-aes.use-of-default-aes
@@ -11478,6 +12105,8 @@ rules:
     shortlink: https://sg.run/AWL2
     semgrep.dev:
       rule:
+        r_id: 39194
+        rv_id: 109706
         rule_id: BYUGK0
         version_id: 1QTOYBy
         url: https://semgrep.dev/playground/r/1QTOYBy/java.lang.security.audit.crypto.use-of-md5-digest-utils.use-of-md5-digest-utils
@@ -11527,6 +12156,8 @@ rules:
     shortlink: https://sg.run/ryJn
     semgrep.dev:
       rule:
+        r_id: 17325
+        rv_id: 109707
         rule_id: KxU5lW
         version_id: 9lTdW2l
         url: https://semgrep.dev/playground/r/9lTdW2l/java.lang.security.audit.crypto.use-of-md5.use-of-md5
@@ -11570,6 +12201,8 @@ rules:
     shortlink: https://sg.run/EEvA
     semgrep.dev:
       rule:
+        r_id: 48737
+        rv_id: 109708
         rule_id: qNUzXG
         version_id: yeTR28q
         url: https://semgrep.dev/playground/r/yeTR28q/java.lang.security.audit.crypto.use-of-rc2.use-of-rc2
@@ -11609,6 +12242,8 @@ rules:
     shortlink: https://sg.run/7OYR
     semgrep.dev:
       rule:
+        r_id: 48738
+        rv_id: 109709
         rule_id: lBUw8k
         version_id: rxTyLql
         url: https://semgrep.dev/playground/r/rxTyLql/java.lang.security.audit.crypto.use-of-rc4.use-of-rc4
@@ -11659,6 +12294,8 @@ rules:
     shortlink: https://sg.run/bXNp
     semgrep.dev:
       rule:
+        r_id: 17326
+        rv_id: 109710
         rule_id: qNUWNn
         version_id: bZTb1rl
         url: https://semgrep.dev/playground/r/bZTb1rl/java.lang.security.audit.crypto.use-of-sha1.use-of-sha1
@@ -11708,6 +12345,8 @@ rules:
     shortlink: https://sg.run/4x6x
     semgrep.dev:
       rule:
+        r_id: 9200
+        rv_id: 109712
         rule_id: 0oU5P5
         version_id: kbTdxpZ
         url: https://semgrep.dev/playground/r/kbTdxpZ/java.lang.security.audit.crypto.weak-rsa.use-of-weak-rsa-key
@@ -11755,6 +12394,8 @@ rules:
     shortlink: https://sg.run/OPXp
     semgrep.dev:
       rule:
+        r_id: 9175
+        rv_id: 109715
         rule_id: QrUzxR
         version_id: O9TNOzA
         url: https://semgrep.dev/playground/r/O9TNOzA/java.lang.security.audit.formatted-sql-string.formatted-sql-string
@@ -11843,6 +12484,8 @@ rules:
     shortlink: https://sg.run/eL0l
     semgrep.dev:
       rule:
+        r_id: 9176
+        rv_id: 109716
         rule_id: 3qUPyK
         version_id: e1T015P
         url: https://semgrep.dev/playground/r/e1T015P/java.lang.security.audit.http-response-splitting.http-response-splitting
@@ -11894,6 +12537,8 @@ rules:
     shortlink: https://sg.run/vzN4
     semgrep.dev:
       rule:
+        r_id: 9177
+        rv_id: 109717
         rule_id: 4bUkrW
         version_id: vdTYNgx
         url: https://semgrep.dev/playground/r/vdTYNgx/java.lang.security.audit.insecure-smtp-connection.insecure-smtp-connection
@@ -11947,6 +12592,8 @@ rules:
     shortlink: https://sg.run/JxEQ
     semgrep.dev:
       rule:
+        r_id: 14690
+        rv_id: 109722
         rule_id: JDULAW
         version_id: 7ZTgod0
         url: https://semgrep.dev/playground/r/7ZTgod0/java.lang.security.audit.md5-used-as-password.md5-used-as-password
@@ -11999,6 +12646,8 @@ rules:
     shortlink: https://sg.run/Lg56
     semgrep.dev:
       rule:
+        r_id: 18239
+        rv_id: 109732
         rule_id: oqUBJG
         version_id: GxTv6yG
         url: https://semgrep.dev/playground/r/GxTv6yG/java.lang.security.audit.sqli.tainted-sql-from-http-request.tainted-sql-from-http-request
@@ -12109,6 +12758,8 @@ rules:
     shortlink: https://sg.run/8zPN
     semgrep.dev:
       rule:
+        r_id: 18240
+        rv_id: 109735
         rule_id: zdUWrg
         version_id: BjTXr52
         url: https://semgrep.dev/playground/r/BjTXr52/java.lang.security.audit.tainted-cmd-from-http-request.tainted-cmd-from-http-request
@@ -12163,6 +12814,8 @@ rules:
     shortlink: https://sg.run/EJAB
     semgrep.dev:
       rule:
+        r_id: 70981
+        rv_id: 109736
         rule_id: nJULjy
         version_id: DkT6nld
         url: https://semgrep.dev/playground/r/DkT6nld/java.lang.security.audit.tainted-env-from-http-request.tainted-env-from-http-request
@@ -12196,6 +12849,8 @@ rules:
     shortlink: https://sg.run/gRg0
     semgrep.dev:
       rule:
+        r_id: 18241
+        rv_id: 109737
         rule_id: pKUXAv
         version_id: WrTWQBW
         url: https://semgrep.dev/playground/r/WrTWQBW/java.lang.security.audit.tainted-ldapi-from-http-request.tainted-ldapi-from-http-request
@@ -12290,6 +12945,8 @@ rules:
     shortlink: https://sg.run/QbDZ
     semgrep.dev:
       rule:
+        r_id: 18242
+        rv_id: 109738
         rule_id: 2ZU7Eo
         version_id: 0bTLlNy
         url: https://semgrep.dev/playground/r/0bTLlNy/java.lang.security.audit.tainted-session-from-http-request.tainted-session-from-http-request
@@ -12335,6 +12992,8 @@ rules:
     shortlink: https://sg.run/3BvK
     semgrep.dev:
       rule:
+        r_id: 18243
+        rv_id: 109739
         rule_id: X5U5nj
         version_id: K3TvjEz
         url: https://semgrep.dev/playground/r/K3TvjEz/java.lang.security.audit.tainted-xpath-from-http-request.tainted-xpath-from-http-request
@@ -12371,6 +13030,8 @@ rules:
     shortlink: https://sg.run/Q51P
     semgrep.dev:
       rule:
+        r_id: 9186
+        rv_id: 109741
         rule_id: WAUo0p
         version_id: l4T4vkd
         url: https://semgrep.dev/playground/r/l4T4vkd/java.lang.security.audit.unvalidated-redirect.unvalidated-redirect
@@ -12502,6 +13163,8 @@ rules:
     shortlink: https://sg.run/3x7b
     semgrep.dev:
       rule:
+        r_id: 9187
+        rv_id: 109742
         rule_id: 0oU5j3
         version_id: YDTp2WQ
         url: https://semgrep.dev/playground/r/YDTp2WQ/java.lang.security.audit.url-rewriting.url-rewriting
@@ -12602,6 +13265,8 @@ rules:
     shortlink: https://sg.run/4Dv5
     semgrep.dev:
       rule:
+        r_id: 18244
+        rv_id: 109751
         rule_id: j2UrJ8
         version_id: 9lTdWrl
         url: https://semgrep.dev/playground/r/9lTdWrl/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-false.documentbuilderfactory-disallow-doctype-decl-false
@@ -12685,6 +13350,8 @@ rules:
     shortlink: https://sg.run/PYBz
     semgrep.dev:
       rule:
+        r_id: 18245
+        rv_id: 109752
         rule_id: 10UPQB
         version_id: yeTR2lq
         url: https://semgrep.dev/playground/r/yeTR2lq/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing
@@ -12846,6 +13513,8 @@ rules:
     shortlink: https://sg.run/JgPy
     semgrep.dev:
       rule:
+        r_id: 18246
+        rv_id: 109753
         rule_id: 9AUJ6r
         version_id: rxTyLdl
         url: https://semgrep.dev/playground/r/rxTyLdl/java.lang.security.audit.xxe.documentbuilderfactory-external-general-entities-true.documentbuilderfactory-external-general-entities-true
@@ -12894,6 +13563,8 @@ rules:
     shortlink: https://sg.run/5Lv0
     semgrep.dev:
       rule:
+        r_id: 18247
+        rv_id: 109754
         rule_id: yyUNeo
         version_id: bZTb1pl
         url: https://semgrep.dev/playground/r/bZTb1pl/java.lang.security.audit.xxe.documentbuilderfactory-external-parameter-entities-true.documentbuilderfactory-external-parameter-entities-true
@@ -12943,6 +13614,8 @@ rules:
     shortlink: https://sg.run/Gj32
     semgrep.dev:
       rule:
+        r_id: 59048
+        rv_id: 109755
         rule_id: j2Udpk
         version_id: NdT3dPr
         url: https://semgrep.dev/playground/r/NdT3dPr/java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing
@@ -13107,6 +13780,8 @@ rules:
     shortlink: https://sg.run/1wyQ
     semgrep.dev:
       rule:
+        r_id: 59622
+        rv_id: 109756
         rule_id: v8UeQ1
         version_id: kbTdxNZ
         url: https://semgrep.dev/playground/r/kbTdxNZ/java.lang.security.audit.xxe.transformerfactory-dtds-not-disabled.transformerfactory-dtds-not-disabled
@@ -13288,6 +13963,8 @@ rules:
     shortlink: https://sg.run/oxXN
     semgrep.dev:
       rule:
+        r_id: 9160
+        rv_id: 109758
         rule_id: NbUk7X
         version_id: xyTKZP1
         url: https://semgrep.dev/playground/r/xyTKZP1/java.lang.security.httpservlet-path-traversal.httpservlet-path-traversal
@@ -13362,6 +14039,8 @@ rules:
     shortlink: https://sg.run/zvO1
     semgrep.dev:
       rule:
+        r_id: 9161
+        rv_id: 109759
         rule_id: kxUk12
         version_id: O9TNOwA
         url: https://semgrep.dev/playground/r/O9TNOwA/java.lang.security.insecure-jms-deserialization.insecure-jms-deserialization
@@ -13416,6 +14095,8 @@ rules:
     shortlink: https://sg.run/pxjN
     semgrep.dev:
       rule:
+        r_id: 9162
+        rv_id: 109761
         rule_id: wdUJOk
         version_id: vdTYNex
         url: https://semgrep.dev/playground/r/vdTYNex/java.lang.security.servletresponse-writer-xss.servletresponse-writer-xss
@@ -13467,9 +14148,11 @@ rules:
     shortlink: https://sg.run/XBwA
     semgrep.dev:
       rule:
+        r_id: 9164
+        rv_id: 745880
         rule_id: OrU35O
-        version_id: nWTxPXE
-        url: https://semgrep.dev/playground/r/nWTxPXE/java.lang.security.xmlinputfactory-possible-xxe.xmlinputfactory-possible-xxe
+        version_id: 0bTrP1z
+        url: https://semgrep.dev/playground/r/0bTrP1z/java.lang.security.xmlinputfactory-possible-xxe.xmlinputfactory-possible-xxe
         origin: community
   message: XML external entities are not explicitly disabled for this XMLInputFactory.
     This could be vulnerable to XML external entity vulnerabilities. Explicitly disable
@@ -13477,20 +14160,32 @@ rules:
     false.
   patterns:
   - pattern-not-inside: |
-      $RETURNTYPE $METHOD(...) {
+      $METHOD(...) {
         ...
         $XMLFACTORY.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
         ...
       }
   - pattern-not-inside: |
-      $RETURNTYPE $METHOD(...) {
+      $METHOD(...) {
         ...
-        $XMLFACTORY.setProperty(java.xml.stream.XMLFactoryInput.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        $XMLFACTORY.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        ...
+      }
+  - pattern-not-inside: |
+      $METHOD(...) {
+        ...
+        $XMLFACTORY.setProperty("javax.xml.stream.isSupportingExternalEntities", Boolean.FALSE);
+        ...
+      }
+  - pattern-not-inside: |
+      $METHOD(...) {
+        ...
+        $XMLFACTORY.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         ...
       }
   - pattern-either:
-    - pattern: "$XMLFACTORY = $W.newFactory(...);"
-    - pattern: "$XMLFACTORY = new XMLInputFactory(...);"
+    - pattern: javax.xml.stream.XMLInputFactory.newFactory(...)
+    - pattern: new XMLInputFactory(...)
   languages:
   - java
 - id: java.spring.security.audit.spring-actuator-fully-enabled-yaml.spring-actuator-fully-enabled-yaml
@@ -13540,6 +14235,8 @@ rules:
     shortlink: https://sg.run/1Bzw
     semgrep.dev:
       rule:
+        r_id: 29422
+        rv_id: 109771
         rule_id: eqUerQ
         version_id: 3ZTkQqw
         url: https://semgrep.dev/playground/r/3ZTkQqw/java.spring.security.audit.spring-actuator-fully-enabled-yaml.spring-actuator-fully-enabled-yaml
@@ -13582,6 +14279,8 @@ rules:
     shortlink: https://sg.run/L0vY
     semgrep.dev:
       rule:
+        r_id: 10439
+        rv_id: 109772
         rule_id: EwU4vg
         version_id: 44TRl4j
         url: https://semgrep.dev/playground/r/44TRl4j/java.spring.security.audit.spring-actuator-fully-enabled.spring-actuator-fully-enabled
@@ -13636,6 +14335,8 @@ rules:
     shortlink: https://sg.run/JzKQ
     semgrep.dev:
       rule:
+        r_id: 32290
+        rv_id: 109773
         rule_id: kxUWpX
         version_id: PkTJ14y
         url: https://semgrep.dev/playground/r/PkTJ14y/java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
@@ -13679,6 +14380,8 @@ rules:
     shortlink: https://sg.run/5g23
     semgrep.dev:
       rule:
+        r_id: 32291
+        rv_id: 109774
         rule_id: wdUWrZ
         version_id: JdTNp0W
         url: https://semgrep.dev/playground/r/JdTNp0W/java.spring.security.audit.spring-actuator-non-health-enabled.spring-actuator-dangerous-endpoints-enabled
@@ -13759,6 +14462,8 @@ rules:
     shortlink: https://sg.run/1Z3x
     semgrep.dev:
       rule:
+        r_id: 9222
+        rv_id: 109777
         rule_id: eqU8N2
         version_id: RGTDkJb
         url: https://semgrep.dev/playground/r/RGTDkJb/java.spring.security.audit.spring-sqli.spring-sqli
@@ -13789,6 +14494,8 @@ rules:
     shortlink: https://sg.run/9oXz
     semgrep.dev:
       rule:
+        r_id: 9223
+        rv_id: 109778
         rule_id: v8Un7w
         version_id: A8T95DY
         url: https://semgrep.dev/playground/r/A8T95DY/java.spring.security.audit.spring-unvalidated-redirect.spring-unvalidated-redirect
@@ -13858,6 +14565,8 @@ rules:
     shortlink: https://sg.run/x9o0
     semgrep.dev:
       rule:
+        r_id: 22074
+        rv_id: 109780
         rule_id: lBUxok
         version_id: DkT6nEd
         url: https://semgrep.dev/playground/r/DkT6nEd/java.spring.security.injection.tainted-file-path.tainted-file-path
@@ -13945,6 +14654,8 @@ rules:
     shortlink: https://sg.run/ObdR
     semgrep.dev:
       rule:
+        r_id: 22075
+        rv_id: 109781
         rule_id: YGUvkL
         version_id: WrTWQLW
         url: https://semgrep.dev/playground/r/WrTWQLW/java.spring.security.injection.tainted-html-string.tainted-html-string
@@ -14063,6 +14774,8 @@ rules:
     shortlink: https://sg.run/9rzz
     semgrep.dev:
       rule:
+        r_id: 14767
+        rv_id: 109782
         rule_id: 10UdRR
         version_id: 0bTLlny
         url: https://semgrep.dev/playground/r/0bTLlny/java.spring.security.injection.tainted-sql-string.tainted-sql-string
@@ -14235,6 +14948,8 @@ rules:
     shortlink: https://sg.run/epY0
     semgrep.dev:
       rule:
+        r_id: 22076
+        rv_id: 109783
         rule_id: 6JUxGN
         version_id: K3Tvjxz
         url: https://semgrep.dev/playground/r/K3Tvjxz/java.spring.security.injection.tainted-system-command.tainted-system-command
@@ -14278,6 +14993,8 @@ rules:
     shortlink: https://sg.run/vkYn
     semgrep.dev:
       rule:
+        r_id: 22077
+        rv_id: 109784
         rule_id: oqUZo8
         version_id: qkT2xDj
         url: https://semgrep.dev/playground/r/qkT2xDj/java.spring.security.injection.tainted-url-host.tainted-url-host
@@ -14365,6 +15082,8 @@ rules:
     shortlink: https://sg.run/ydnO
     semgrep.dev:
       rule:
+        r_id: 9224
+        rv_id: 109787
         rule_id: d8Ujdo
         version_id: JdTNpXL
         url: https://semgrep.dev/playground/r/JdTNpXL/javascript.angular.security.detect-angular-element-methods.detect-angular-element-methods
@@ -14440,6 +15159,8 @@ rules:
     shortlink: https://sg.run/5AQ0
     semgrep.dev:
       rule:
+        r_id: 21503
+        rv_id: 109788
         rule_id: GdUP71
         version_id: 5PTdAZp
         url: https://semgrep.dev/playground/r/5PTdAZp/javascript.angular.security.detect-angular-element-taint.detect-angular-element-taint
@@ -14531,6 +15252,8 @@ rules:
     shortlink: https://sg.run/N4DG
     semgrep.dev:
       rule:
+        r_id: 9227
+        rv_id: 109791
         rule_id: EwU20Z
         version_id: A8T95BJ
         url: https://semgrep.dev/playground/r/A8T95BJ/javascript.angular.security.detect-angular-sce-disabled.detect-angular-sce-disabled
@@ -14570,6 +15293,8 @@ rules:
     shortlink: https://sg.run/OPW2
     semgrep.dev:
       rule:
+        r_id: 9231
+        rv_id: 109795
         rule_id: gxU1QX
         version_id: 0bTLlno
         url: https://semgrep.dev/playground/r/0bTLlno/javascript.angular.security.detect-angular-trust-as-method.detect-angular-trust-as-method
@@ -14619,6 +15344,8 @@ rules:
     shortlink: https://sg.run/ALq4
     semgrep.dev:
       rule:
+        r_id: 20150
+        rv_id: 109800
         rule_id: DbU2X8
         version_id: 6xTvJB0
         url: https://semgrep.dev/playground/r/6xTvJB0/javascript.argon2.security.unsafe-argon2-config.unsafe-argon2-config
@@ -14675,6 +15402,8 @@ rules:
     shortlink: https://sg.run/Ggoq
     semgrep.dev:
       rule:
+        r_id: 18248
+        rv_id: 109802
         rule_id: r6UDNQ
         version_id: zyTK8z9
         url: https://semgrep.dev/playground/r/zyTK8z9/javascript.aws-lambda.security.detect-child-process.detect-child-process
@@ -14748,6 +15477,8 @@ rules:
     shortlink: https://sg.run/X1e4
     semgrep.dev:
       rule:
+        r_id: 21320
+        rv_id: 109803
         rule_id: 0oU1xk
         version_id: pZT1yER
         url: https://semgrep.dev/playground/r/pZT1yER/javascript.aws-lambda.security.dynamodb-request-object.dynamodb-request-object
@@ -14830,6 +15561,8 @@ rules:
     shortlink: https://sg.run/RgWq
     semgrep.dev:
       rule:
+        r_id: 18249
+        rv_id: 109804
         rule_id: bwUBlj
         version_id: 2KTzr8N
         url: https://semgrep.dev/playground/r/2KTzr8N/javascript.aws-lambda.security.knex-sqli.knex-sqli
@@ -14903,6 +15636,8 @@ rules:
     shortlink: https://sg.run/A502
     semgrep.dev:
       rule:
+        r_id: 18250
+        rv_id: 109805
         rule_id: NbUBJ2
         version_id: X0TQxRX
         url: https://semgrep.dev/playground/r/X0TQxRX/javascript.aws-lambda.security.mysql-sqli.mysql-sqli
@@ -14987,6 +15722,8 @@ rules:
     shortlink: https://sg.run/BGKA
     semgrep.dev:
       rule:
+        r_id: 18251
+        rv_id: 109806
         rule_id: kxU25P
         version_id: jQTgYP0
         url: https://semgrep.dev/playground/r/jQTgYP0/javascript.aws-lambda.security.pg-sqli.pg-sqli
@@ -15058,6 +15795,8 @@ rules:
     shortlink: https://sg.run/DAlP
     semgrep.dev:
       rule:
+        r_id: 18252
+        rv_id: 109807
         rule_id: wdUA5o
         version_id: 1QTOYGR
         url: https://semgrep.dev/playground/r/1QTOYGR/javascript.aws-lambda.security.sequelize-sqli.sequelize-sqli
@@ -15124,6 +15863,8 @@ rules:
     shortlink: https://sg.run/WjY2
     semgrep.dev:
       rule:
+        r_id: 18253
+        rv_id: 109808
         rule_id: x8UNw5
         version_id: 9lTdWpv
         url: https://semgrep.dev/playground/r/9lTdWpv/javascript.aws-lambda.security.tainted-eval.tainted-eval
@@ -15187,6 +15928,8 @@ rules:
     shortlink: https://sg.run/0Gvj
     semgrep.dev:
       rule:
+        r_id: 18254
+        rv_id: 109809
         rule_id: OrUJBY
         version_id: yeTR2o8
         url: https://semgrep.dev/playground/r/yeTR2o8/javascript.aws-lambda.security.tainted-html-response.tainted-html-response
@@ -15249,6 +15992,8 @@ rules:
     shortlink: https://sg.run/Lgqr
     semgrep.dev:
       rule:
+        r_id: 18483
+        rv_id: 109810
         rule_id: PeUxwW
         version_id: rxTyLWd
         url: https://semgrep.dev/playground/r/rxTyLWd/javascript.aws-lambda.security.tainted-html-string.tainted-html-string
@@ -15330,6 +16075,8 @@ rules:
     shortlink: https://sg.run/KgJ5
     semgrep.dev:
       rule:
+        r_id: 18255
+        rv_id: 109811
         rule_id: eqUDqW
         version_id: bZTb1yy
         url: https://semgrep.dev/playground/r/bZTb1yy/javascript.aws-lambda.security.tainted-sql-string.tainted-sql-string
@@ -15405,6 +16152,8 @@ rules:
     shortlink: https://sg.run/q9w7
     semgrep.dev:
       rule:
+        r_id: 18256
+        rv_id: 109812
         rule_id: v8UOdZ
         version_id: NdT3d47
         url: https://semgrep.dev/playground/r/NdT3d47/javascript.aws-lambda.security.vm-runincontext-injection.vm-runincontext-injection
@@ -15478,6 +16227,8 @@ rules:
     shortlink: https://sg.run/ndnZ
     semgrep.dev:
       rule:
+        r_id: 9236
+        rv_id: 109813
         rule_id: JDUy9J
         version_id: kbTdxJn
         url: https://semgrep.dev/playground/r/kbTdxJn/javascript.bluebird.security.audit.tofastproperties-code-execution.tofastproperties-code-execution
@@ -15540,6 +16291,8 @@ rules:
     shortlink: https://sg.run/3xRe
     semgrep.dev:
       rule:
+        r_id: 9243
+        rv_id: 109821
         rule_id: WAUopl
         version_id: nWTxP37
         url: https://semgrep.dev/playground/r/nWTxP37/javascript.browser.security.open-redirect.js-open-redirect
@@ -15643,6 +16396,8 @@ rules:
     shortlink: https://sg.run/4xAx
     semgrep.dev:
       rule:
+        r_id: 9244
+        rv_id: 109822
         rule_id: 0oU5b5
         version_id: ExTjNZk
         url: https://semgrep.dev/playground/r/ExTjNZk/javascript.browser.security.raw-html-concat.raw-html-concat
@@ -15819,6 +16574,8 @@ rules:
     shortlink: https://sg.run/J9kj
     semgrep.dev:
       rule:
+        r_id: 9246
+        rv_id: 109825
         rule_id: qNUjnb
         version_id: 8KTQ9wQ
         url: https://semgrep.dev/playground/r/8KTQ9wQ/javascript.chrome-remote-interface.security.audit.chrome-remote-interface-compilescript-injection.chrome-remote-interface-compilescript-injection
@@ -15878,6 +16635,8 @@ rules:
     shortlink: https://sg.run/Nrrn
     semgrep.dev:
       rule:
+        r_id: 9927
+        rv_id: 109830
         rule_id: x8UWWg
         version_id: PkTJ1NB
         url: https://semgrep.dev/playground/r/PkTJ1NB/javascript.deno.security.audit.deno-dangerous-run.deno-dangerous-run
@@ -15940,6 +16699,8 @@ rules:
     shortlink: https://sg.run/DX2G
     semgrep.dev:
       rule:
+        r_id: 22552
+        rv_id: 109833
         rule_id: x8UqEb
         version_id: GxTv6pD
         url: https://semgrep.dev/playground/r/GxTv6pD/javascript.express.security.audit.express-check-directory-listing.express-check-directory-listing
@@ -16002,6 +16763,8 @@ rules:
     shortlink: https://sg.run/1Z5x
     semgrep.dev:
       rule:
+        r_id: 9266
+        rv_id: 109834
         rule_id: eqU8k2
         version_id: RGTDkj2
         url: https://semgrep.dev/playground/r/RGTDkj2/javascript.express.security.audit.express-cookie-settings.express-cookie-session-default-name
@@ -16059,6 +16822,8 @@ rules:
     shortlink: https://sg.run/rd41
     semgrep.dev:
       rule:
+        r_id: 9269
+        rv_id: 109837
         rule_id: ZqU5Pn
         version_id: DkT6nAY
         url: https://semgrep.dev/playground/r/DkT6nAY/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-domain
@@ -16133,6 +16898,8 @@ rules:
     shortlink: https://sg.run/N4eG
     semgrep.dev:
       rule:
+        r_id: 9271
+        rv_id: 109839
         rule_id: EwU2DZ
         version_id: 0bTLljo
         url: https://semgrep.dev/playground/r/0bTLljo/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-expires
@@ -16208,6 +16975,8 @@ rules:
     shortlink: https://sg.run/ydBO
     semgrep.dev:
       rule:
+        r_id: 9268
+        rv_id: 109836
         rule_id: d8UjGo
         version_id: BjTXr6r
         url: https://semgrep.dev/playground/r/BjTXr6r/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-httponly
@@ -16283,6 +17052,8 @@ rules:
     shortlink: https://sg.run/b7pd
     semgrep.dev:
       rule:
+        r_id: 9270
+        rv_id: 109838
         rule_id: nJUz4X
         version_id: WrTWQ0q
         url: https://semgrep.dev/playground/r/WrTWQ0q/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-path
@@ -16357,6 +17128,8 @@ rules:
     shortlink: https://sg.run/9oKz
     semgrep.dev:
       rule:
+        r_id: 9267
+        rv_id: 109835
         rule_id: v8Unzw
         version_id: A8T95wJ
         url: https://semgrep.dev/playground/r/A8T95wJ/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-secure
@@ -16432,6 +17205,8 @@ rules:
     shortlink: https://sg.run/kXNo
     semgrep.dev:
       rule:
+        r_id: 9272
+        rv_id: 109841
         rule_id: 7KUQ9k
         version_id: qkT2x3L
         url: https://semgrep.dev/playground/r/qkT2x3L/javascript.express.security.audit.express-jwt-not-revoked.express-jwt-not-revoked
@@ -16483,6 +17258,8 @@ rules:
     shortlink: https://sg.run/Z75x
     semgrep.dev:
       rule:
+        r_id: 22079
+        rv_id: 109842
         rule_id: pKUNeD
         version_id: l4T4vG1
         url: https://semgrep.dev/playground/r/l4T4vG1/javascript.express.security.audit.express-libxml-noent.express-libxml-noent
@@ -16575,6 +17352,8 @@ rules:
     shortlink: https://sg.run/EpoP
     semgrep.dev:
       rule:
+        r_id: 22081
+        rv_id: 109844
         rule_id: X5ULkq
         version_id: 6xTvJN0
         url: https://semgrep.dev/playground/r/6xTvJN0/javascript.express.security.audit.express-open-redirect.express-open-redirect
@@ -16695,6 +17474,8 @@ rules:
     shortlink: https://sg.run/weRn
     semgrep.dev:
       rule:
+        r_id: 9273
+        rv_id: 109845
         rule_id: L1Uyb8
         version_id: o5Tgl6W
         url: https://semgrep.dev/playground/r/o5Tgl6W/javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal
@@ -16798,6 +17579,8 @@ rules:
     shortlink: https://sg.run/7DJk
     semgrep.dev:
       rule:
+        r_id: 22082
+        rv_id: 109846
         rule_id: j2UzDx
         version_id: zyTK8E9
         url: https://semgrep.dev/playground/r/zyTK8E9/javascript.express.security.audit.express-res-sendfile.express-res-sendfile
@@ -16890,6 +17673,8 @@ rules:
     shortlink: https://sg.run/LYvG
     semgrep.dev:
       rule:
+        r_id: 22083
+        rv_id: 109847
         rule_id: 10Uo39
         version_id: pZT1y5R
         url: https://semgrep.dev/playground/r/pZT1y5R/javascript.express.security.audit.express-session-hardcoded-secret.express-session-hardcoded-secret
@@ -16953,6 +17738,8 @@ rules:
     shortlink: https://sg.run/0PNw
     semgrep.dev:
       rule:
+        r_id: 22554
+        rv_id: 109848
         rule_id: eqU9l2
         version_id: 2KTzr9N
         url: https://semgrep.dev/playground/r/2KTzr9N/javascript.express.security.audit.express-ssrf.express-ssrf
@@ -17149,6 +17936,8 @@ rules:
     shortlink: https://sg.run/8W5j
     semgrep.dev:
       rule:
+        r_id: 22084
+        rv_id: 109849
         rule_id: 9AUyqj
         version_id: X0TQxrX
         url: https://semgrep.dev/playground/r/X0TQxrX/javascript.express.security.audit.express-third-party-object-deserialization.express-third-party-object-deserialization
@@ -17242,6 +18031,8 @@ rules:
     shortlink: https://sg.run/x1AA
     semgrep.dev:
       rule:
+        r_id: 9274
+        rv_id: 109850
         rule_id: 8GUjkk
         version_id: jQTgYo0
         url: https://semgrep.dev/playground/r/jQTgYo0/javascript.express.security.audit.express-xml2json-xxe-event.express-xml2json-xxe-event
@@ -17320,6 +18111,8 @@ rules:
     shortlink: https://sg.run/Z4gn
     semgrep.dev:
       rule:
+        r_id: 13579
+        rv_id: 109852
         rule_id: JDUL1B
         version_id: 9lTdWxv
         url: https://semgrep.dev/playground/r/9lTdWxv/javascript.express.security.audit.remote-property-injection.remote-property-injection
@@ -17408,6 +18201,8 @@ rules:
     shortlink: https://sg.run/eLjd
     semgrep.dev:
       rule:
+        r_id: 9276
+        rv_id: 109853
         rule_id: QrUzrq
         version_id: yeTR2K8
         url: https://semgrep.dev/playground/r/yeTR2K8/javascript.express.security.audit.res-render-injection.res-render-injection
@@ -17486,9 +18281,11 @@ rules:
     shortlink: https://sg.run/vzGl
     semgrep.dev:
       rule:
+        r_id: 9277
+        rv_id: 751090
         rule_id: 3qUPA1
-        version_id: rxTyLQd
-        url: https://semgrep.dev/playground/r/rxTyLQd/javascript.express.security.audit.xss.direct-response-write.direct-response-write
+        version_id: qkTWwqp
+        url: https://semgrep.dev/playground/r/qkTWwqp/javascript.express.security.audit.xss.direct-response-write.direct-response-write
         origin: community
   languages:
   - javascript
@@ -17575,6 +18372,7 @@ rules:
       - pattern: "$RES.send($ARG)"
     - pattern-not: "$RES. ... .set('...'). ... .send($ARG)"
     - pattern-not: "$RES. ... .type('...'). ... .send($ARG)"
+    - pattern-not-inside: "$RES.$METHOD({ ... })"
     - focus-metavariable: "$ARG"
   pattern-sanitizers:
   - patterns:
@@ -17722,6 +18520,8 @@ rules:
     shortlink: https://sg.run/nKXO
     semgrep.dev:
       rule:
+        r_id: 13580
+        rv_id: 109867
         rule_id: 5rULJQ
         version_id: 7ZTgokN
         url: https://semgrep.dev/playground/r/7ZTgokN/javascript.express.security.cors-misconfiguration.cors-misconfiguration
@@ -17810,6 +18610,8 @@ rules:
     shortlink: https://sg.run/BkXx
     semgrep.dev:
       rule:
+        r_id: 9251
+        rv_id: 109869
         rule_id: zdUkJl
         version_id: 8KTQ98Q
         url: https://semgrep.dev/playground/r/8KTQ98Q/javascript.express.security.express-expat-xxe.express-expat-xxe
@@ -17914,6 +18716,8 @@ rules:
     shortlink: https://sg.run/b49v
     semgrep.dev:
       rule:
+        r_id: 19226
+        rv_id: 109870
         rule_id: EwUr9k
         version_id: gET3xQ6
         url: https://semgrep.dev/playground/r/gET3xQ6/javascript.express.security.express-insecure-template-usage.express-insecure-template-usage
@@ -18085,6 +18889,8 @@ rules:
     shortlink: https://sg.run/W8BL
     semgrep.dev:
       rule:
+        r_id: 9253
+        rv_id: 109872
         rule_id: 2ZUbx3
         version_id: 3ZTkQ0P
         url: https://semgrep.dev/playground/r/3ZTkQ0P/javascript.express.security.express-phantom-injection.express-phantom-injection
@@ -18168,6 +18974,8 @@ rules:
     shortlink: https://sg.run/0QJB
     semgrep.dev:
       rule:
+        r_id: 9254
+        rv_id: 109873
         rule_id: X5U8Nz
         version_id: 44TRl0z
         url: https://semgrep.dev/playground/r/44TRl0z/javascript.express.security.express-puppeteer-injection.express-puppeteer-injection
@@ -18252,6 +19060,8 @@ rules:
     shortlink: https://sg.run/KlwL
     semgrep.dev:
       rule:
+        r_id: 9255
+        rv_id: 109874
         rule_id: j2UvXB
         version_id: PkTJ1PB
         url: https://semgrep.dev/playground/r/PkTJ1PB/javascript.express.security.express-sandbox-injection.express-sandbox-code-injection
@@ -18332,6 +19142,8 @@ rules:
     shortlink: https://sg.run/jkqJ
     semgrep.dev:
       rule:
+        r_id: 12821
+        rv_id: 109875
         rule_id: DbUKPX
         version_id: JdTNp9L
         url: https://semgrep.dev/playground/r/JdTNp9L/javascript.express.security.express-vm-injection.express-vm-injection
@@ -18408,6 +19220,8 @@ rules:
     shortlink: https://sg.run/1GWv
     semgrep.dev:
       rule:
+        r_id: 12822
+        rv_id: 109876
         rule_id: WAUPXJ
         version_id: 5PTdAgp
         url: https://semgrep.dev/playground/r/5PTdAgp/javascript.express.security.express-vm2-injection.express-vm2-injection
@@ -18503,6 +19317,8 @@ rules:
     shortlink: https://sg.run/pxe0
     semgrep.dev:
       rule:
+        r_id: 9262
+        rv_id: 109877
         rule_id: kxUkl9
         version_id: GxTv6dD
         url: https://semgrep.dev/playground/r/GxTv6dD/javascript.express.security.express-wkhtml-injection.express-wkhtmltoimage-injection
@@ -18574,6 +19390,8 @@ rules:
     shortlink: https://sg.run/2xGq
     semgrep.dev:
       rule:
+        r_id: 9263
+        rv_id: 109878
         rule_id: wdUJxq
         version_id: RGTDk42
         url: https://semgrep.dev/playground/r/RGTDk42/javascript.express.security.express-wkhtml-injection.express-wkhtmltopdf-injection
@@ -18654,6 +19472,8 @@ rules:
     shortlink: https://sg.run/XBD4
     semgrep.dev:
       rule:
+        r_id: 9264
+        rv_id: 109879
         rule_id: x8Uneb
         version_id: A8T95oJ
         url: https://semgrep.dev/playground/r/A8T95oJ/javascript.express.security.express-xml2json-xxe.express-xml2json-xxe
@@ -18740,6 +19560,8 @@ rules:
     shortlink: https://sg.run/5DO3
     semgrep.dev:
       rule:
+        r_id: 14691
+        rv_id: 109880
         rule_id: 5rUL0X
         version_id: BjTXr3r
         url: https://semgrep.dev/playground/r/BjTXr3r/javascript.express.security.injection.raw-html-format.raw-html-format
@@ -18818,11 +19640,11 @@ rules:
     as Sequelize which will protect your queries.
   metadata:
     owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
+    - A01:2017 - Injection
     - A03:2021 - Injection
     cwe:
-    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
-      Scripting'')'
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
     references:
     - https://owasp.org/www-community/attacks/SQL_Injection
     category: security
@@ -18837,14 +19659,16 @@ rules:
     impact: MEDIUM
     confidence: MEDIUM
     vulnerability_class:
-    - Cross-Site-Scripting (XSS)
+    - SQL Injection
     source: https://semgrep.dev/r/javascript.express.security.injection.tainted-sql-string.tainted-sql-string
     shortlink: https://sg.run/66ZL
     semgrep.dev:
       rule:
+        r_id: 14715
+        rv_id: 751091
         rule_id: NbUNpr
-        version_id: DkT6nrY
-        url: https://semgrep.dev/playground/r/DkT6nrY/javascript.express.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: l4TWDPx
+        url: https://semgrep.dev/playground/r/l4TWDPx/javascript.express.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   languages:
   - javascript
@@ -18854,13 +19678,7 @@ rules:
   pattern-sources:
   - patterns:
     - pattern-either:
-      - pattern-inside: function ... ($REQ, $RES) {...}
-      - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
-      - pattern-inside: "$APP.$METHOD(..., function $FUNC($REQ, $RES) {...})"
-      - pattern-inside: "$APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})"
-    - metavariable-regex:
-        metavariable: "$METHOD"
-        regex: "^(get|post|put|head|delete|options)$"
+      - pattern-inside: function ... (...,$REQ, ...) {...}
     - pattern-either:
       - pattern: "$REQ.query"
       - pattern: "$REQ.body"
@@ -18869,10 +19687,8 @@ rules:
       - pattern: "$REQ.headers"
   - patterns:
     - pattern-either:
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
-          {...}
-      - pattern-inside: "({ $REQ }: Request,$RES: Response) => {...}\n"
+      - pattern-inside: "(...,{ $REQ }: Request,...) => {...}\n"
+      - pattern-inside: "(...,{ $REQ }: $EXPRESS.Request,...) => {...}\n"
     - focus-metavariable: "$REQ"
     - pattern-either:
       - pattern: params
@@ -18926,6 +19742,8 @@ rules:
     shortlink: https://sg.run/jRbl
     semgrep.dev:
       rule:
+        r_id: 9265
+        rv_id: 109882
         rule_id: OrU3WK
         version_id: WrTWQ4q
         url: https://semgrep.dev/playground/r/WrTWQ4q/javascript.express.security.require-request.require-request
@@ -18996,6 +19814,8 @@ rules:
     shortlink: https://sg.run/EvjA
     semgrep.dev:
       rule:
+        r_id: 13581
+        rv_id: 109883
         rule_id: GdUrLy
         version_id: 0bTLlPo
         url: https://semgrep.dev/playground/r/0bTLlPo/javascript.express.security.x-frame-options-misconfiguration.x-frame-options-misconfiguration
@@ -19085,6 +19905,8 @@ rules:
     shortlink: https://sg.run/Ro1g
     semgrep.dev:
       rule:
+        r_id: 9293
+        rv_id: 109889
         rule_id: JDUyRl
         version_id: 5PTdAgB
         url: https://semgrep.dev/playground/r/5PTdAgB/javascript.jose.security.jwt-hardcode.hardcoded-jwt-secret
@@ -19165,6 +19987,8 @@ rules:
     shortlink: https://sg.run/AvRL
     semgrep.dev:
       rule:
+        r_id: 9294
+        rv_id: 109890
         rule_id: 5rUOGN
         version_id: GxTv6dg
         url: https://semgrep.dev/playground/r/GxTv6dg/javascript.jose.security.jwt-none-alg.jwt-none-alg
@@ -19229,6 +20053,8 @@ rules:
     shortlink: https://sg.run/4xN9
     semgrep.dev:
       rule:
+        r_id: 9300
+        rv_id: 230007
         rule_id: WAUon7
         version_id: e1TgQKG
         url: https://semgrep.dev/playground/r/e1TgQKG/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
@@ -19303,6 +20129,8 @@ rules:
     shortlink: https://sg.run/PJXv
     semgrep.dev:
       rule:
+        r_id: 9301
+        rv_id: 109898
         rule_id: 0oU53g
         version_id: qkT2x86
         url: https://semgrep.dev/playground/r/qkT2x86/javascript.jsonwebtoken.security.jwt-none-alg.jwt-none-alg
@@ -19352,6 +20180,8 @@ rules:
     shortlink: https://sg.run/zdjod
     semgrep.dev:
       rule:
+        r_id: 120561
+        rv_id: 724919
         rule_id: r6UyNLy
         version_id: 44TgJGG
         url: https://semgrep.dev/playground/r/44TgJGG/javascript.jwt-simple.security.jwt-simple-noverify.jwt-simple-noverify
@@ -19409,6 +20239,8 @@ rules:
     shortlink: https://sg.run/96Yk
     semgrep.dev:
       rule:
+        r_id: 13023
+        rv_id: 109911
         rule_id: DbUKEz
         version_id: rxTyL7P
         url: https://semgrep.dev/playground/r/rxTyL7P/javascript.lang.security.audit.code-string-concat.code-string-concat
@@ -19504,6 +20336,8 @@ rules:
     shortlink: https://sg.run/DJ8v
     semgrep.dev:
       rule:
+        r_id: 9852
+        rv_id: 109912
         rule_id: qNUo10
         version_id: bZTb1eA
         url: https://semgrep.dev/playground/r/bZTb1eA/javascript.lang.security.audit.dangerous-spawn-shell.dangerous-spawn-shell
@@ -19583,6 +20417,8 @@ rules:
     shortlink: https://sg.run/gr65
     semgrep.dev:
       rule:
+        r_id: 12685
+        rv_id: 109915
         rule_id: zdU1gD
         version_id: w8T9nxz
         url: https://semgrep.dev/playground/r/w8T9nxz/javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
@@ -19639,6 +20475,8 @@ rules:
     shortlink: https://sg.run/GOEn
     semgrep.dev:
       rule:
+        r_id: 14692
+        rv_id: 109920
         rule_id: GdUr5G
         version_id: d6TrAG4
         url: https://semgrep.dev/playground/r/d6TrAG4/javascript.lang.security.audit.md5-used-as-password.md5-used-as-password
@@ -19687,6 +20525,8 @@ rules:
     shortlink: https://sg.run/OPqk
     semgrep.dev:
       rule:
+        r_id: 9331
+        rv_id: 109922
         rule_id: 8GUjrq
         version_id: nWTxP4n
         url: https://semgrep.dev/playground/r/nWTxP4n/javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
@@ -19777,6 +20617,8 @@ rules:
     shortlink: https://sg.run/l9eE
     semgrep.dev:
       rule:
+        r_id: 18257
+        rv_id: 109927
         rule_id: d8UKLD
         version_id: gET3x2P
         url: https://semgrep.dev/playground/r/gET3x2P/javascript.lang.security.audit.sqli.node-knex-sqli.node-knex-sqli
@@ -19870,6 +20712,8 @@ rules:
     shortlink: https://sg.run/lxlB
     semgrep.dev:
       rule:
+        r_id: 13157
+        rv_id: 109928
         rule_id: kxU8Pd
         version_id: QkTW0rE
         url: https://semgrep.dev/playground/r/QkTW0rE/javascript.lang.security.audit.sqli.node-mssql-sqli.node-mssql-sqli
@@ -19936,6 +20780,8 @@ rules:
     shortlink: https://sg.run/Y0oy
     semgrep.dev:
       rule:
+        r_id: 18258
+        rv_id: 109929
         rule_id: ZqUlWE
         version_id: 3ZTkQAW
         url: https://semgrep.dev/playground/r/3ZTkQAW/javascript.lang.security.audit.sqli.node-mysql-sqli.node-mysql-sqli
@@ -20011,6 +20857,8 @@ rules:
     shortlink: https://sg.run/0n3v
     semgrep.dev:
       rule:
+        r_id: 10710
+        rv_id: 109930
         rule_id: ReUPN9
         version_id: 44TRlP8
         url: https://semgrep.dev/playground/r/44TRlP8/javascript.lang.security.audit.sqli.node-postgres-sqli.node-postgres-sqli
@@ -20080,6 +20928,8 @@ rules:
     shortlink: https://sg.run/6nwK
     semgrep.dev:
       rule:
+        r_id: 9315
+        rv_id: 109946
         rule_id: yyUngo
         version_id: o5TglEE
         url: https://semgrep.dev/playground/r/o5TglEE/javascript.lang.security.detect-eval-with-expression.detect-eval-with-expression
@@ -20176,6 +21026,8 @@ rules:
     shortlink: https://sg.run/2R0D
     semgrep.dev:
       rule:
+        r_id: 12819
+        rv_id: 109952
         rule_id: AbUGOq
         version_id: 1QTOYLD
         url: https://semgrep.dev/playground/r/1QTOYLD/javascript.lang.security.insecure-object-assign.insecure-object-assign
@@ -20228,6 +21080,8 @@ rules:
     shortlink: https://sg.run/vz70
     semgrep.dev:
       rule:
+        r_id: 9333
+        rv_id: 109956
         rule_id: QrUzq6
         version_id: bZTb1oA
         url: https://semgrep.dev/playground/r/bZTb1oA/javascript.passport-jwt.security.passport-hardcode.hardcoded-passport-secret
@@ -20344,6 +21198,8 @@ rules:
     shortlink: https://sg.run/gjoe
     semgrep.dev:
       rule:
+        r_id: 22085
+        rv_id: 109973
         rule_id: yyU0GX
         version_id: 3ZTkQwW
         url: https://semgrep.dev/playground/r/3ZTkQwW/javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection
@@ -20428,6 +21284,8 @@ rules:
     shortlink: https://sg.run/lxv5
     semgrep.dev:
       rule:
+        r_id: 13413
+        rv_id: 109986
         rule_id: 7KUpLy
         version_id: qkT2xw6
         url: https://semgrep.dev/playground/r/qkT2xw6/json.aws.security.public-s3-bucket.public-s3-bucket
@@ -20502,6 +21360,8 @@ rules:
     shortlink: https://sg.run/Yv1d
     semgrep.dev:
       rule:
+        r_id: 9358
+        rv_id: 109987
         rule_id: 9AU1br
         version_id: l4T4vDE
         url: https://semgrep.dev/playground/r/l4T4vDE/json.aws.security.public-s3-policy-statement.public-s3-policy-statement
@@ -20546,6 +21406,8 @@ rules:
     shortlink: https://sg.run/7YEZ
     semgrep.dev:
       rule:
+        r_id: 15138
+        rv_id: 109988
         rule_id: JDULx5
         version_id: YDTp2bd
         url: https://semgrep.dev/playground/r/YDTp2bd/json.aws.security.wildcard-assume-role.wildcard-assume-role
@@ -20580,6 +21442,8 @@ rules:
     shortlink: https://sg.run/rY2n
     semgrep.dev:
       rule:
+        r_id: 15125
+        rv_id: 109990
         rule_id: v8U9Q7
         version_id: 5PTdAGD
         url: https://semgrep.dev/playground/r/5PTdAGD/kotlin.lang.security.anonymous-ldap-bind.anonymous-ldap-bind
@@ -20619,6 +21483,8 @@ rules:
     shortlink: https://sg.run/DzLj
     semgrep.dev:
       rule:
+        r_id: 14696
+        rv_id: 109996
         rule_id: DbU1Zd
         version_id: WrTWQnR
         url: https://semgrep.dev/playground/r/WrTWQnR/kotlin.lang.security.ecb-cipher.ecb-cipher
@@ -20677,6 +21543,8 @@ rules:
     shortlink: https://sg.run/0ywb
     semgrep.dev:
       rule:
+        r_id: 14698
+        rv_id: 109998
         rule_id: 0oU2Yy
         version_id: K3TvjLy
         url: https://semgrep.dev/playground/r/K3TvjLy/kotlin.lang.security.no-null-cipher.no-null-cipher
@@ -20720,6 +21588,8 @@ rules:
     shortlink: https://sg.run/4eQx
     semgrep.dev:
       rule:
+        r_id: 14700
+        rv_id: 258077
         rule_id: qNUXPj
         version_id: yeTBRZG
         url: https://semgrep.dev/playground/r/yeTBRZG/kotlin.lang.security.use-of-md5.use-of-md5
@@ -20765,6 +21635,8 @@ rules:
     shortlink: https://sg.run/N1pp
     semgrep.dev:
       rule:
+        r_id: 15127
+        rv_id: 110001
         rule_id: ZqUOdd
         version_id: YDTp2ep
         url: https://semgrep.dev/playground/r/YDTp2ep/kotlin.lang.security.use-of-sha1.use-of-sha1
@@ -20812,6 +21684,8 @@ rules:
     shortlink: https://sg.run/jwDJ
     semgrep.dev:
       rule:
+        r_id: 13965
+        rv_id: 110030
         rule_id: kxUw23
         version_id: 3ZTkQXq
         url: https://semgrep.dev/playground/r/3ZTkQXq/php.doctrine.security.audit.doctrine-orm-dangerous-query.doctrine-orm-dangerous-query
@@ -20905,6 +21779,8 @@ rules:
     shortlink: https://sg.run/3xXW
     semgrep.dev:
       rule:
+        r_id: 9387
+        rv_id: 110031
         rule_id: DbUpjk
         version_id: 44TRljD
         url: https://semgrep.dev/playground/r/44TRljD/php.lang.security.assert-use.assert-use
@@ -20948,6 +21824,8 @@ rules:
     shortlink: https://sg.run/PJqv
     semgrep.dev:
       rule:
+        r_id: 9389
+        rv_id: 110035
         rule_id: 0oU5Xg
         version_id: GxTv6eX
         url: https://semgrep.dev/playground/r/GxTv6eX/php.lang.security.curl-ssl-verifypeer-off.curl-ssl-verifypeer-off
@@ -20995,6 +21873,8 @@ rules:
     shortlink: https://sg.run/6bv1
     semgrep.dev:
       rule:
+        r_id: 18259
+        rv_id: 110036
         rule_id: nJUykq
         version_id: RGTDkLL
         url: https://semgrep.dev/playground/r/RGTDkLL/php.lang.security.deserialization.extract-user-data
@@ -21012,13 +21892,26 @@ rules:
   - pattern: "$_GET"
   - pattern: "$_POST"
   pattern-sinks:
-  - pattern: echo ...;
-  - pattern: print(...);
+  - pattern: echo $...VARS;
   pattern-sanitizers:
-  - pattern: isset(...)
-  - pattern: empty(...)
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
+  - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
+  - pattern: esc_html(...)
+  - pattern: esc_attr(...)
+  - pattern: wp_kses(...)
+  - pattern: e(...)
+  - pattern: twig_escape_filter(...)
+  - pattern: xss_clean(...)
+  - pattern: html_escape(...)
+  - pattern: Html::escape(...)
+  - pattern: Xss::filter(...)
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtmlAttr(...)
+  fix: echo htmlentities($...VARS);
   metadata:
     technology:
     - php
@@ -21049,9 +21942,79 @@ rules:
     shortlink: https://sg.run/Bqqb
     semgrep.dev:
       rule:
+        r_id: 31707
+        rv_id: 743482
         rule_id: BYUyyg
-        version_id: 8KT4RlJ
-        url: https://semgrep.dev/playground/r/8KT4RlJ/php.lang.security.injection.echoed-request.echoed-request
+        version_id: 9lTZxd4
+        url: https://semgrep.dev/playground/r/9lTZxd4/php.lang.security.injection.echoed-request.echoed-request
+        origin: community
+- id: php.lang.security.injection.printed-request.printed-request
+  mode: taint
+  message: "`Printing user input risks cross-site scripting vulnerability. You should
+    use `htmlentities()` when showing data to users."
+  languages:
+  - php
+  severity: ERROR
+  pattern-sources:
+  - pattern: "$_REQUEST"
+  - pattern: "$_GET"
+  - pattern: "$_POST"
+  pattern-sinks:
+  - pattern: print($...VARS);
+  pattern-sanitizers:
+  - pattern: htmlentities(...)
+  - pattern: htmlspecialchars(...)
+  - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
+  - pattern: esc_html(...)
+  - pattern: esc_attr(...)
+  - pattern: wp_kses(...)
+  - pattern: e(...)
+  - pattern: twig_escape_filter(...)
+  - pattern: xss_clean(...)
+  - pattern: html_escape(...)
+  - pattern: Html::escape(...)
+  - pattern: Xss::filter(...)
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtmlAttr(...)
+  fix: print(htmlentities($...VARS));
+  metadata:
+    technology:
+    - php
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    references:
+    - https://www.php.net/manual/en/function.htmlentities.php
+    - https://www.php.net/manual/en/reserved.variables.request.php
+    - https://www.php.net/manual/en/reserved.variables.post.php
+    - https://www.php.net/manual/en/reserved.variables.get.php
+    - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Cross-Site-Scripting (XSS)
+    source: https://semgrep.dev/r/php.lang.security.injection.printed-request.printed-request
+    shortlink: https://sg.run/QrxEJ
+    semgrep.dev:
+      rule:
+        r_id: 128886
+        rv_id: 743483
+        rule_id: KxUvRBw
+        version_id: yeTAKRO
+        url: https://semgrep.dev/playground/r/yeTAKRO/php.lang.security.injection.printed-request.printed-request
         origin: community
 - id: php.lang.security.injection.tainted-filename.tainted-filename
   severity: WARNING
@@ -21080,6 +22043,8 @@ rules:
     shortlink: https://sg.run/Ayqp
     semgrep.dev:
       rule:
+        r_id: 16250
+        rv_id: 110042
         rule_id: 5rUpro
         version_id: K3Tvjky
         url: https://semgrep.dev/playground/r/K3Tvjky/php.lang.security.injection.tainted-filename.tainted-filename
@@ -21271,6 +22236,8 @@ rules:
     shortlink: https://sg.run/7ndw
     semgrep.dev:
       rule:
+        r_id: 16438
+        rv_id: 110043
         rule_id: v8U4DA
         version_id: qkT2x7l
         url: https://semgrep.dev/playground/r/qkT2x7l/php.lang.security.injection.tainted-object-instantiation.tainted-object-instantiation
@@ -21319,6 +22286,8 @@ rules:
     shortlink: https://sg.run/bxNp
     semgrep.dev:
       rule:
+        r_id: 73470
+        rv_id: 113532
         rule_id: 4bUdoP
         version_id: 0bTLKDl
         url: https://semgrep.dev/playground/r/0bTLKDl/php.lang.security.injection.tainted-session.tainted-session
@@ -21409,6 +22378,8 @@ rules:
     shortlink: https://sg.run/lZYG
     semgrep.dev:
       rule:
+        r_id: 14757
+        rv_id: 251682
         rule_id: qNUXdL
         version_id: RGTevOe
         url: https://semgrep.dev/playground/r/RGTevOe/php.lang.security.injection.tainted-sql-string.tainted-sql-string
@@ -21484,6 +22455,8 @@ rules:
     shortlink: https://sg.run/Y8no
     semgrep.dev:
       rule:
+        r_id: 14758
+        rv_id: 110045
         rule_id: lBU8K1
         version_id: YDTp27p
         url: https://semgrep.dev/playground/r/YDTp27p/php.lang.security.injection.tainted-url-host.tainted-url-host
@@ -21558,6 +22531,8 @@ rules:
     shortlink: https://sg.run/66YL
     semgrep.dev:
       rule:
+        r_id: 14759
+        rv_id: 110050
         rule_id: YGUD1O
         version_id: 2KTzrjK
         url: https://semgrep.dev/playground/r/2KTzrjK/php.lang.security.md5-used-as-password.md5-used-as-password
@@ -21610,6 +22585,8 @@ rules:
     shortlink: https://sg.run/LgWJ
     semgrep.dev:
       rule:
+        r_id: 19039
+        rv_id: 110052
         rule_id: DbUGbE
         version_id: jQTgY2Q
         url: https://semgrep.dev/playground/r/jQTgY2Q/php.lang.security.openssl-cbc-static-iv.openssl-cbc-static-iv
@@ -21641,6 +22618,8 @@ rules:
     shortlink: https://sg.run/W82E
     semgrep.dev:
       rule:
+        r_id: 9397
+        rv_id: 110055
         rule_id: ReUglY
         version_id: yeTR2r0
         url: https://semgrep.dev/playground/r/yeTR2r0/php.lang.security.phpinfo-use.phpinfo-use
@@ -21688,6 +22667,8 @@ rules:
     shortlink: https://sg.run/RWl2
     semgrep.dev:
       rule:
+        r_id: 35493
+        rv_id: 110057
         rule_id: 3qUb4n
         version_id: bZTb1d9
         url: https://semgrep.dev/playground/r/bZTb1d9/php.lang.security.redirect-to-request-uri.redirect-to-request-uri
@@ -21739,6 +22720,8 @@ rules:
     shortlink: https://sg.run/JAkP
     semgrep.dev:
       rule:
+        r_id: 73146
+        rv_id: 110058
         rule_id: 9AUw06
         version_id: NdT3djz
         url: https://semgrep.dev/playground/r/NdT3djz/php.lang.security.tainted-exec.tainted-exec
@@ -21796,6 +22779,8 @@ rules:
     shortlink: https://sg.run/x94g
     semgrep.dev:
       rule:
+        r_id: 21674
+        rv_id: 110063
         rule_id: zdUln0
         version_id: e1T01OG
         url: https://semgrep.dev/playground/r/e1T01OG/php.laravel.security.laravel-api-route-sql-injection.laravel-api-route-sql-injection
@@ -21827,6 +22812,8 @@ rules:
     shortlink: https://sg.run/x40p
     semgrep.dev:
       rule:
+        r_id: 16830
+        rv_id: 110071
         rule_id: j2UQdp
         version_id: 8KTQ9ZJ
         url: https://semgrep.dev/playground/r/8KTQ9ZJ/php.laravel.security.laravel-sql-injection.laravel-sql-injection
@@ -22016,6 +23003,8 @@ rules:
     shortlink: https://sg.run/vkeb
     semgrep.dev:
       rule:
+        r_id: 21677
+        rv_id: 110072
         rule_id: X5ULgE
         version_id: gET3xDz
         url: https://semgrep.dev/playground/r/gET3xDz/php.laravel.security.laravel-unsafe-validator.laravel-unsafe-validator
@@ -22045,6 +23034,8 @@ rules:
     shortlink: https://sg.run/4xj5
     semgrep.dev:
       rule:
+        r_id: 9400
+        rv_id: 110087
         rule_id: DbUpjg
         version_id: qkT2xyl
         url: https://semgrep.dev/playground/r/qkT2xyl/problem-based-packs.insecure-transport.go-stdlib.bypass-tls-verification.bypass-tls-verification
@@ -22085,6 +23076,8 @@ rules:
     shortlink: https://sg.run/PJqz
     semgrep.dev:
       rule:
+        r_id: 9401
+        rv_id: 110088
         rule_id: WAUow9
         version_id: l4T4vjQ
         url: https://semgrep.dev/playground/r/l4T4vjQ/problem-based-packs.insecure-transport.go-stdlib.disallow-old-tls-versions.disallow-old-tls-versions
@@ -22130,6 +23123,8 @@ rules:
     shortlink: https://sg.run/J9Ay
     semgrep.dev:
       rule:
+        r_id: 9402
+        rv_id: 110089
         rule_id: 0oU5XN
         version_id: YDTp2yp
         url: https://semgrep.dev/playground/r/YDTp2yp/problem-based-packs.insecure-transport.go-stdlib.ftp-request.ftp-request
@@ -22188,6 +23183,8 @@ rules:
     shortlink: https://sg.run/5Q10
     semgrep.dev:
       rule:
+        r_id: 9403
+        rv_id: 110090
         rule_id: KxUbXx
         version_id: JdTNpW5
         url: https://semgrep.dev/playground/r/JdTNpW5/problem-based-packs.insecure-transport.go-stdlib.gorequest-http-request.gorequest-http-request
@@ -22238,6 +23235,8 @@ rules:
     shortlink: https://sg.run/Ge5q
     semgrep.dev:
       rule:
+        r_id: 9404
+        rv_id: 110091
         rule_id: qNUjy3
         version_id: 5PTdAwP
         url: https://semgrep.dev/playground/r/5PTdAwP/problem-based-packs.insecure-transport.go-stdlib.grequests-http-request.grequests-http-request
@@ -22281,6 +23280,8 @@ rules:
     shortlink: https://sg.run/RoYq
     semgrep.dev:
       rule:
+        r_id: 9405
+        rv_id: 110092
         rule_id: lBU90n
         version_id: GxTv6A7
         url: https://semgrep.dev/playground/r/GxTv6A7/problem-based-packs.insecure-transport.go-stdlib.http-customized-request.http-customized-request
@@ -22320,6 +23321,8 @@ rules:
     shortlink: https://sg.run/Avd2
     semgrep.dev:
       rule:
+        r_id: 9406
+        rv_id: 110093
         rule_id: YGUR70
         version_id: RGTDkzP
         url: https://semgrep.dev/playground/r/RGTDkzP/problem-based-packs.insecure-transport.go-stdlib.http-request.http-request
@@ -22376,6 +23379,8 @@ rules:
     shortlink: https://sg.run/BkZA
     semgrep.dev:
       rule:
+        r_id: 9407
+        rv_id: 110094
         rule_id: 6JUjoX
         version_id: A8T954G
         url: https://semgrep.dev/playground/r/A8T954G/problem-based-packs.insecure-transport.go-stdlib.sling-http-request.sling-http-request
@@ -22446,6 +23451,8 @@ rules:
     shortlink: https://sg.run/Do4P
     semgrep.dev:
       rule:
+        r_id: 9408
+        rv_id: 110095
         rule_id: oqUewD
         version_id: BjTXrPd
         url: https://semgrep.dev/playground/r/BjTXrPd/problem-based-packs.insecure-transport.go-stdlib.telnet-request.telnet-request
@@ -22483,6 +23490,8 @@ rules:
     shortlink: https://sg.run/W822
     semgrep.dev:
       rule:
+        r_id: 9409
+        rv_id: 110096
         rule_id: zdUkZZ
         version_id: DkT6n5x
         url: https://semgrep.dev/playground/r/DkT6n5x/problem-based-packs.insecure-transport.java-spring.bypass-tls-verification.bypass-tls-verification
@@ -22538,6 +23547,8 @@ rules:
     shortlink: https://sg.run/0Qzj
     semgrep.dev:
       rule:
+        r_id: 9410
+        rv_id: 110097
         rule_id: pKUOYW
         version_id: WrTWQ1d
         url: https://semgrep.dev/playground/r/WrTWQ1d/problem-based-packs.insecure-transport.java-spring.spring-ftp-request.spring-ftp-request
@@ -22590,6 +23601,8 @@ rules:
     shortlink: https://sg.run/KlB5
     semgrep.dev:
       rule:
+        r_id: 9411
+        rv_id: 110098
         rule_id: 2ZUbjg
         version_id: 0bTLldp
         url: https://semgrep.dev/playground/r/0bTLldp/problem-based-packs.insecure-transport.java-spring.spring-http-request.spring-http-request
@@ -22648,6 +23661,8 @@ rules:
     shortlink: https://sg.run/qxD7
     semgrep.dev:
       rule:
+        r_id: 9412
+        rv_id: 110099
         rule_id: X5U8qv
         version_id: K3Tvj0J
         url: https://semgrep.dev/playground/r/K3Tvj0J/problem-based-packs.insecure-transport.java-stdlib.bypass-tls-verification.bypass-tls-verification
@@ -22708,6 +23723,8 @@ rules:
     shortlink: https://sg.run/l25E
     semgrep.dev:
       rule:
+        r_id: 9413
+        rv_id: 250960
         rule_id: j2Uv2K
         version_id: d6TqD0o
         url: https://semgrep.dev/playground/r/d6TqD0o/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions1.disallow-old-tls-versions1
@@ -22765,6 +23782,8 @@ rules:
     shortlink: https://sg.run/Yvjy
     semgrep.dev:
       rule:
+        r_id: 9414
+        rv_id: 110101
         rule_id: 10UKvx
         version_id: l4T4vj6
         url: https://semgrep.dev/playground/r/l4T4vj6/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions2.disallow-old-tls-versions2
@@ -22807,6 +23826,8 @@ rules:
     shortlink: https://sg.run/6n91
     semgrep.dev:
       rule:
+        r_id: 9415
+        rv_id: 110102
         rule_id: 9AU1wD
         version_id: YDTp2yZ
         url: https://semgrep.dev/playground/r/YDTp2yZ/problem-based-packs.insecure-transport.java-stdlib.ftp-request.ftp-request
@@ -22852,6 +23873,8 @@ rules:
     shortlink: https://sg.run/oxD0
     semgrep.dev:
       rule:
+        r_id: 9416
+        rv_id: 110103
         rule_id: yyUnjk
         version_id: 6xTvJY8
         url: https://semgrep.dev/playground/r/6xTvJY8/problem-based-packs.insecure-transport.java-stdlib.http-components-request.http-components-request
@@ -22899,6 +23922,8 @@ rules:
     shortlink: https://sg.run/zv2d
     semgrep.dev:
       rule:
+        r_id: 9417
+        rv_id: 110104
         rule_id: r6Ur3y
         version_id: o5TglNL
         url: https://semgrep.dev/playground/r/o5TglNL/problem-based-packs.insecure-transport.java-stdlib.httpclient-http-request.httpclient-http-request
@@ -22981,6 +24006,8 @@ rules:
     shortlink: https://sg.run/QE2q
     semgrep.dev:
       rule:
+        r_id: 48942
+        rv_id: 110105
         rule_id: 6JUOJ2
         version_id: zyTK84N
         url: https://semgrep.dev/playground/r/zyTK84N/problem-based-packs.insecure-transport.java-stdlib.httpget-http-request.httpget-http-request
@@ -23026,6 +24053,8 @@ rules:
     shortlink: https://sg.run/px3Z
     semgrep.dev:
       rule:
+        r_id: 9418
+        rv_id: 110106
         rule_id: bwUwvR
         version_id: pZT1yWA
         url: https://semgrep.dev/playground/r/pZT1yWA/problem-based-packs.insecure-transport.java-stdlib.httpurlconnection-http-request.httpurlconnection-http-request
@@ -23078,6 +24107,8 @@ rules:
     shortlink: https://sg.run/XBQB
     semgrep.dev:
       rule:
+        r_id: 9420
+        rv_id: 110108
         rule_id: kxUkXk
         version_id: X0TQx9J
         url: https://semgrep.dev/playground/r/X0TQx9J/problem-based-packs.insecure-transport.java-stdlib.telnet-request.telnet-request
@@ -23114,6 +24145,8 @@ rules:
     shortlink: https://sg.run/jR5N
     semgrep.dev:
       rule:
+        r_id: 9421
+        rv_id: 110109
         rule_id: wdUJw8
         version_id: jQTgYxL
         url: https://semgrep.dev/playground/r/jQTgYxL/problem-based-packs.insecure-transport.java-stdlib.tls-renegotiation.tls-renegotiation
@@ -23150,6 +24183,8 @@ rules:
     shortlink: https://sg.run/1Z1G
     semgrep.dev:
       rule:
+        r_id: 9422
+        rv_id: 110110
         rule_id: x8Uno2
         version_id: 1QTOYln
         url: https://semgrep.dev/playground/r/1QTOYln/problem-based-packs.insecure-transport.java-stdlib.unirest-http-request.unirest-http-request
@@ -23196,6 +24231,8 @@ rules:
     shortlink: https://sg.run/9oxr
     semgrep.dev:
       rule:
+        r_id: 9423
+        rv_id: 110111
         rule_id: OrU3Y6
         version_id: 9lTdWB8
         url: https://semgrep.dev/playground/r/9lTdWB8/problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
@@ -23236,6 +24273,8 @@ rules:
     shortlink: https://sg.run/ydpP
     semgrep.dev:
       rule:
+        r_id: 9424
+        rv_id: 110112
         rule_id: eqU8nr
         version_id: yeTR2jb
         url: https://semgrep.dev/playground/r/yeTR2jb/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions1.disallow-old-tls-versions1
@@ -23295,6 +24334,8 @@ rules:
     shortlink: https://sg.run/rdKe
     semgrep.dev:
       rule:
+        r_id: 9425
+        rv_id: 110113
         rule_id: v8UnPO
         version_id: rxTyL3R
         url: https://semgrep.dev/playground/r/rxTyL3R/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions2.disallow-old-tls-versions2
@@ -23369,6 +24410,8 @@ rules:
     shortlink: https://sg.run/b7QW
     semgrep.dev:
       rule:
+        r_id: 9426
+        rv_id: 110114
         rule_id: d8UjZ6
         version_id: bZTb1vg
         url: https://semgrep.dev/playground/r/bZTb1vg/problem-based-packs.insecure-transport.js-node.ftp-request.ftp-request
@@ -23413,6 +24456,8 @@ rules:
     shortlink: https://sg.run/N4Qy
     semgrep.dev:
       rule:
+        r_id: 9427
+        rv_id: 110115
         rule_id: ZqU5r3
         version_id: NdT3dlK
         url: https://semgrep.dev/playground/r/NdT3dlK/problem-based-packs.insecure-transport.js-node.http-request.http-request
@@ -23475,6 +24520,8 @@ rules:
     shortlink: https://sg.run/kXGP
     semgrep.dev:
       rule:
+        r_id: 9428
+        rv_id: 110116
         rule_id: nJUzKP
         version_id: kbTdxXE
         url: https://semgrep.dev/playground/r/kbTdxXE/problem-based-packs.insecure-transport.js-node.rest-http-client-support.rest-http-client-support
@@ -23534,6 +24581,8 @@ rules:
     shortlink: https://sg.run/weoA
     semgrep.dev:
       rule:
+        r_id: 9429
+        rv_id: 110117
         rule_id: EwU2GA
         version_id: w8T9nwr
         url: https://semgrep.dev/playground/r/w8T9nwr/problem-based-packs.insecure-transport.js-node.telnet-request.telnet-request
@@ -23581,6 +24630,8 @@ rules:
     shortlink: https://sg.run/OPQL
     semgrep.dev:
       rule:
+        r_id: 9431
+        rv_id: 110119
         rule_id: L1UyKG
         version_id: O9TNOY1
         url: https://semgrep.dev/playground/r/O9TNOY1/problem-based-packs.insecure-transport.ruby-stdlib.http-client-requests.http-client-requests
@@ -23627,6 +24678,8 @@ rules:
     shortlink: https://sg.run/eLQ8
     semgrep.dev:
       rule:
+        r_id: 9432
+        rv_id: 110120
         rule_id: 8GUj13
         version_id: e1T01nJ
         url: https://semgrep.dev/playground/r/e1T01nJ/problem-based-packs.insecure-transport.ruby-stdlib.net-ftp-request.net-ftp-request
@@ -23669,6 +24722,8 @@ rules:
     shortlink: https://sg.run/vz6Y
     semgrep.dev:
       rule:
+        r_id: 9433
+        rv_id: 110121
         rule_id: gxU1lE
         version_id: vdTYNP7
         url: https://semgrep.dev/playground/r/vdTYNP7/problem-based-packs.insecure-transport.ruby-stdlib.net-http-request.net-http-request
@@ -23718,6 +24773,8 @@ rules:
     shortlink: https://sg.run/dKQE
     semgrep.dev:
       rule:
+        r_id: 9434
+        rv_id: 110122
         rule_id: QrUzo2
         version_id: d6TrAZG
         url: https://semgrep.dev/playground/r/d6TrAZG/problem-based-packs.insecure-transport.ruby-stdlib.net-telnet-request.net-telnet-request
@@ -23755,6 +24812,8 @@ rules:
     shortlink: https://sg.run/ZvQw
     semgrep.dev:
       rule:
+        r_id: 9435
+        rv_id: 110123
         rule_id: 3qUPNe
         version_id: ZRTQNrd
         url: https://semgrep.dev/playground/r/ZRTQNrd/problem-based-packs.insecure-transport.ruby-stdlib.openuri-request.openuri-request
@@ -23836,6 +24895,8 @@ rules:
     shortlink: https://sg.run/oyv0
     semgrep.dev:
       rule:
+        r_id: 18260
+        rv_id: 110126
         rule_id: EwUrX8
         version_id: 7ZTgoAA
         url: https://semgrep.dev/playground/r/7ZTgoAA/python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
@@ -23898,6 +24959,8 @@ rules:
     shortlink: https://sg.run/z14d
     semgrep.dev:
       rule:
+        r_id: 18261
+        rv_id: 110127
         rule_id: 7KUxXg
         version_id: LjTqQKw
         url: https://semgrep.dev/playground/r/LjTqQKw/python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
@@ -23957,6 +25020,8 @@ rules:
     shortlink: https://sg.run/p9vZ
     semgrep.dev:
       rule:
+        r_id: 18262
+        rv_id: 110128
         rule_id: L1UEl7
         version_id: 8KTQ91d
         url: https://semgrep.dev/playground/r/8KTQ91d/python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
@@ -24002,6 +25067,8 @@ rules:
     shortlink: https://sg.run/2AjL
     semgrep.dev:
       rule:
+        r_id: 18263
+        rv_id: 110129
         rule_id: 8GUGBq
         version_id: gET3xlq
         url: https://semgrep.dev/playground/r/gET3xlq/python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
@@ -24081,6 +25148,8 @@ rules:
     shortlink: https://sg.run/XZ7B
     semgrep.dev:
       rule:
+        r_id: 18264
+        rv_id: 110130
         rule_id: gxUyn1
         version_id: QkTW0oy
         url: https://semgrep.dev/playground/r/QkTW0oy/python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
@@ -24139,6 +25208,8 @@ rules:
     shortlink: https://sg.run/jDvN
     semgrep.dev:
       rule:
+        r_id: 18265
+        rv_id: 110131
         rule_id: QrUkg6
         version_id: 3ZTkQN9
         url: https://semgrep.dev/playground/r/3ZTkQN9/python.aws-lambda.security.dangerous-system-call.dangerous-system-call
@@ -24188,6 +25259,8 @@ rules:
     shortlink: https://sg.run/jjrl
     semgrep.dev:
       rule:
+        r_id: 21321
+        rv_id: 110132
         rule_id: KxUJ2B
         version_id: 44TRlny
         url: https://semgrep.dev/playground/r/44TRlny/python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
@@ -24262,6 +25335,8 @@ rules:
     shortlink: https://sg.run/1RjG
     semgrep.dev:
       rule:
+        r_id: 18266
+        rv_id: 110133
         rule_id: 3qU3eE
         version_id: PkTJ1gJ
         url: https://semgrep.dev/playground/r/PkTJ1gJ/python.aws-lambda.security.mysql-sqli.mysql-sqli
@@ -24325,6 +25400,8 @@ rules:
     shortlink: https://sg.run/9L8r
     semgrep.dev:
       rule:
+        r_id: 18267
+        rv_id: 110134
         rule_id: 4bUQG1
         version_id: JdTNpd5
         url: https://semgrep.dev/playground/r/JdTNpd5/python.aws-lambda.security.psycopg-sqli.psycopg-sqli
@@ -24382,6 +25459,8 @@ rules:
     shortlink: https://sg.run/yXvP
     semgrep.dev:
       rule:
+        r_id: 18268
+        rv_id: 110135
         rule_id: PeUxO0
         version_id: 5PTdAXP
         url: https://semgrep.dev/playground/r/5PTdAXP/python.aws-lambda.security.pymssql-sqli.pymssql-sqli
@@ -24436,6 +25515,8 @@ rules:
     shortlink: https://sg.run/reve
     semgrep.dev:
       rule:
+        r_id: 18269
+        rv_id: 110136
         rule_id: JDUlel
         version_id: GxTv6Q7
         url: https://semgrep.dev/playground/r/GxTv6Q7/python.aws-lambda.security.pymysql-sqli.pymysql-sqli
@@ -24494,6 +25575,8 @@ rules:
     shortlink: https://sg.run/b48W
     semgrep.dev:
       rule:
+        r_id: 18270
+        rv_id: 110137
         rule_id: 5rUy3N
         version_id: RGTDk5P
         url: https://semgrep.dev/playground/r/RGTDk5P/python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
@@ -24557,6 +25640,8 @@ rules:
     shortlink: https://sg.run/Ng7y
     semgrep.dev:
       rule:
+        r_id: 18271
+        rv_id: 110138
         rule_id: GdUDJP
         version_id: A8T95AG
         url: https://semgrep.dev/playground/r/A8T95AG/python.aws-lambda.security.tainted-code-exec.tainted-code-exec
@@ -24609,6 +25694,8 @@ rules:
     shortlink: https://sg.run/k9vP
     semgrep.dev:
       rule:
+        r_id: 18272
+        rv_id: 110139
         rule_id: ReUKrk
         version_id: BjTXrwd
         url: https://semgrep.dev/playground/r/BjTXrwd/python.aws-lambda.security.tainted-html-response.tainted-html-response
@@ -24651,6 +25738,8 @@ rules:
     shortlink: https://sg.run/8zNy
     semgrep.dev:
       rule:
+        r_id: 18484
+        rv_id: 110140
         rule_id: JDUlwy
         version_id: DkT6nDx
         url: https://semgrep.dev/playground/r/DkT6nDx/python.aws-lambda.security.tainted-html-string.tainted-html-string
@@ -24738,6 +25827,8 @@ rules:
     shortlink: https://sg.run/JbjW
     semgrep.dev:
       rule:
+        r_id: 21602
+        rv_id: 110141
         rule_id: JDUDQg
         version_id: WrTWQvd
         url: https://semgrep.dev/playground/r/WrTWQvd/python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
@@ -24780,6 +25871,8 @@ rules:
     shortlink: https://sg.run/wXvA
     semgrep.dev:
       rule:
+        r_id: 18273
+        rv_id: 110142
         rule_id: AbU3LX
         version_id: 0bTLlAp
         url: https://semgrep.dev/playground/r/0bTLlAp/python.aws-lambda.security.tainted-sql-string.tainted-sql-string
@@ -24846,6 +25939,8 @@ rules:
     shortlink: https://sg.run/LwQ6
     semgrep.dev:
       rule:
+        r_id: 9439
+        rv_id: 110144
         rule_id: 5rUOwK
         version_id: qkT2xkx
         url: https://semgrep.dev/playground/r/qkT2xkx/python.boto3.security.hardcoded-token.hardcoded-token
@@ -24913,6 +26008,8 @@ rules:
     shortlink: https://sg.run/zQ9G
     semgrep.dev:
       rule:
+        r_id: 44817
+        rv_id: 251683
         rule_id: OrUADK
         version_id: A8TkYjr
         url: https://semgrep.dev/playground/r/A8TkYjr/python.cryptography.security.empty-aes-key.empty-aes-key
@@ -24951,6 +26048,8 @@ rules:
     shortlink: https://sg.run/xoZL
     semgrep.dev:
       rule:
+        r_id: 33630
+        rv_id: 252912
         rule_id: KxU8gK
         version_id: 0bTyODx
         url: https://semgrep.dev/playground/r/0bTyODx/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
@@ -25001,6 +26100,8 @@ rules:
     shortlink: https://sg.run/OdzL
     semgrep.dev:
       rule:
+        r_id: 33631
+        rv_id: 252913
         rule_id: qNULvO
         version_id: K3TnyZv
         url: https://semgrep.dev/playground/r/K3TnyZv/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
@@ -25052,6 +26153,8 @@ rules:
     shortlink: https://sg.run/3xyK
     semgrep.dev:
       rule:
+        r_id: 9443
+        rv_id: 252914
         rule_id: BYUNPg
         version_id: qkT5qE5
         url: https://semgrep.dev/playground/r/qkT5qE5/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
@@ -25101,6 +26204,8 @@ rules:
     shortlink: https://sg.run/eY88
     semgrep.dev:
       rule:
+        r_id: 33632
+        rv_id: 252916
         rule_id: lBUopp
         version_id: YDTNPBR
         url: https://semgrep.dev/playground/r/YDTNPBR/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
@@ -25161,6 +26266,8 @@ rules:
     shortlink: https://sg.run/J9Qy
     semgrep.dev:
       rule:
+        r_id: 9446
+        rv_id: 251689
         rule_id: 0oU5dN
         version_id: qkT5qYQ
         url: https://semgrep.dev/playground/r/qkT5qYQ/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
@@ -25212,6 +26319,8 @@ rules:
     shortlink: https://sg.run/5Qb0
     semgrep.dev:
       rule:
+        r_id: 9447
+        rv_id: 252917
         rule_id: KxUb0x
         version_id: 6xTZKrq
         url: https://semgrep.dev/playground/r/6xTZKrq/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
@@ -25259,6 +26368,8 @@ rules:
     shortlink: https://sg.run/AvQ2
     semgrep.dev:
       rule:
+        r_id: 9450
+        rv_id: 110159
         rule_id: YGURy0
         version_id: NdT3d8K
         url: https://semgrep.dev/playground/r/NdT3d8K/python.distributed.security.require-encryption
@@ -25291,6 +26402,8 @@ rules:
     shortlink: https://sg.run/9oyr
     semgrep.dev:
       rule:
+        r_id: 9467
+        rv_id: 110180
         rule_id: OrU3e6
         version_id: GxTv6G7
         url: https://semgrep.dev/playground/r/GxTv6G7/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
@@ -25377,6 +26490,8 @@ rules:
     shortlink: https://sg.run/rd5e
     semgrep.dev:
       rule:
+        r_id: 9469
+        rv_id: 110182
         rule_id: v8UnqO
         version_id: A8T956G
         url: https://semgrep.dev/playground/r/A8T956G/python.django.security.audit.csrf-exempt.no-csrf-exempt
@@ -25414,6 +26529,8 @@ rules:
     shortlink: https://sg.run/bxeZ
     semgrep.dev:
       rule:
+        r_id: 72426
+        rv_id: 110208
         rule_id: 0oUXqy
         version_id: 2KTzrD9
         url: https://semgrep.dev/playground/r/2KTzrD9/python.django.security.hashids-with-django-secret.hashids-with-django-secret
@@ -25449,6 +26566,8 @@ rules:
     shortlink: https://sg.run/4x2z
     semgrep.dev:
       rule:
+        r_id: 9500
+        rv_id: 110210
         rule_id: BYUNw9
         version_id: jQTgYEX
         url: https://semgrep.dev/playground/r/jQTgYEX/python.django.security.injection.code.user-eval-format-string.user-eval-format-string
@@ -25586,6 +26705,8 @@ rules:
     shortlink: https://sg.run/PJDW
     semgrep.dev:
       rule:
+        r_id: 9501
+        rv_id: 110211
         rule_id: DbUpDQ
         version_id: 1QTOYDN
         url: https://semgrep.dev/playground/r/1QTOYDN/python.django.security.injection.code.user-eval.user-eval
@@ -25641,6 +26762,8 @@ rules:
     shortlink: https://sg.run/J9JW
     semgrep.dev:
       rule:
+        r_id: 9502
+        rv_id: 110212
         rule_id: WAUovx
         version_id: 9lTdWjb
         url: https://semgrep.dev/playground/r/9lTdWjb/python.django.security.injection.code.user-exec-format-string.user-exec-format-string
@@ -25871,6 +26994,8 @@ rules:
     shortlink: https://sg.run/5Q3X
     semgrep.dev:
       rule:
+        r_id: 9503
+        rv_id: 110213
         rule_id: 0oU5AW
         version_id: yeTR26r
         url: https://semgrep.dev/playground/r/yeTR26r/python.django.security.injection.code.user-exec.user-exec
@@ -25949,6 +27074,8 @@ rules:
     shortlink: https://sg.run/Gen2
     semgrep.dev:
       rule:
+        r_id: 9504
+        rv_id: 110214
         rule_id: KxUbp2
         version_id: rxTyL53
         url: https://semgrep.dev/playground/r/rxTyL53/python.django.security.injection.command.command-injection-os-system.command-injection-os-system
@@ -26284,6 +27411,8 @@ rules:
     shortlink: https://sg.run/49BE
     semgrep.dev:
       rule:
+        r_id: 31144
+        rv_id: 110215
         rule_id: EwUepx
         version_id: bZTb1Yq
         url: https://semgrep.dev/playground/r/bZTb1Yq/python.django.security.injection.command.subprocess-injection.subprocess-injection
@@ -26324,6 +27453,8 @@ rules:
     shortlink: https://sg.run/Pw9q
     semgrep.dev:
       rule:
+        r_id: 31145
+        rv_id: 110216
         rule_id: 7KUK1y
         version_id: NdT3dxx
         url: https://semgrep.dev/playground/r/NdT3dxx/python.django.security.injection.csv-writer-injection.csv-writer-injection
@@ -26380,6 +27511,8 @@ rules:
     shortlink: https://sg.run/RoBe
     semgrep.dev:
       rule:
+        r_id: 9505
+        rv_id: 110217
         rule_id: qNUj02
         version_id: kbTdxo7
         url: https://semgrep.dev/playground/r/kbTdxo7/python.django.security.injection.email.xss-html-email-body.xss-html-email-body
@@ -26593,6 +27726,8 @@ rules:
     shortlink: https://sg.run/Avx8
     semgrep.dev:
       rule:
+        r_id: 9506
+        rv_id: 110218
         rule_id: lBU9Ll
         version_id: w8T9ne2
         url: https://semgrep.dev/playground/r/w8T9ne2/python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
@@ -26850,6 +27985,8 @@ rules:
     shortlink: https://sg.run/Ave2
     semgrep.dev:
       rule:
+        r_id: 9494
+        rv_id: 110220
         rule_id: PeUZgr
         version_id: O9TNOyj
         url: https://semgrep.dev/playground/r/O9TNOyj/python.django.security.injection.open-redirect.open-redirect
@@ -27448,6 +28585,8 @@ rules:
     shortlink: https://sg.run/BkO2
     semgrep.dev:
       rule:
+        r_id: 9507
+        rv_id: 110221
         rule_id: YGUR36
         version_id: e1T01x0
         url: https://semgrep.dev/playground/r/e1T01x0/python.django.security.injection.path-traversal.path-traversal-file-name.path-traversal-file-name
@@ -27537,6 +28676,8 @@ rules:
     shortlink: https://sg.run/W8qg
     semgrep.dev:
       rule:
+        r_id: 9509
+        rv_id: 110223
         rule_id: oqUe7z
         version_id: d6TrADQ
         url: https://semgrep.dev/playground/r/d6TrADQ/python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
@@ -27994,6 +29135,8 @@ rules:
     shortlink: https://sg.run/oYj1
     semgrep.dev:
       rule:
+        r_id: 14360
+        rv_id: 110224
         rule_id: 2ZUPER
         version_id: ZRTQNw5
         url: https://semgrep.dev/playground/r/ZRTQNw5/python.django.security.injection.raw-html-format.raw-html-format
@@ -28056,6 +29199,8 @@ rules:
     shortlink: https://sg.run/BkvA
     semgrep.dev:
       rule:
+        r_id: 9495
+        rv_id: 110225
         rule_id: JDUydR
         version_id: nWTxP7Y
         url: https://semgrep.dev/playground/r/nWTxP7Y/python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
@@ -28332,6 +29477,8 @@ rules:
     shortlink: https://sg.run/DoZP
     semgrep.dev:
       rule:
+        r_id: 9496
+        rv_id: 110226
         rule_id: 5rUOX1
         version_id: ExTjNnQ
         url: https://semgrep.dev/playground/r/ExTjNnQ/python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
@@ -28609,6 +29756,8 @@ rules:
     shortlink: https://sg.run/W862
     semgrep.dev:
       rule:
+        r_id: 9497
+        rv_id: 110227
         rule_id: GdU7QR
         version_id: 7ZTgoOv
         url: https://semgrep.dev/playground/r/7ZTgoOv/python.django.security.injection.request-data-fileresponse.request-data-fileresponse
@@ -28701,6 +29850,8 @@ rules:
     shortlink: https://sg.run/0Q6j
     semgrep.dev:
       rule:
+        r_id: 9498
+        rv_id: 110228
         rule_id: ReUg5z
         version_id: LjTqQ0P
         url: https://semgrep.dev/playground/r/LjTqQ0P/python.django.security.injection.request-data-write.request-data-write
@@ -28912,6 +30063,8 @@ rules:
     shortlink: https://sg.run/0Ql5
     semgrep.dev:
       rule:
+        r_id: 9510
+        rv_id: 110229
         rule_id: zdUkx1
         version_id: 8KTQ9bG
         url: https://semgrep.dev/playground/r/8KTQ9bG/python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
@@ -29236,6 +30389,8 @@ rules:
     shortlink: https://sg.run/Kl4X
     semgrep.dev:
       rule:
+        r_id: 9511
+        rv_id: 110230
         rule_id: pKUOBp
         version_id: gET3xqk
         url: https://semgrep.dev/playground/r/gET3xqk/python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
@@ -29553,6 +30708,8 @@ rules:
     shortlink: https://sg.run/qx7y
     semgrep.dev:
       rule:
+        r_id: 9512
+        rv_id: 110231
         rule_id: 2ZUbDL
         version_id: QkTW0JZ
         url: https://semgrep.dev/playground/r/QkTW0JZ/python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
@@ -29860,6 +31017,8 @@ rules:
     shortlink: https://sg.run/l2v9
     semgrep.dev:
       rule:
+        r_id: 9513
+        rv_id: 110232
         rule_id: X5U8v5
         version_id: 3ZTkQdQ
         url: https://semgrep.dev/playground/r/3ZTkQdQ/python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
@@ -30168,6 +31327,8 @@ rules:
     shortlink: https://sg.run/YvY4
     semgrep.dev:
       rule:
+        r_id: 9514
+        rv_id: 110233
         rule_id: j2UvEw
         version_id: 44TRlo6
         url: https://semgrep.dev/playground/r/44TRlo6/python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
@@ -30435,6 +31596,8 @@ rules:
     shortlink: https://sg.run/6n2B
     semgrep.dev:
       rule:
+        r_id: 9515
+        rv_id: 110234
         rule_id: 10UKDo
         version_id: PkTJ1YR
         url: https://semgrep.dev/playground/r/PkTJ1YR/python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
@@ -30724,6 +31887,8 @@ rules:
     shortlink: https://sg.run/Og7L
     semgrep.dev:
       rule:
+        r_id: 18275
+        rv_id: 110238
         rule_id: DbUGvk
         version_id: RGTDkb9
         url: https://semgrep.dev/playground/r/RGTDkb9/python.django.security.nan-injection.nan-injection
@@ -30753,6 +31918,8 @@ rules:
     shortlink: https://sg.run/oxnR
     semgrep.dev:
       rule:
+        r_id: 9516
+        rv_id: 110239
         rule_id: 9AU1jW
         version_id: A8T95RL
         url: https://semgrep.dev/playground/r/A8T95RL/python.django.security.passwords.password-empty-string.password-empty-string
@@ -30801,6 +31968,8 @@ rules:
     shortlink: https://sg.run/zvBW
     semgrep.dev:
       rule:
+        r_id: 9517
+        rv_id: 250906
         rule_id: yyUn6Z
         version_id: yeT3XWe
         url: https://semgrep.dev/playground/r/yeT3XWe/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
@@ -30868,6 +32037,8 @@ rules:
     shortlink: https://sg.run/KxApY
     semgrep.dev:
       rule:
+        r_id: 112311
+        rv_id: 250907
         rule_id: lBU4JQ3
         version_id: rxT0xJG
         url: https://semgrep.dev/playground/r/rxT0xJG/python.fastapi.security.wildcard-cors.wildcard-cors
@@ -30896,6 +32067,8 @@ rules:
     shortlink: https://sg.run/eLby
     semgrep.dev:
       rule:
+        r_id: 9532
+        rv_id: 110248
         rule_id: L1Uy1n
         version_id: 6xTvJer
         url: https://semgrep.dev/playground/r/6xTvJer/python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
@@ -30939,6 +32112,8 @@ rules:
     shortlink: https://sg.run/vz5b
     semgrep.dev:
       rule:
+        r_id: 9533
+        rv_id: 110249
         rule_id: 8GUjdX
         version_id: o5Tglnv
         url: https://semgrep.dev/playground/r/o5Tglnv/python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
@@ -30976,6 +32151,8 @@ rules:
     shortlink: https://sg.run/dKrd
     semgrep.dev:
       rule:
+        r_id: 9534
+        rv_id: 110250
         rule_id: gxU1bd
         version_id: zyTK85o
         url: https://semgrep.dev/playground/r/zyTK85o/python.flask.security.audit.debug-enabled.debug-enabled
@@ -31013,6 +32190,8 @@ rules:
     shortlink: https://sg.run/Zv6o
     semgrep.dev:
       rule:
+        r_id: 9535
+        rv_id: 110251
         rule_id: QrUz49
         version_id: pZT1yrE
         url: https://semgrep.dev/playground/r/pZT1yrE/python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
@@ -31096,6 +32275,8 @@ rules:
     shortlink: https://sg.run/N0Rx
     semgrep.dev:
       rule:
+        r_id: 72427
+        rv_id: 110263
         rule_id: KxUX3z
         version_id: xyTKZ4J
         url: https://semgrep.dev/playground/r/xyTKZ4J/python.flask.security.hashids-with-flask-secret.hashids-with-flask-secret
@@ -31147,6 +32328,8 @@ rules:
     shortlink: https://sg.run/JzqQ
     semgrep.dev:
       rule:
+        r_id: 31146
+        rv_id: 110264
         rule_id: L1UR2K
         version_id: O9TNO0j
         url: https://semgrep.dev/playground/r/O9TNO0j/python.flask.security.injection.csv-writer-injection.csv-writer-injection
@@ -31243,6 +32426,8 @@ rules:
     shortlink: https://sg.run/e598
     semgrep.dev:
       rule:
+        r_id: 18276
+        rv_id: 110265
         rule_id: WAUdj7
         version_id: e1T01d0
         url: https://semgrep.dev/playground/r/e1T01d0/python.flask.security.injection.nan-injection.nan-injection
@@ -31283,6 +32468,8 @@ rules:
     shortlink: https://sg.run/Pb7e
     semgrep.dev:
       rule:
+        r_id: 14389
+        rv_id: 110268
         rule_id: GdUrJv
         version_id: ZRTQNE5
         url: https://semgrep.dev/playground/r/ZRTQNE5/python.flask.security.injection.raw-html-concat.raw-html-format
@@ -31356,6 +32543,8 @@ rules:
     shortlink: https://sg.run/J9LW
     semgrep.dev:
       rule:
+        r_id: 9546
+        rv_id: 110269
         rule_id: WAUoRx
         version_id: nWTxPeY
         url: https://semgrep.dev/playground/r/nWTxPeY/python.flask.security.injection.ssrf-requests.ssrf-requests
@@ -31499,6 +32688,8 @@ rules:
     shortlink: https://sg.run/5gW3
     semgrep.dev:
       rule:
+        r_id: 31147
+        rv_id: 110270
         rule_id: 8GU3qp
         version_id: ExTjNkQ
         url: https://semgrep.dev/playground/r/ExTjNkQ/python.flask.security.injection.subprocess-injection.subprocess-injection
@@ -31536,6 +32727,8 @@ rules:
     shortlink: https://sg.run/JxZj
     semgrep.dev:
       rule:
+        r_id: 14702
+        rv_id: 110271
         rule_id: YGUDKQ
         version_id: 7ZTgo7v
         url: https://semgrep.dev/playground/r/7ZTgo7v/python.flask.security.injection.tainted-sql-string.tainted-sql-string
@@ -31606,6 +32799,8 @@ rules:
     shortlink: https://sg.run/RXpK
     semgrep.dev:
       rule:
+        r_id: 14649
+        rv_id: 110272
         rule_id: ReU3Wb
         version_id: LjTqQYP
         url: https://semgrep.dev/playground/r/LjTqQYP/python.flask.security.injection.tainted-url-host.tainted-url-host
@@ -31687,6 +32882,8 @@ rules:
     shortlink: https://sg.run/5QpX
     semgrep.dev:
       rule:
+        r_id: 9547
+        rv_id: 110273
         rule_id: 0oU54W
         version_id: 8KTQ92G
         url: https://semgrep.dev/playground/r/8KTQ92G/python.flask.security.injection.user-eval.eval-injection
@@ -31764,6 +32961,8 @@ rules:
     shortlink: https://sg.run/Ge42
     semgrep.dev:
       rule:
+        r_id: 9548
+        rv_id: 110274
         rule_id: KxUbl2
         version_id: gET3x4k
         url: https://semgrep.dev/playground/r/gET3x4k/python.flask.security.injection.user-exec.exec-injection
@@ -31850,6 +33049,8 @@ rules:
     shortlink: https://sg.run/L2L7
     semgrep.dev:
       rule:
+        r_id: 20039
+        rv_id: 110286
         rule_id: QrU1Xg
         version_id: WrTWQxg
         url: https://semgrep.dev/playground/r/WrTWQxg/python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
@@ -31892,6 +33093,8 @@ rules:
     shortlink: https://sg.run/8kY4
     semgrep.dev:
       rule:
+        r_id: 20040
+        rv_id: 110287
         rule_id: 3qULRx
         version_id: 0bTLlO0
         url: https://semgrep.dev/playground/r/0bTLlO0/python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
@@ -31928,6 +33131,8 @@ rules:
     shortlink: https://sg.run/l2E9
     semgrep.dev:
       rule:
+        r_id: 9557
+        rv_id: 110290
         rule_id: X5U8P5
         version_id: l4T4vPA
         url: https://semgrep.dev/playground/r/l4T4vPA/python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
@@ -31972,6 +33177,8 @@ rules:
     shortlink: https://sg.run/Yvp4
     semgrep.dev:
       rule:
+        r_id: 9558
+        rv_id: 110291
         rule_id: j2UvKw
         version_id: YDTp2P1
         url: https://semgrep.dev/playground/r/YDTp2P1/python.jwt.security.jwt-none-alg.jwt-python-none-alg
@@ -32083,6 +33290,8 @@ rules:
     shortlink: https://sg.run/Apjp
     semgrep.dev:
       rule:
+        r_id: 27250
+        rv_id: 110367
         rule_id: 7KUE1E
         version_id: vdTY8rX
         url: https://semgrep.dev/playground/r/vdTY8rX/python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
@@ -32186,6 +33395,8 @@ rules:
     shortlink: https://sg.run/Dx8Y
     semgrep.dev:
       rule:
+        r_id: 27252
+        rv_id: 110369
         rule_id: 8GU5q3
         version_id: ZRTQp4x
         url: https://semgrep.dev/playground/r/ZRTQp4x/python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
@@ -32298,6 +33509,8 @@ rules:
     shortlink: https://sg.run/0Bgv
     semgrep.dev:
       rule:
+        r_id: 27254
+        rv_id: 110371
         rule_id: QrUG72
         version_id: ExTjA8X
         url: https://semgrep.dev/playground/r/ExTjA8X/python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
@@ -32415,6 +33628,8 @@ rules:
     shortlink: https://sg.run/qL6z
     semgrep.dev:
       rule:
+        r_id: 27256
+        rv_id: 110373
         rule_id: 4bUEAY
         version_id: LjTqANx
         url: https://semgrep.dev/playground/r/LjTqANx/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
@@ -32534,6 +33749,8 @@ rules:
     shortlink: https://sg.run/Y3Ke
     semgrep.dev:
       rule:
+        r_id: 27258
+        rv_id: 110375
         rule_id: JDUz34
         version_id: gET3OZv
         url: https://semgrep.dev/playground/r/gET3OZv/python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
@@ -32624,6 +33841,8 @@ rules:
     shortlink: https://sg.run/oLl9
     semgrep.dev:
       rule:
+        r_id: 27260
+        rv_id: 110377
         rule_id: GdUkxO
         version_id: 3ZTkrYD
         url: https://semgrep.dev/playground/r/3ZTkrYD/python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
@@ -32747,6 +33966,8 @@ rules:
     shortlink: https://sg.run/pLGg
     semgrep.dev:
       rule:
+        r_id: 27262
+        rv_id: 110379
         rule_id: AbUgrZ
         version_id: PkTJd5l
         url: https://semgrep.dev/playground/r/PkTJd5l/python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
@@ -32864,6 +34085,8 @@ rules:
     shortlink: https://sg.run/XR2K
     semgrep.dev:
       rule:
+        r_id: 27264
+        rv_id: 110382
         rule_id: DbUR9g
         version_id: GxTv8LN
         url: https://semgrep.dev/playground/r/GxTv8LN/python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
@@ -32960,6 +34183,8 @@ rules:
     shortlink: https://sg.run/1DLw
     semgrep.dev:
       rule:
+        r_id: 27266
+        rv_id: 110384
         rule_id: 0oUK7N
         version_id: A8T9Xjw
         url: https://semgrep.dev/playground/r/A8T9Xjw/python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
@@ -32995,6 +34220,8 @@ rules:
     shortlink: https://sg.run/AXY4
     semgrep.dev:
       rule:
+        r_id: 13594
+        rv_id: 110392
         rule_id: zdUYqR
         version_id: YDTpnq3
         url: https://semgrep.dev/playground/r/YDTpnq3/python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
@@ -33079,6 +34306,8 @@ rules:
     shortlink: https://sg.run/ydNx
     semgrep.dev:
       rule:
+        r_id: 9668
+        rv_id: 110411
         rule_id: x8UnJk
         version_id: X0TQ2Q4
         url: https://semgrep.dev/playground/r/X0TQ2Q4/python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
@@ -33120,6 +34349,8 @@ rules:
     shortlink: https://sg.run/5DwD
     semgrep.dev:
       rule:
+        r_id: 14703
+        rv_id: 110414
         rule_id: 6JU1w1
         version_id: 9lTd5d6
         url: https://semgrep.dev/playground/r/9lTd5d6/python.lang.security.audit.md5-used-as-password.md5-used-as-password
@@ -33166,6 +34397,8 @@ rules:
     shortlink: https://sg.run/rdln
     semgrep.dev:
       rule:
+        r_id: 9669
+        rv_id: 110415
         rule_id: OrU3og
         version_id: yeTRZR5
         url: https://semgrep.dev/playground/r/yeTRZR5/python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
@@ -33224,6 +34457,8 @@ rules:
     shortlink: https://sg.run/b7yp
     semgrep.dev:
       rule:
+        r_id: 9670
+        rv_id: 110416
         rule_id: eqU87k
         version_id: rxTy4y8
         url: https://semgrep.dev/playground/r/rxTy4y8/python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
@@ -33260,6 +34495,8 @@ rules:
     shortlink: https://sg.run/PJOY
     semgrep.dev:
       rule:
+        r_id: 9645
+        rv_id: 110427
         rule_id: BYUN2e
         version_id: nWTxox3
         url: https://semgrep.dev/playground/r/nWTxox3/python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
@@ -33306,6 +34543,8 @@ rules:
     shortlink: https://sg.run/J92w
     semgrep.dev:
       rule:
+        r_id: 9646
+        rv_id: 110428
         rule_id: DbUpz2
         version_id: ExTjAjz
         url: https://semgrep.dev/playground/r/ExTjAjz/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
@@ -33470,6 +34709,8 @@ rules:
     shortlink: https://sg.run/9pRY
     semgrep.dev:
       rule:
+        r_id: 27267
+        rv_id: 110432
         rule_id: KxUKzx
         version_id: gET3O37
         url: https://semgrep.dev/playground/r/gET3O37/python.lang.security.dangerous-code-run.dangerous-interactive-code-run
@@ -33639,6 +34880,8 @@ rules:
     shortlink: https://sg.run/yL9x
     semgrep.dev:
       rule:
+        r_id: 27268
+        rv_id: 110434
         rule_id: qNUR13
         version_id: 3ZTkrkN
         url: https://semgrep.dev/playground/r/3ZTkrkN/python.lang.security.dangerous-os-exec.dangerous-os-exec
@@ -33851,6 +35094,8 @@ rules:
     shortlink: https://sg.run/r8Zn
     semgrep.dev:
       rule:
+        r_id: 27269
+        rv_id: 110435
         rule_id: lBUJrn
         version_id: 44TR6Rn
         url: https://semgrep.dev/playground/r/44TR6Rn/python.lang.security.dangerous-spawn-process.dangerous-spawn-process
@@ -33993,6 +35238,8 @@ rules:
     shortlink: https://sg.run/bPop
     semgrep.dev:
       rule:
+        r_id: 27270
+        rv_id: 110436
         rule_id: PeURWr
         version_id: PkTJdJp
         url: https://semgrep.dev/playground/r/PkTJdJp/python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
@@ -34168,6 +35415,8 @@ rules:
     shortlink: https://sg.run/NWxp
     semgrep.dev:
       rule:
+        r_id: 27271
+        rv_id: 110437
         rule_id: JDUz3R
         version_id: JdTNvNq
         url: https://semgrep.dev/playground/r/JdTNvNq/python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
@@ -34340,6 +35589,8 @@ rules:
     shortlink: https://sg.run/k0W7
     semgrep.dev:
       rule:
+        r_id: 27272
+        rv_id: 110438
         rule_id: 5rUoP1
         version_id: 5PTded5
         url: https://semgrep.dev/playground/r/5PTded5/python.lang.security.dangerous-system-call.dangerous-system-call
@@ -34488,6 +35739,8 @@ rules:
     shortlink: https://sg.run/wLpY
     semgrep.dev:
       rule:
+        r_id: 27273
+        rv_id: 110439
         rule_id: GdUkxR
         version_id: GxTv8v9
         url: https://semgrep.dev/playground/r/GxTv8v9/python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
@@ -34535,6 +35788,8 @@ rules:
     shortlink: https://sg.run/vYrY
     semgrep.dev:
       rule:
+        r_id: 33633
+        rv_id: 110447
         rule_id: PeU2e2
         version_id: qkT2B5X
         url: https://semgrep.dev/playground/r/qkT2B5X/python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
@@ -34583,6 +35838,8 @@ rules:
     shortlink: https://sg.run/ydYx
     semgrep.dev:
       rule:
+        r_id: 9624
+        rv_id: 110448
         rule_id: x8UnBk
         version_id: l4T46lW
         url: https://semgrep.dev/playground/r/l4T46lW/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
@@ -34618,6 +35875,8 @@ rules:
     shortlink: https://sg.run/n3jG
     semgrep.dev:
       rule:
+        r_id: 72436
+        rv_id: 110452
         rule_id: X5Uqnx
         version_id: zyTKDj8
         url: https://semgrep.dev/playground/r/zyTKDj8/python.lang.security.use-defused-xml-parse.use-defused-xml-parse
@@ -34661,6 +35920,8 @@ rules:
     shortlink: https://sg.run/dlOE
     semgrep.dev:
       rule:
+        r_id: 33634
+        rv_id: 110456
         rule_id: JDUGnK
         version_id: jQTgyl1
         url: https://semgrep.dev/playground/r/jQTgyl1/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
@@ -34699,6 +35960,8 @@ rules:
     shortlink: https://sg.run/Z5bw
     semgrep.dev:
       rule:
+        r_id: 33635
+        rv_id: 110457
         rule_id: 5rUr73
         version_id: 1QTO7z3
         url: https://semgrep.dev/playground/r/1QTO7z3/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
@@ -34737,6 +36000,8 @@ rules:
     shortlink: https://sg.run/nAbY
     semgrep.dev:
       rule:
+        r_id: 33636
+        rv_id: 110458
         rule_id: GdUYlW
         version_id: 9lTd5e6
         url: https://semgrep.dev/playground/r/9lTd5e6/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
@@ -34775,6 +36040,8 @@ rules:
     shortlink: https://sg.run/Eo6N
     semgrep.dev:
       rule:
+        r_id: 33637
+        rv_id: 110459
         rule_id: ReUnEB
         version_id: yeTRZ35
         url: https://semgrep.dev/playground/r/yeTRZ35/python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
@@ -34813,6 +36080,8 @@ rules:
     shortlink: https://sg.run/L0yr
     semgrep.dev:
       rule:
+        r_id: 9683
+        rv_id: 110460
         rule_id: PeUk5W
         version_id: rxTy408
         url: https://semgrep.dev/playground/r/rxTy408/python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
@@ -34854,6 +36123,8 @@ rules:
     shortlink: https://sg.run/7JP2
     semgrep.dev:
       rule:
+        r_id: 33638
+        rv_id: 110461
         rule_id: AbU0Ex
         version_id: bZTb9Rx
         url: https://semgrep.dev/playground/r/bZTb9Rx/python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
@@ -34895,6 +36166,8 @@ rules:
     shortlink: https://sg.run/Lve6
     semgrep.dev:
       rule:
+        r_id: 33639
+        rv_id: 110462
         rule_id: BYUJy4
         version_id: NdT3ogE
         url: https://semgrep.dev/playground/r/NdT3ogE/python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
@@ -34936,6 +36209,8 @@ rules:
     shortlink: https://sg.run/85JN
     semgrep.dev:
       rule:
+        r_id: 33640
+        rv_id: 110463
         rule_id: DbUXwo
         version_id: kbTdLgQ
         url: https://semgrep.dev/playground/r/kbTdLgQ/python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
@@ -34977,6 +36252,8 @@ rules:
     shortlink: https://sg.run/3ALr
     semgrep.dev:
       rule:
+        r_id: 9687
+        rv_id: 110464
         rule_id: ReUPO3
         version_id: w8T9D6g
         url: https://semgrep.dev/playground/r/w8T9D6g/python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
@@ -35023,6 +36300,8 @@ rules:
     shortlink: https://sg.run/4y8l
     semgrep.dev:
       rule:
+        r_id: 9688
+        rv_id: 110465
         rule_id: AbUWje
         version_id: xyTKpvy
         url: https://semgrep.dev/playground/r/xyTKpvy/python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
@@ -35066,6 +36345,8 @@ rules:
     shortlink: https://sg.run/PprY
     semgrep.dev:
       rule:
+        r_id: 9689
+        rv_id: 110466
         rule_id: BYUBWe
         version_id: O9TNdk2
         url: https://semgrep.dev/playground/r/O9TNdk2/python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
@@ -35103,6 +36384,8 @@ rules:
     shortlink: https://sg.run/k1K1
     semgrep.dev:
       rule:
+        r_id: 31872
+        rv_id: 110467
         rule_id: YGUw8w
         version_id: e1T03go
         url: https://semgrep.dev/playground/r/e1T03go/python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
@@ -35159,6 +36442,8 @@ rules:
     shortlink: https://sg.run/YXRd
     semgrep.dev:
       rule:
+        r_id: 12658
+        rv_id: 110468
         rule_id: d8UlOX
         version_id: vdTY81E
         url: https://semgrep.dev/playground/r/vdTY81E/python.pymongo.security.mongodb.mongo-client-bad-auth
@@ -35201,6 +36486,8 @@ rules:
     shortlink: https://sg.run/EprB
     semgrep.dev:
       rule:
+        r_id: 21437
+        rv_id: 110469
         rule_id: bwUXKB
         version_id: d6Trvq1
         url: https://semgrep.dev/playground/r/d6Trvq1/python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
@@ -35254,6 +36541,8 @@ rules:
     shortlink: https://sg.run/7DgQ
     semgrep.dev:
       rule:
+        r_id: 21438
+        rv_id: 110470
         rule_id: NbUq9e
         version_id: ZRTQp60
         url: https://semgrep.dev/playground/r/ZRTQp60/python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
@@ -35299,6 +36588,8 @@ rules:
     shortlink: https://sg.run/LYrY
     semgrep.dev:
       rule:
+        r_id: 21439
+        rv_id: 110471
         rule_id: kxUYjY
         version_id: nWTxoO3
         url: https://semgrep.dev/playground/r/nWTxoO3/python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
@@ -35348,6 +36639,8 @@ rules:
     shortlink: https://sg.run/8WxQ
     semgrep.dev:
       rule:
+        r_id: 21440
+        rv_id: 110472
         rule_id: wdUKzn
         version_id: ExTjARz
         url: https://semgrep.dev/playground/r/ExTjARz/python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
@@ -35400,6 +36693,8 @@ rules:
     shortlink: https://sg.run/gjp5
     semgrep.dev:
       rule:
+        r_id: 21441
+        rv_id: 110473
         rule_id: x8UqAp
         version_id: 7ZTgnD4
         url: https://semgrep.dev/playground/r/7ZTgnD4/python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
@@ -35449,6 +36744,8 @@ rules:
     shortlink: https://sg.run/3GeW
     semgrep.dev:
       rule:
+        r_id: 21443
+        rv_id: 110475
         rule_id: eqU9Le
         version_id: 8KTQy4l
         url: https://semgrep.dev/playground/r/8KTQy4l/python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
@@ -35485,6 +36782,8 @@ rules:
     shortlink: https://sg.run/4RB9
     semgrep.dev:
       rule:
+        r_id: 21444
+        rv_id: 110476
         rule_id: v8UGpL
         version_id: gET3O67
         url: https://semgrep.dev/playground/r/gET3O67/python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
@@ -35552,6 +36851,8 @@ rules:
     shortlink: https://sg.run/P19v
     semgrep.dev:
       rule:
+        r_id: 21445
+        rv_id: 110477
         rule_id: d8UPQ7
         version_id: QkTWw8O
         url: https://semgrep.dev/playground/r/QkTWw8O/python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
@@ -35612,6 +36913,8 @@ rules:
     shortlink: https://sg.run/JbqP
     semgrep.dev:
       rule:
+        r_id: 21446
+        rv_id: 110478
         rule_id: ZqU37W
         version_id: 3ZTkrlN
         url: https://semgrep.dev/playground/r/3ZTkrlN/python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
@@ -35665,6 +36968,8 @@ rules:
     shortlink: https://sg.run/5AWj
     semgrep.dev:
       rule:
+        r_id: 21447
+        rv_id: 110479
         rule_id: nJUp80
         version_id: 44TR67n
         url: https://semgrep.dev/playground/r/44TR67n/python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
@@ -35719,6 +37024,8 @@ rules:
     shortlink: https://sg.run/GXR6
     semgrep.dev:
       rule:
+        r_id: 21448
+        rv_id: 110480
         rule_id: EwUgpY
         version_id: PkTJdDp
         url: https://semgrep.dev/playground/r/PkTJdDp/python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
@@ -35772,6 +37079,8 @@ rules:
     shortlink: https://sg.run/RbrN
     semgrep.dev:
       rule:
+        r_id: 21449
+        rv_id: 110481
         rule_id: 7KUr15
         version_id: JdTNv5q
         url: https://semgrep.dev/playground/r/JdTNv5q/python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
@@ -35830,6 +37139,8 @@ rules:
     shortlink: https://sg.run/AzjB
     semgrep.dev:
       rule:
+        r_id: 21450
+        rv_id: 110482
         rule_id: L1UX2J
         version_id: 5PTdek5
         url: https://semgrep.dev/playground/r/5PTdek5/python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
@@ -35878,6 +37189,8 @@ rules:
     shortlink: https://sg.run/Bx2R
     semgrep.dev:
       rule:
+        r_id: 21451
+        rv_id: 110483
         rule_id: 8GUKqP
         version_id: GxTv8j9
         url: https://semgrep.dev/playground/r/GxTv8j9/python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
@@ -35912,6 +37225,8 @@ rules:
     shortlink: https://sg.run/DX8G
     semgrep.dev:
       rule:
+        r_id: 21452
+        rv_id: 110484
         rule_id: gxUeA8
         version_id: RGTDRQO
         url: https://semgrep.dev/playground/r/RGTDRQO/python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
@@ -35978,6 +37293,8 @@ rules:
     shortlink: https://sg.run/W7eE
     semgrep.dev:
       rule:
+        r_id: 21453
+        rv_id: 110485
         rule_id: QrUZ7l
         version_id: A8T9Xr9
         url: https://semgrep.dev/playground/r/A8T9Xr9/python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
@@ -36078,10 +37395,70 @@ rules:
     shortlink: https://sg.run/J3Xo
     semgrep.dev:
       rule:
+        r_id: 9702
+        rv_id: 110499
         rule_id: BYUBWo
         version_id: BjTXpDb
         url: https://semgrep.dev/playground/r/BjTXpDb/python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
         origin: community
+- id: python.twilio.security.twiml-injection.twiml-injection
+  languages:
+  - python
+  severity: WARNING
+  message: Using non-constant TwiML (Twilio Markup Language) argument when creating
+    a Twilio conversation could allow the injection of additional TwiML commands
+  metadata:
+    cwe:
+    - 'CWE-91: XML Injection'
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - python
+    - twilio
+    - twiml
+    confidence: MEDIUM
+    likelihood: HIGH
+    impact: MEDIUM
+    subcategory: vuln
+    references:
+    - https://codeberg.org/fennix/funjection
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/python.twilio.security.twiml-injection.twiml-injection
+    shortlink: https://sg.run/GdEEy
+    semgrep.dev:
+      rule:
+        r_id: 134692
+        rv_id: 756860
+        rule_id: oqUgjj2
+        version_id: rxT23xn
+        url: https://semgrep.dev/playground/r/rxT23xn/python.twilio.security.twiml-injection.twiml-injection
+        origin: community
+  mode: taint
+  pattern-sources:
+  - pattern: 'f"..."
+
+      '
+  - pattern: '"..." % ...
+
+      '
+  - pattern: '"...".format(...)
+
+      '
+  - patterns:
+    - pattern: "$ARG"
+    - pattern-inside: |
+        def $F(..., $ARG, ...):
+            ...
+  pattern-sanitizers:
+  - pattern: xml.sax.saxutils.escape(...)
+  - pattern: html.escape(...)
+  pattern-sinks:
+  - patterns:
+    - pattern: "$CLIENT.calls.create(..., twiml=$SINK, ...)\n"
+    - focus-metavariable: "$SINK"
 - id: ruby.aws-lambda.security.activerecord-sqli.activerecord-sqli
   languages:
   - ruby
@@ -36118,6 +37495,8 @@ rules:
     shortlink: https://sg.run/vXvY
     semgrep.dev:
       rule:
+        r_id: 18277
+        rv_id: 110500
         rule_id: 0oUw9g
         version_id: DkT6Y9w
         url: https://semgrep.dev/playground/r/DkT6Y9w/ruby.aws-lambda.security.activerecord-sqli.activerecord-sqli
@@ -36175,6 +37554,8 @@ rules:
     shortlink: https://sg.run/dJLE
     semgrep.dev:
       rule:
+        r_id: 18278
+        rv_id: 110501
         rule_id: KxUrQ3
         version_id: WrTW3lG
         url: https://semgrep.dev/playground/r/WrTW3lG/ruby.aws-lambda.security.mysql2-sqli.mysql2-sqli
@@ -36235,6 +37616,8 @@ rules:
     shortlink: https://sg.run/ZKww
     semgrep.dev:
       rule:
+        r_id: 18279
+        rv_id: 110502
         rule_id: qNUQee
         version_id: 0bTLe7q
         url: https://semgrep.dev/playground/r/0bTLe7q/ruby.aws-lambda.security.pg-sqli.pg-sqli
@@ -36296,6 +37679,8 @@ rules:
     shortlink: https://sg.run/n9vY
     semgrep.dev:
       rule:
+        r_id: 18280
+        rv_id: 110503
         rule_id: lBUy2N
         version_id: K3TvGzQ
         url: https://semgrep.dev/playground/r/K3TvGzQ/ruby.aws-lambda.security.sequel-sqli.sequel-sqli
@@ -36355,6 +37740,8 @@ rules:
     shortlink: https://sg.run/dplX
     semgrep.dev:
       rule:
+        r_id: 22078
+        rv_id: 110504
         rule_id: zdUlNJ
         version_id: qkT2B1K
         url: https://semgrep.dev/playground/r/qkT2B1K/ruby.aws-lambda.security.tainted-deserialization.tainted-deserialization
@@ -36419,6 +37806,8 @@ rules:
     shortlink: https://sg.run/EB7N
     semgrep.dev:
       rule:
+        r_id: 18281
+        rv_id: 110505
         rule_id: PeUxOE
         version_id: l4T46re
         url: https://semgrep.dev/playground/r/l4T46re/ruby.aws-lambda.security.tainted-sql-string.tainted-sql-string
@@ -36507,6 +37896,8 @@ rules:
     shortlink: https://sg.run/DJj2
     semgrep.dev:
       rule:
+        r_id: 9708
+        rv_id: 110513
         rule_id: lBUdQg
         version_id: jQTgy6W
         url: https://semgrep.dev/playground/r/jQTgy6W/ruby.lang.security.bad-deserialization.bad-deserialization
@@ -36571,6 +37962,8 @@ rules:
     shortlink: https://sg.run/R8GY
     semgrep.dev:
       rule:
+        r_id: 9805
+        rv_id: 110516
         rule_id: WAUZOw
         version_id: yeTRZBK
         url: https://semgrep.dev/playground/r/yeTRZBK/ruby.lang.security.dangerous-exec.dangerous-exec
@@ -36600,6 +37993,8 @@ rules:
     shortlink: https://sg.run/KWpP
     semgrep.dev:
       rule:
+        r_id: 9711
+        rv_id: 110521
         rule_id: oqUzXA
         version_id: w8T9DzL
         url: https://semgrep.dev/playground/r/w8T9DzL/ruby.lang.security.divide-by-zero.divide-by-zero
@@ -36645,6 +38040,8 @@ rules:
     shortlink: https://sg.run/YgkW
     semgrep.dev:
       rule:
+        r_id: 9714
+        rv_id: 110524
         rule_id: 2ZU4lx
         version_id: e1T03L6
         url: https://semgrep.dev/playground/r/e1T03L6/ruby.lang.security.force-ssl-false.force-ssl-false
@@ -36689,6 +38086,8 @@ rules:
     shortlink: https://sg.run/xPEe
     semgrep.dev:
       rule:
+        r_id: 20730
+        rv_id: 110526
         rule_id: bwULyN
         version_id: d6TrvQR
         url: https://semgrep.dev/playground/r/d6TrvQR/ruby.lang.security.hardcoded-secret-rsa-passphrase.hardcoded-secret-rsa-passphrase
@@ -36795,6 +38194,8 @@ rules:
     shortlink: https://sg.run/O4Re
     semgrep.dev:
       rule:
+        r_id: 20731
+        rv_id: 110527
         rule_id: NbUe4N
         version_id: ZRTQp7j
         url: https://semgrep.dev/playground/r/ZRTQp7j/ruby.lang.security.insufficient-rsa-key-size.insufficient-rsa-key-size
@@ -36859,6 +38260,8 @@ rules:
     shortlink: https://sg.run/GOZy
     semgrep.dev:
       rule:
+        r_id: 14704
+        rv_id: 110532
         rule_id: oqU4p2
         version_id: 8KTQyjj
         url: https://semgrep.dev/playground/r/8KTQyjj/ruby.lang.security.md5-used-as-password.md5-used-as-password
@@ -36903,6 +38306,8 @@ rules:
     shortlink: https://sg.run/bDwZ
     semgrep.dev:
       rule:
+        r_id: 9726
+        rv_id: 110539
         rule_id: OrUGNk
         version_id: 5PTdeO9
         url: https://semgrep.dev/playground/r/5PTdeO9/ruby.lang.security.no-eval.ruby-eval
@@ -36971,6 +38376,8 @@ rules:
     shortlink: https://sg.run/kLxX
     semgrep.dev:
       rule:
+        r_id: 9728
+        rv_id: 110541
         rule_id: v8U5Yn
         version_id: RGTDRgR
         url: https://semgrep.dev/playground/r/RGTDRgR/ruby.lang.security.ssl-mode-no-verify.ssl-mode-no-verify
@@ -37002,6 +38409,8 @@ rules:
     shortlink: https://sg.run/O1re
     semgrep.dev:
       rule:
+        r_id: 9731
+        rv_id: 110544
         rule_id: nJUYxZ
         version_id: DkT6Ypw
         url: https://semgrep.dev/playground/r/DkT6Ypw/ruby.lang.security.weak-hashes-md5.weak-hashes-md5
@@ -37046,6 +38455,8 @@ rules:
     shortlink: https://sg.run/e4qX
     semgrep.dev:
       rule:
+        r_id: 9732
+        rv_id: 110545
         rule_id: EwU4jq
         version_id: WrTW3oG
         url: https://semgrep.dev/playground/r/WrTW3oG/ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
@@ -37092,6 +38503,8 @@ rules:
     shortlink: https://sg.run/86q7
     semgrep.dev:
       rule:
+        r_id: 13584
+        rv_id: 110549
         rule_id: BYUdW6
         version_id: l4T469e
         url: https://semgrep.dev/playground/r/l4T469e/ruby.rails.security.audit.avoid-session-manipulation.avoid-session-manipulation
@@ -37136,6 +38549,8 @@ rules:
     shortlink: https://sg.run/gYln
     semgrep.dev:
       rule:
+        r_id: 13585
+        rv_id: 110550
         rule_id: DbU1dr
         version_id: YDTpnRx
         url: https://semgrep.dev/playground/r/YDTpnRx/ruby.rails.security.audit.avoid-tainted-file-access.avoid-tainted-file-access
@@ -37216,6 +38631,8 @@ rules:
     shortlink: https://sg.run/Q9gP
     semgrep.dev:
       rule:
+        r_id: 13586
+        rv_id: 110551
         rule_id: WAUyzp
         version_id: 6xTvQj4
         url: https://semgrep.dev/playground/r/6xTvQj4/ruby.rails.security.audit.avoid-tainted-ftp-call.avoid-tainted-ftp-call
@@ -37264,6 +38681,8 @@ rules:
     shortlink: https://sg.run/3rLb
     semgrep.dev:
       rule:
+        r_id: 13587
+        rv_id: 110552
         rule_id: 0oU2x3
         version_id: o5Tg9eQ
         url: https://semgrep.dev/playground/r/o5Tg9eQ/ruby.rails.security.audit.avoid-tainted-http-request.avoid-tainted-http-request
@@ -37353,6 +38772,8 @@ rules:
     shortlink: https://sg.run/4e8E
     semgrep.dev:
       rule:
+        r_id: 13588
+        rv_id: 110553
         rule_id: KxU72k
         version_id: zyTKDkv
         url: https://semgrep.dev/playground/r/zyTKDkv/ruby.rails.security.audit.avoid-tainted-shell-call.avoid-tainted-shell-call
@@ -37482,6 +38903,8 @@ rules:
     shortlink: https://sg.run/kL0o
     semgrep.dev:
       rule:
+        r_id: 10328
+        rv_id: 110569
         rule_id: NbUAz7
         version_id: vdTY8n2
         url: https://semgrep.dev/playground/r/vdTY8n2/ruby.rails.security.audit.sqli.ruby-pg-sqli.ruby-pg-sqli
@@ -37516,6 +38939,8 @@ rules:
     shortlink: https://sg.run/JxXQ
     semgrep.dev:
       rule:
+        r_id: 13590
+        rv_id: 110573
         rule_id: lBU8Qj
         version_id: ExTjA4j
         url: https://semgrep.dev/playground/r/ExTjA4j/ruby.rails.security.audit.xss.avoid-link-to.avoid-link-to
@@ -37572,6 +38997,8 @@ rules:
     shortlink: https://sg.run/5DY3
     semgrep.dev:
       rule:
+        r_id: 13591
+        rv_id: 110575
         rule_id: YGUDqJ
         version_id: LjTqA42
         url: https://semgrep.dev/playground/r/LjTqA42/ruby.rails.security.audit.xss.avoid-redirect.avoid-redirect
@@ -37645,6 +39072,8 @@ rules:
     shortlink: https://sg.run/GO2n
     semgrep.dev:
       rule:
+        r_id: 13592
+        rv_id: 110576
         rule_id: 6JU1bL
         version_id: 8KTQyEj
         url: https://semgrep.dev/playground/r/8KTQyEj/ruby.rails.security.audit.xss.avoid-render-dynamic-path.avoid-render-dynamic-path
@@ -37713,6 +39142,8 @@ rules:
     shortlink: https://sg.run/O4Zn
     semgrep.dev:
       rule:
+        r_id: 20531
+        rv_id: 110590
         rule_id: wdUkBP
         version_id: 0bTLeEq
         url: https://semgrep.dev/playground/r/0bTLeEq/ruby.rails.security.brakeman.check-before-filter.check-before-filter
@@ -37764,6 +39195,8 @@ rules:
     shortlink: https://sg.run/3QWl
     semgrep.dev:
       rule:
+        r_id: 20043
+        rv_id: 110592
         rule_id: JDUokO
         version_id: qkT2BoK
         url: https://semgrep.dev/playground/r/qkT2BoK/ruby.rails.security.brakeman.check-dynamic-render-local-file-include.check-dynamic-render-local-file-include
@@ -37812,6 +39245,8 @@ rules:
     shortlink: https://sg.run/eJ6y
     semgrep.dev:
       rule:
+        r_id: 20532
+        rv_id: 110593
         rule_id: x8UdDE
         version_id: l4T46de
         url: https://semgrep.dev/playground/r/l4T46de/ruby.rails.security.brakeman.check-http-verb-confusion.check-http-verb-confusion
@@ -37868,6 +39303,8 @@ rules:
     shortlink: https://sg.run/KyJd
     semgrep.dev:
       rule:
+        r_id: 20155
+        rv_id: 110597
         rule_id: lBUX1r
         version_id: GxTv805
         url: https://semgrep.dev/playground/r/GxTv805/ruby.rails.security.brakeman.check-rails-session-secret-handling.check-rails-session-secret-handling
@@ -37958,6 +39395,8 @@ rules:
     shortlink: https://sg.run/eJNX
     semgrep.dev:
       rule:
+        r_id: 20732
+        rv_id: 110598
         rule_id: kxUOJ6
         version_id: RGTDRPZ
         url: https://semgrep.dev/playground/r/RGTDRPZ/ruby.rails.security.brakeman.check-redirect-to.check-redirect-to
@@ -38035,6 +39474,8 @@ rules:
     shortlink: https://sg.run/qZwx
     semgrep.dev:
       rule:
+        r_id: 20156
+        rv_id: 110599
         rule_id: YGUY4R
         version_id: A8T9XWO
         url: https://semgrep.dev/playground/r/A8T9XWO/ruby.rails.security.brakeman.check-regex-dos.check-regex-dos
@@ -38108,6 +39549,8 @@ rules:
     shortlink: https://sg.run/Jw8Z
     semgrep.dev:
       rule:
+        r_id: 20046
+        rv_id: 253875
         rule_id: ReU2pZ
         version_id: X0TOBZb
         url: https://semgrep.dev/playground/r/X0TOBZb/ruby.rails.security.brakeman.check-render-local-file-include.check-render-local-file-include
@@ -38185,6 +39628,8 @@ rules:
     shortlink: https://sg.run/r30j
     semgrep.dev:
       rule:
+        r_id: 22069
+        rv_id: 110601
         rule_id: DbUNX4
         version_id: DkT6YWJ
         url: https://semgrep.dev/playground/r/DkT6YWJ/ruby.rails.security.brakeman.check-reverse-tabnabbing.check-reverse-tabnabbing
@@ -38229,6 +39674,8 @@ rules:
     shortlink: https://sg.run/5ZKl
     semgrep.dev:
       rule:
+        r_id: 20047
+        rv_id: 110602
         rule_id: AbUNqO
         version_id: WrTW3ZB
         url: https://semgrep.dev/playground/r/WrTW3ZB/ruby.rails.security.brakeman.check-secrets.check-secrets
@@ -38289,6 +39736,8 @@ rules:
     shortlink: https://sg.run/GbY1
     semgrep.dev:
       rule:
+        r_id: 20048
+        rv_id: 110603
         rule_id: BYUKbl
         version_id: 0bTLeEn
         url: https://semgrep.dev/playground/r/0bTLeEn/ruby.rails.security.brakeman.check-send-file.check-send-file
@@ -38398,6 +39847,8 @@ rules:
     shortlink: https://sg.run/vpgb
     semgrep.dev:
       rule:
+        r_id: 20533
+        rv_id: 110604
         rule_id: OrUv2z
         version_id: K3TvG41
         url: https://semgrep.dev/playground/r/K3TvG41/ruby.rails.security.brakeman.check-sql.check-sql
@@ -38468,6 +39919,8 @@ rules:
     shortlink: https://sg.run/dPYd
     semgrep.dev:
       rule:
+        r_id: 20534
+        rv_id: 252884
         rule_id: eqUZ2Q
         version_id: LjT7YWR
         url: https://semgrep.dev/playground/r/LjT7YWR/ruby.rails.security.brakeman.check-unsafe-reflection-methods.check-unsafe-reflection-methods
@@ -38536,6 +39989,8 @@ rules:
     shortlink: https://sg.run/vpEX
     semgrep.dev:
       rule:
+        r_id: 20733
+        rv_id: 110606
         rule_id: wdUkYA
         version_id: l4T46dO
         url: https://semgrep.dev/playground/r/l4T46dO/ruby.rails.security.brakeman.check-unsafe-reflection.check-unsafe-reflection
@@ -38602,6 +40057,8 @@ rules:
     shortlink: https://sg.run/dPbP
     semgrep.dev:
       rule:
+        r_id: 20734
+        rv_id: 110607
         rule_id: x8Ud6d
         version_id: YDTpnrb
         url: https://semgrep.dev/playground/r/YDTpnrb/ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
@@ -38653,6 +40110,8 @@ rules:
     shortlink: https://sg.run/ZPo7
     semgrep.dev:
       rule:
+        r_id: 20735
+        rv_id: 110608
         rule_id: OrUv1X
         version_id: 6xTvQq9
         url: https://semgrep.dev/playground/r/6xTvQq9/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex
@@ -38694,6 +40153,8 @@ rules:
     shortlink: https://sg.run/b2JQ
     semgrep.dev:
       rule:
+        r_id: 14470
+        rv_id: 110610
         rule_id: kxUwZX
         version_id: zyTKDy4
         url: https://semgrep.dev/playground/r/zyTKDy4/ruby.rails.security.injection.raw-html-format.raw-html-format
@@ -38763,6 +40224,8 @@ rules:
     shortlink: https://sg.run/Y85o
     semgrep.dev:
       rule:
+        r_id: 14714
+        rv_id: 113536
         rule_id: bwU8gl
         version_id: YDTpZBw
         url: https://semgrep.dev/playground/r/YDTpZBw/ruby.rails.security.injection.tainted-sql-string.tainted-sql-string
@@ -38847,6 +40310,8 @@ rules:
     shortlink: https://sg.run/RX3g
     semgrep.dev:
       rule:
+        r_id: 14705
+        rv_id: 110612
         rule_id: zdUY0W
         version_id: 2KTz34D
         url: https://semgrep.dev/playground/r/2KTz34D/ruby.rails.security.injection.tainted-url-host.tainted-url-host
@@ -38902,6 +40367,8 @@ rules:
     shortlink: https://sg.run/DqrG
     semgrep.dev:
       rule:
+        r_id: 40108
+        rv_id: 110617
         rule_id: qNUKDg
         version_id: yeTRZyR
         url: https://semgrep.dev/playground/r/yeTRZyR/rust.lang.security.reqwest-accept-invalid.reqwest-accept-invalid
@@ -38937,6 +40404,8 @@ rules:
     shortlink: https://sg.run/01Rw
     semgrep.dev:
       rule:
+        r_id: 40110
+        rv_id: 110619
         rule_id: YGU8LK
         version_id: bZTb9NK
         url: https://semgrep.dev/playground/r/bZTb9NK/rust.lang.security.rustls-dangerous.rustls-dangerous
@@ -38965,6 +40434,8 @@ rules:
     shortlink: https://sg.run/K2Pn
     semgrep.dev:
       rule:
+        r_id: 40111
+        rv_id: 110620
         rule_id: 6JU0Bl
         version_id: NdT3oYk
         url: https://semgrep.dev/playground/r/NdT3oYk/rust.lang.security.ssl-verify-none.ssl-verify-none
@@ -39061,6 +40532,8 @@ rules:
     shortlink: https://sg.run/8zE7
     semgrep.dev:
       rule:
+        r_id: 19040
+        rv_id: 110623
         rule_id: WAUdK0
         version_id: xyTKp2x
         url: https://semgrep.dev/playground/r/xyTKp2x/scala.jwt-scala.security.jwt-scala-hardcode.jwt-scala-hardcode
@@ -39156,6 +40629,8 @@ rules:
     shortlink: https://sg.run/gRQn
     semgrep.dev:
       rule:
+        r_id: 19041
+        rv_id: 110628
         rule_id: 0oUwzP
         version_id: ZRTQpgN
         url: https://semgrep.dev/playground/r/ZRTQpgN/scala.lang.security.audit.documentbuilder-dtd-enabled.documentbuilder-dtd-enabled
@@ -39196,6 +40671,8 @@ rules:
     shortlink: https://sg.run/ALD6
     semgrep.dev:
       rule:
+        r_id: 20050
+        rv_id: 110638
         rule_id: WAUY8B
         version_id: PkTJdBK
         url: https://semgrep.dev/playground/r/PkTJdBK/scala.lang.security.audit.tainted-sql-string.tainted-sql-string
@@ -39341,6 +40818,8 @@ rules:
     shortlink: https://sg.run/4DEE
     semgrep.dev:
       rule:
+        r_id: 19044
+        rv_id: 110640
         rule_id: lBUyRR
         version_id: 5PTde8l
         url: https://semgrep.dev/playground/r/5PTde8l/scala.play.security.conf-csrf-headers-bypass.conf-csrf-headers-bypass
@@ -39386,6 +40865,8 @@ rules:
     shortlink: https://sg.run/8z8N
     semgrep.dev:
       rule:
+        r_id: 18284
+        rv_id: 110641
         rule_id: GdUDJO
         version_id: GxTv8Z5
         url: https://semgrep.dev/playground/r/GxTv8Z5/scala.play.security.conf-insecure-cookie-settings.conf-insecure-cookie-settings
@@ -39419,6 +40900,8 @@ rules:
     shortlink: https://sg.run/BG96
     semgrep.dev:
       rule:
+        r_id: 18795
+        rv_id: 110642
         rule_id: 0oUwn2
         version_id: RGTDRoZ
         url: https://semgrep.dev/playground/r/RGTDRoZ/scala.play.security.tainted-html-response.tainted-html-response
@@ -39516,6 +40999,8 @@ rules:
     shortlink: https://sg.run/k9K2
     semgrep.dev:
       rule:
+        r_id: 18328
+        rv_id: 110643
         rule_id: GdUDWO
         version_id: A8T9XGO
         url: https://semgrep.dev/playground/r/A8T9XGO/scala.play.security.tainted-slick-sqli.tainted-slick-sqli
@@ -39600,6 +41085,8 @@ rules:
     shortlink: https://sg.run/BeW9
     semgrep.dev:
       rule:
+        r_id: 20051
+        rv_id: 110644
         rule_id: 0oUpon
         version_id: BjTXp7l
         url: https://semgrep.dev/playground/r/BjTXp7l/scala.play.security.tainted-sql-from-http-request.tainted-sql-from-http-request
@@ -39684,6 +41171,8 @@ rules:
     shortlink: https://sg.run/803Q
     semgrep.dev:
       rule:
+        r_id: 67640
+        rv_id: 110668
         rule_id: kxUl7x
         version_id: O9TNd6l
         url: https://semgrep.dev/playground/r/O9TNd6l/solidity.security.balancer-readonly-reentrancy-getpooltokens.balancer-readonly-reentrancy-getpooltokens
@@ -39832,6 +41321,8 @@ rules:
     shortlink: https://sg.run/g9e5
     semgrep.dev:
       rule:
+        r_id: 67641
+        rv_id: 110669
         rule_id: wdUx3D
         version_id: e1T03zD
         url: https://semgrep.dev/playground/r/e1T03zD/solidity.security.balancer-readonly-reentrancy-getrate.balancer-readonly-reentrancy-getrate
@@ -39971,6 +41462,8 @@ rules:
     shortlink: https://sg.run/4A19
     semgrep.dev:
       rule:
+        r_id: 67644
+        rv_id: 110672
         rule_id: eqUkx4
         version_id: ZRTQpON
         url: https://semgrep.dev/playground/r/ZRTQpON/solidity.security.compound-borrowfresh-reentrancy.compound-borrowfresh-reentrancy
@@ -40011,6 +41504,8 @@ rules:
     shortlink: https://sg.run/P4Wv
     semgrep.dev:
       rule:
+        r_id: 67645
+        rv_id: 110673
         rule_id: v8Uz2o
         version_id: nWTxoZo
         url: https://semgrep.dev/playground/r/nWTxoZo/solidity.security.compound-sweeptoken-not-restricted.compound-sweeptoken-not-restricted
@@ -40057,6 +41552,8 @@ rules:
     shortlink: https://sg.run/Jk5P
     semgrep.dev:
       rule:
+        r_id: 67646
+        rv_id: 110674
         rule_id: d8UGDL
         version_id: ExTjAKE
         url: https://semgrep.dev/playground/r/ExTjAKE/solidity.security.curve-readonly-reentrancy.curve-readonly-reentrancy
@@ -40135,6 +41632,8 @@ rules:
     shortlink: https://sg.run/Gr46
     semgrep.dev:
       rule:
+        r_id: 67648
+        rv_id: 110676
         rule_id: nJU47w
         version_id: LjTqA5R
         url: https://semgrep.dev/playground/r/LjTqA5R/solidity.security.encode-packed-collision.encode-packed-collision
@@ -40224,6 +41723,8 @@ rules:
     shortlink: https://sg.run/BXnR
     semgrep.dev:
       rule:
+        r_id: 67651
+        rv_id: 110679
         rule_id: L1Ub0L
         version_id: QkTWwdg
         url: https://semgrep.dev/playground/r/QkTWwdg/solidity.security.erc677-reentrancy.erc677-reentrancy
@@ -40259,6 +41760,8 @@ rules:
     shortlink: https://sg.run/D17G
     semgrep.dev:
       rule:
+        r_id: 67652
+        rv_id: 110680
         rule_id: 8GUkbo
         version_id: 3ZTkrjx
         url: https://semgrep.dev/playground/r/3ZTkrjx/solidity.security.erc721-arbitrary-transferfrom.erc721-arbitrary-transferfrom
@@ -40309,6 +41812,8 @@ rules:
     shortlink: https://sg.run/WBoE
     semgrep.dev:
       rule:
+        r_id: 67653
+        rv_id: 110681
         rule_id: gxU2qG
         version_id: 44TR61x
         url: https://semgrep.dev/playground/r/44TR61x/solidity.security.erc721-reentrancy.erc721-reentrancy
@@ -40340,6 +41845,8 @@ rules:
     shortlink: https://sg.run/0Jpw
     semgrep.dev:
       rule:
+        r_id: 67654
+        rv_id: 110682
         rule_id: QrUrJj
         version_id: PkTJdoK
         url: https://semgrep.dev/playground/r/PkTJdoK/solidity.security.erc777-reentrancy.erc777-reentrancy
@@ -40371,6 +41878,8 @@ rules:
     shortlink: https://sg.run/qvPO
     semgrep.dev:
       rule:
+        r_id: 67656
+        rv_id: 110684
         rule_id: 4bUPoB
         version_id: 5PTdeLl
         url: https://semgrep.dev/playground/r/5PTdeLl/solidity.security.incorrect-use-of-blockhash.incorrect-use-of-blockhash
@@ -40412,6 +41921,8 @@ rules:
     shortlink: https://sg.run/lkEo
     semgrep.dev:
       rule:
+        r_id: 67657
+        rv_id: 110685
         rule_id: PeUrYv
         version_id: GxTv8r5
         url: https://semgrep.dev/playground/r/GxTv8r5/solidity.security.keeper-network-oracle-manipulation.keeper-network-oracle-manipulation
@@ -40421,6 +41932,63 @@ rules:
   languages:
   - solidity
   severity: WARNING
+- id: solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
+  languages:
+  - solidity
+  message: Missing check for 'from' and 'to' being the same before updating balances
+    could lead to incorrect balance manipulation on self-transfers. Include a check
+    to ensure 'from' and 'to' are not the same before updating balances to prevent
+    balance manipulation during self-transfers.
+  severity: ERROR
+  metadata:
+    category: security
+    technology:
+    - blockchain
+    - solidity
+    cwe: 'CWE-682: Incorrect Calculation'
+    subcategory:
+    - vuln
+    confidence: HIGH
+    likelihood: HIGH
+    impact: HIGH
+    owasp:
+    - A7:2021 Identification and Authentication Failures
+    references:
+    - https://blog.verichains.io/p/miner-project-attacked-by-vulnerabilities
+    - https://x.com/shoucccc/status/1757777764646859121
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
+    shortlink: https://sg.run/Or6X7
+    semgrep.dev:
+      rule:
+        r_id: 133075
+        rv_id: 751093
+        rule_id: 6JUv7Nz
+        version_id: 6xTEXKQ
+        url: https://semgrep.dev/playground/r/6xTEXKQ/solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
+        origin: community
+  patterns:
+  - pattern-either:
+    - pattern: '_balances[$FROM] = $FROM_BALANCE - value;
+
+        '
+    - pattern: '_balances[$TO] = $TO_BALANCE + value;
+
+        '
+  - pattern-not-inside: |
+      if ($FROM != $TO) {
+        ...
+        _balances[$FROM] = $FROM_BALANCE - value;
+        ...
+        _balances[$TO] = $TO_BALANCE + value;
+        ...
+      }
+  - pattern-inside: |
+      function _update(address $FROM, address $TO, uint256 value, bool mint) internal virtual {
+        ...
+      }
 - id: solidity.security.no-slippage-check.no-slippage-check
   message: No slippage check in a Uniswap v2/v3 trade
   metadata:
@@ -40442,6 +42010,8 @@ rules:
     shortlink: https://sg.run/oO8X
     semgrep.dev:
       rule:
+        r_id: 67660
+        rv_id: 110688
         rule_id: GdUE2p
         version_id: BjTXpdl
         url: https://semgrep.dev/playground/r/BjTXpdl/solidity.security.no-slippage-check.no-slippage-check
@@ -40530,6 +42100,8 @@ rules:
     shortlink: https://sg.run/2GXr
     semgrep.dev:
       rule:
+        r_id: 67663
+        rv_id: 110691
         rule_id: BYU0EL
         version_id: 0bTLe2n
         url: https://semgrep.dev/playground/r/0bTLe2n/solidity.security.proxy-storage-collision.proxy-storage-collision
@@ -40615,6 +42187,8 @@ rules:
     shortlink: https://sg.run/XDzj
     semgrep.dev:
       rule:
+        r_id: 67664
+        rv_id: 110692
         rule_id: DbU0Qb
         version_id: K3TvG71
         url: https://semgrep.dev/playground/r/K3TvG71/solidity.security.redacted-cartel-custom-approval-bug.redacted-cartel-custom-approval-bug
@@ -40651,6 +42225,8 @@ rules:
     shortlink: https://sg.run/jbZP
     semgrep.dev:
       rule:
+        r_id: 67665
+        rv_id: 110693
         rule_id: WAUpbw
         version_id: qkT2BX8
         url: https://semgrep.dev/playground/r/qkT2BX8/solidity.security.rigoblock-missing-access-control.rigoblock-missing-access-control
@@ -40683,6 +42259,8 @@ rules:
     shortlink: https://sg.run/1521
     semgrep.dev:
       rule:
+        r_id: 67666
+        rv_id: 110694
         rule_id: 0oUbvd
         version_id: l4T468O
         url: https://semgrep.dev/playground/r/l4T468O/solidity.security.sense-missing-oracle-access-control.sense-missing-oracle-access-control
@@ -40745,6 +42323,8 @@ rules:
     shortlink: https://sg.run/9KNy
     semgrep.dev:
       rule:
+        r_id: 67667
+        rv_id: 110695
         rule_id: KxUqld
         version_id: YDTpnDb
         url: https://semgrep.dev/playground/r/YDTpnDb/solidity.security.superfluid-ctx-injection.superfluid-ctx-injection
@@ -40779,6 +42359,8 @@ rules:
     shortlink: https://sg.run/yBWA
     semgrep.dev:
       rule:
+        r_id: 67668
+        rv_id: 110696
         rule_id: qNUnN0
         version_id: JdTNvLx
         url: https://semgrep.dev/playground/r/JdTNvLx/solidity.security.tecra-coin-burnfrom-bug.tecra-coin-burnfrom-bug
@@ -40828,6 +42410,8 @@ rules:
     shortlink: https://sg.run/qvoO
     semgrep.dev:
       rule:
+        r_id: 66512
+        rv_id: 110700
         rule_id: KxUqoZ
         version_id: A8T9XQ6
         url: https://semgrep.dev/playground/r/A8T9XQ6/swift.lang.storage.sensitive-storage-userdefaults.swift-user-defaults
@@ -41050,6 +42634,8 @@ rules:
     shortlink: https://sg.run/Q6o4
     semgrep.dev:
       rule:
+        r_id: 17342
+        rv_id: 253876
         rule_id: kxU6A8
         version_id: jQTlOqE
         url: https://semgrep.dev/playground/r/jQTlOqE/terraform.aws.security.aws-cloudfront-insecure-tls.aws-insecure-cloudfront-distribution-tls-version
@@ -41097,6 +42683,8 @@ rules:
     shortlink: https://sg.run/4lwl
     semgrep.dev:
       rule:
+        r_id: 17344
+        rv_id: 110730
         rule_id: x8UGBG
         version_id: nWTxoG1
         url: https://semgrep.dev/playground/r/nWTxoG1/terraform.aws.security.aws-cloudwatch-log-group-no-retention.aws-cloudwatch-log-group-no-retention
@@ -41142,6 +42730,8 @@ rules:
     shortlink: https://sg.run/5yxA
     semgrep.dev:
       rule:
+        r_id: 17347
+        rv_id: 110734
         rule_id: v8U4kG
         version_id: 8KTQyAR
         url: https://semgrep.dev/playground/r/8KTQyAR/terraform.aws.security.aws-codebuild-project-unencrypted.aws-codebuild-project-unencrypted
@@ -41187,6 +42777,8 @@ rules:
     shortlink: https://sg.run/GyAp
     semgrep.dev:
       rule:
+        r_id: 17348
+        rv_id: 110736
         rule_id: d8U4RA
         version_id: QkTWwnx
         url: https://semgrep.dev/playground/r/QkTWwnx/terraform.aws.security.aws-db-instance-no-logging.aws-db-instance-no-logging
@@ -41237,6 +42829,8 @@ rules:
     shortlink: https://sg.run/Ay4p
     semgrep.dev:
       rule:
+        r_id: 17350
+        rv_id: 110741
         rule_id: nJUGe2
         version_id: 5PTdepz
         url: https://semgrep.dev/playground/r/5PTdepz/terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
@@ -41281,6 +42875,8 @@ rules:
     shortlink: https://sg.run/ByPW
     semgrep.dev:
       rule:
+        r_id: 17351
+        rv_id: 110742
         rule_id: EwUqko
         version_id: GxTv8zA
         url: https://semgrep.dev/playground/r/GxTv8zA/terraform.aws.security.aws-ebs-snapshot-encrypted-with-cmk.aws-ebs-snapshot-encrypted-with-cmk
@@ -41324,6 +42920,8 @@ rules:
     shortlink: https://sg.run/Dy5Y
     semgrep.dev:
       rule:
+        r_id: 17352
+        rv_id: 110743
         rule_id: 7KUW7K
         version_id: RGTDRq5
         url: https://semgrep.dev/playground/r/RGTDRq5/terraform.aws.security.aws-ebs-unencrypted.aws-ebs-unencrypted
@@ -41374,6 +42972,8 @@ rules:
     shortlink: https://sg.run/08rv
     semgrep.dev:
       rule:
+        r_id: 17354
+        rv_id: 110746
         rule_id: 8GUA2n
         version_id: DkT6Yx8
         url: https://semgrep.dev/playground/r/DkT6Yx8/terraform.aws.security.aws-ec2-has-public-ip.aws-ec2-has-public-ip
@@ -41458,6 +43058,8 @@ rules:
     shortlink: https://sg.run/nzqb
     semgrep.dev:
       rule:
+        r_id: 48636
+        rv_id: 110754
         rule_id: qNUzov
         version_id: o5Tg9Br
         url: https://semgrep.dev/playground/r/o5Tg9Br/terraform.aws.security.aws-ecr-repository-wildcard-principal.aws-ecr-repository-wildcard-principal
@@ -41506,6 +43108,8 @@ rules:
     shortlink: https://sg.run/PYlq
     semgrep.dev:
       rule:
+        r_id: 19045
+        rv_id: 110757
         rule_id: YGUle7
         version_id: 2KTz377
         url: https://semgrep.dev/playground/r/2KTz377/terraform.aws.security.aws-elasticsearch-insecure-tls-version.aws-elasticsearch-insecure-tls-version
@@ -41574,6 +43178,8 @@ rules:
     shortlink: https://sg.run/lp3y
     semgrep.dev:
       rule:
+        r_id: 17357
+        rv_id: 110758
         rule_id: 3qU6J7
         version_id: X0TQ25A
         url: https://semgrep.dev/playground/r/X0TQ25A/terraform.aws.security.aws-elasticsearch-nodetonode-encryption.aws-elasticsearch-nodetonode-encryption-not-enabled
@@ -41634,6 +43240,8 @@ rules:
     shortlink: https://sg.run/XN9K
     semgrep.dev:
       rule:
+        r_id: 17364
+        rv_id: 110765
         rule_id: AbUeYK
         version_id: NdT3oBG
         url: https://semgrep.dev/playground/r/NdT3oBG/terraform.aws.security.aws-glacier-vault-any-principal.aws-glacier-vault-any-principal
@@ -41695,6 +43303,8 @@ rules:
     shortlink: https://sg.run/jzgY
     semgrep.dev:
       rule:
+        r_id: 17365
+        rv_id: 110766
         rule_id: BYUzY5
         version_id: kbTdL25
         url: https://semgrep.dev/playground/r/kbTdL25/terraform.aws.security.aws-iam-admin-policy-ssoadmin.aws-iam-admin-policy-ssoadmin
@@ -41757,6 +43367,8 @@ rules:
     shortlink: https://sg.run/1zbw
     semgrep.dev:
       rule:
+        r_id: 17366
+        rv_id: 110767
         rule_id: DbUx8l
         version_id: w8T9DAy
         url: https://semgrep.dev/playground/r/w8T9DAy/terraform.aws.security.aws-iam-admin-policy.aws-iam-admin-policy
@@ -41823,6 +43435,8 @@ rules:
     shortlink: https://sg.run/p98J
     semgrep.dev:
       rule:
+        r_id: 18818
+        rv_id: 110769
         rule_id: v8UOle
         version_id: O9TNdJ4
         url: https://semgrep.dev/playground/r/O9TNdJ4/terraform.aws.security.aws-insecure-api-gateway-tls-version.aws-insecure-api-gateway-tls-version
@@ -41877,6 +43491,8 @@ rules:
     shortlink: https://sg.run/yPYx
     semgrep.dev:
       rule:
+        r_id: 17368
+        rv_id: 110770
         rule_id: 0oUrOj
         version_id: e1T03Dw
         url: https://semgrep.dev/playground/r/e1T03Dw/terraform.aws.security.aws-insecure-redshift-ssl-configuration.aws-insecure-redshift-ssl-configuration
@@ -41941,6 +43557,8 @@ rules:
     shortlink: https://sg.run/Nwlp
     semgrep.dev:
       rule:
+        r_id: 17371
+        rv_id: 110774
         rule_id: lBUWPD
         version_id: nWTxoy1
         url: https://semgrep.dev/playground/r/nWTxoy1/terraform.aws.security.aws-kms-key-wildcard-principal.aws-kms-key-wildcard-principal
@@ -42009,6 +43627,8 @@ rules:
     shortlink: https://sg.run/kz47
     semgrep.dev:
       rule:
+        r_id: 17372
+        rv_id: 110775
         rule_id: PeU0L3
         version_id: ExTjArL
         url: https://semgrep.dev/playground/r/ExTjArL/terraform.aws.security.aws-kms-no-rotation.aws-kms-no-rotation
@@ -42065,6 +43685,8 @@ rules:
     shortlink: https://sg.run/wZqY
     semgrep.dev:
       rule:
+        r_id: 17373
+        rv_id: 110776
         rule_id: JDU6gj
         version_id: 7ZTgnxG
         url: https://semgrep.dev/playground/r/7ZTgnxG/terraform.aws.security.aws-lambda-environment-credentials.aws-lambda-environment-credentials
@@ -42123,6 +43745,8 @@ rules:
     shortlink: https://sg.run/kOP7
     semgrep.dev:
       rule:
+        r_id: 54772
+        rv_id: 110778
         rule_id: OrU9Ox
         version_id: 8KTQyGR
         url: https://semgrep.dev/playground/r/8KTQyGR/terraform.aws.security.aws-lambda-permission-unrestricted-source-arn.aws-lambda-permission-unrestricted-source-arn
@@ -42169,6 +43793,8 @@ rules:
     shortlink: https://sg.run/L3kn
     semgrep.dev:
       rule:
+        r_id: 16439
+        rv_id: 110783
         rule_id: d8U4n0
         version_id: PkTJdxG
         url: https://semgrep.dev/playground/r/PkTJdxG/terraform.aws.security.aws-provider-static-credentials.aws-provider-static-credentials
@@ -42216,6 +43842,8 @@ rules:
     shortlink: https://sg.run/OyYB
     semgrep.dev:
       rule:
+        r_id: 17375
+        rv_id: 110785
         rule_id: GdUzwQ
         version_id: 5PTdeyz
         url: https://semgrep.dev/playground/r/5PTdeyz/terraform.aws.security.aws-rds-backup-no-retention.aws-rds-backup-no-retention
@@ -42304,6 +43932,8 @@ rules:
     shortlink: https://sg.run/z3eW
     semgrep.dev:
       rule:
+        r_id: 53517
+        rv_id: 110793
         rule_id: PeUl9d
         version_id: K3TvGwv
         url: https://semgrep.dev/playground/r/K3TvGwv/terraform.aws.security.aws-sqs-queue-policy-wildcard-principal.aws-sqs-queue-policy-wildcard-principal
@@ -42376,6 +44006,8 @@ rules:
     shortlink: https://sg.run/187G
     semgrep.dev:
       rule:
+        r_id: 14966
+        rv_id: 110801
         rule_id: 2ZUP9K
         version_id: A8T9XN3
         url: https://semgrep.dev/playground/r/A8T9XN3/terraform.aws.security.insecure-load-balancer-tls-version.insecure-load-balancer-tls-version
@@ -42427,6 +44059,8 @@ rules:
     shortlink: https://sg.run/LXWr
     semgrep.dev:
       rule:
+        r_id: 15139
+        rv_id: 110804
         rule_id: 5rUL1P
         version_id: WrTW3YQ
         url: https://semgrep.dev/playground/r/WrTW3YQ/terraform.aws.security.wildcard-assume-role.wildcard-assume-role
@@ -42491,6 +44125,8 @@ rules:
     shortlink: https://sg.run/JxYw
     semgrep.dev:
       rule:
+        r_id: 15102
+        rv_id: 110865
         rule_id: 0oU23p
         version_id: bZTb9Xr
         url: https://semgrep.dev/playground/r/bZTb9Xr/terraform.azure.security.appservice.appservice-authentication-enabled.appservice-authentication-enabled
@@ -42552,6 +44188,8 @@ rules:
     shortlink: https://sg.run/5DkA
     semgrep.dev:
       rule:
+        r_id: 15103
+        rv_id: 110866
         rule_id: KxU7LJ
         version_id: NdT3oqP
         url: https://semgrep.dev/playground/r/NdT3oqP/terraform.azure.security.appservice.appservice-enable-http2.appservice-enable-http2
@@ -42606,6 +44244,8 @@ rules:
     shortlink: https://sg.run/GOKp
     semgrep.dev:
       rule:
+        r_id: 15104
+        rv_id: 110867
         rule_id: qNUXwx
         version_id: kbTdLYJ
         url: https://semgrep.dev/playground/r/kbTdLYJ/terraform.azure.security.appservice.appservice-enable-https-only.appservice-enable-https-only
@@ -42659,6 +44299,8 @@ rules:
     shortlink: https://sg.run/RX1O
     semgrep.dev:
       rule:
+        r_id: 15105
+        rv_id: 110868
         rule_id: lBU8D6
         version_id: w8T9DKO
         url: https://semgrep.dev/playground/r/w8T9DKO/terraform.azure.security.appservice.appservice-require-client-cert.appservice-require-client-cert
@@ -42700,6 +44342,8 @@ rules:
     shortlink: https://sg.run/AXRp
     semgrep.dev:
       rule:
+        r_id: 15106
+        rv_id: 110869
         rule_id: YGUDbZ
         version_id: xyTKpq7
         url: https://semgrep.dev/playground/r/xyTKpq7/terraform.azure.security.appservice.appservice-use-secure-tls-policy.appservice-use-secure-tls-policy
@@ -42749,6 +44393,8 @@ rules:
     shortlink: https://sg.run/pA1g
     semgrep.dev:
       rule:
+        r_id: 23962
+        rv_id: 110872
         rule_id: bwU1Eg
         version_id: vdTY8G6
         url: https://semgrep.dev/playground/r/vdTY8G6/terraform.azure.security.appservice.azure-appservice-detailed-errormessages-enabled.azure-appservice-detailed-errormessages-enabled
@@ -42795,6 +44441,8 @@ rules:
     shortlink: https://sg.run/1g9w
     semgrep.dev:
       rule:
+        r_id: 23966
+        rv_id: 110876
         rule_id: x8UZRP
         version_id: ExTjAg9
         url: https://semgrep.dev/playground/r/ExTjAg9/terraform.azure.security.appservice.azure-appservice-https-only.azure-appservice-https-only
@@ -42839,6 +44487,8 @@ rules:
     shortlink: https://sg.run/J1vw
     semgrep.dev:
       rule:
+        r_id: 23990
+        rv_id: 110900
         rule_id: 0oUlgp
         version_id: GxTv86W
         url: https://semgrep.dev/playground/r/GxTv86W/terraform.azure.security.azure-key-no-expiration-date.azure-key-no-expiration-date
@@ -42885,6 +44535,8 @@ rules:
     shortlink: https://sg.run/B1lW
     semgrep.dev:
       rule:
+        r_id: 23995
+        rv_id: 110905
         rule_id: 6JUJG8
         version_id: WrTW3Q2
         url: https://semgrep.dev/playground/r/WrTW3Q2/terraform.azure.security.azure-mssql-service-mintls-version.azure-mssql-service-mintls-version
@@ -42929,6 +44581,8 @@ rules:
     shortlink: https://sg.run/Dd6Y
     semgrep.dev:
       rule:
+        r_id: 23996
+        rv_id: 110906
         rule_id: oqUloL
         version_id: 0bTLelY
         url: https://semgrep.dev/playground/r/0bTLelY/terraform.azure.security.azure-mysql-encryption-enabled.azure-mysql-encryption-enabled
@@ -42975,6 +44629,8 @@ rules:
     shortlink: https://sg.run/WR44
     semgrep.dev:
       rule:
+        r_id: 23997
+        rv_id: 110907
         rule_id: zdU8NN
         version_id: K3TvGjD
         url: https://semgrep.dev/playground/r/K3TvGjD/terraform.azure.security.azure-mysql-mintls-version.azure-mysql-mintls-version
@@ -43018,6 +44674,8 @@ rules:
     shortlink: https://sg.run/vq9A
     semgrep.dev:
       rule:
+        r_id: 15133
+        rv_id: 110929
         rule_id: gxUgXq
         version_id: vdTY885
         url: https://semgrep.dev/playground/r/vdTY885/terraform.azure.security.keyvault.keyvault-ensure-key-expires.keyvault-ensure-key-expires
@@ -43061,6 +44719,8 @@ rules:
     shortlink: https://sg.run/d2RZ
     semgrep.dev:
       rule:
+        r_id: 15134
+        rv_id: 110930
         rule_id: QrUdNy
         version_id: d6Trvvl
         url: https://semgrep.dev/playground/r/d6Trvvl/terraform.azure.security.keyvault.keyvault-ensure-secret-expires.keyvault-ensure-secret-expires
@@ -43111,6 +44771,8 @@ rules:
     shortlink: https://sg.run/Z4xD
     semgrep.dev:
       rule:
+        r_id: 15135
+        rv_id: 110931
         rule_id: 3qUjw9
         version_id: ZRTQppO
         url: https://semgrep.dev/playground/r/ZRTQppO/terraform.azure.security.keyvault.keyvault-purge-enabled.keyvault-purge-enabled
@@ -43159,6 +44821,8 @@ rules:
     shortlink: https://sg.run/0y9v
     semgrep.dev:
       rule:
+        r_id: 15110
+        rv_id: 110935
         rule_id: pKUpDA
         version_id: LjTqAAX
         url: https://semgrep.dev/playground/r/LjTqAAX/terraform.azure.security.storage.storage-enforce-https.storage-enforce-https
@@ -43214,6 +44878,8 @@ rules:
     shortlink: https://sg.run/KXD7
     semgrep.dev:
       rule:
+        r_id: 15155
+        rv_id: 110937
         rule_id: AbUQdL
         version_id: gET3OOO
         url: https://semgrep.dev/playground/r/gET3OOO/terraform.azure.security.storage.storage-use-secure-tls-policy.storage-use-secure-tls-policy
@@ -43257,6 +44923,8 @@ rules:
     shortlink: https://sg.run/5g5D
     semgrep.dev:
       rule:
+        r_id: 32303
+        rv_id: 110971
         rule_id: gxUrdg
         version_id: O9TNdpn
         url: https://semgrep.dev/playground/r/O9TNdpn/terraform.gcp.security.gcp-cloud-storage-logging.gcp-cloud-storage-logging
@@ -43320,6 +44988,8 @@ rules:
     shortlink: https://sg.run/bKKW
     semgrep.dev:
       rule:
+        r_id: 33670
+        rv_id: 110997
         rule_id: 7KUZZb
         version_id: l4T46Jb
         url: https://semgrep.dev/playground/r/l4T46Jb/terraform.gcp.security.gcp-dns-key-specs-rsasha1.gcp-dns-key-specs-rsasha1
@@ -43370,6 +45040,8 @@ rules:
     shortlink: https://sg.run/W4Yg
     semgrep.dev:
       rule:
+        r_id: 33709
+        rv_id: 111037
         rule_id: v8Uod5
         version_id: 8KTQyNO
         url: https://semgrep.dev/playground/r/8KTQyNO/terraform.gcp.security.gcp-sql-database-require-ssl.gcp-sql-database-require-ssl
@@ -43438,6 +45110,8 @@ rules:
     shortlink: https://sg.run/0Xv5
     semgrep.dev:
       rule:
+        r_id: 33710
+        rv_id: 111038
         rule_id: d8U7Ll
         version_id: gET3OPo
         url: https://semgrep.dev/playground/r/gET3OPo/terraform.gcp.security.gcp-sql-public-database.gcp-sql-public-database
@@ -43475,6 +45149,8 @@ rules:
     shortlink: https://sg.run/J3BQ
     semgrep.dev:
       rule:
+        r_id: 11302
+        rv_id: 111049
         rule_id: GdU0eA
         version_id: DkT6Ykj
         url: https://semgrep.dev/playground/r/DkT6Ykj/terraform.lang.security.ec2-imdsv1-optional.ec2-imdsv1-optional
@@ -43569,6 +45245,8 @@ rules:
     shortlink: https://sg.run/x4qA
     semgrep.dev:
       rule:
+        r_id: 15830
+        rv_id: 111062
         rule_id: OrUl6W
         version_id: jQTgy1R
         url: https://semgrep.dev/playground/r/jQTgy1R/terraform.lang.security.rds-insecure-password-storage-in-source-code.rds-insecure-password-storage-in-source-code
@@ -43604,6 +45282,8 @@ rules:
     shortlink: https://sg.run/0nok
     semgrep.dev:
       rule:
+        r_id: 9754
+        rv_id: 111066
         rule_id: 6JUqvn
         version_id: rxTy4nj
         url: https://semgrep.dev/playground/r/rxTy4nj/terraform.lang.security.s3-public-rw-bucket.s3-public-rw-bucket
@@ -43641,6 +45321,8 @@ rules:
     shortlink: https://sg.run/KWxP
     semgrep.dev:
       rule:
+        r_id: 9755
+        rv_id: 111068
         rule_id: oqUzgA
         version_id: NdT3o6d
         url: https://semgrep.dev/playground/r/NdT3o6d/typescript.angular.security.audit.angular-domsanitizer.angular-bypasssecuritytrust
@@ -43777,6 +45459,8 @@ rules:
     shortlink: https://sg.run/eowX
     semgrep.dev:
       rule:
+        r_id: 15276
+        rv_id: 111069
         rule_id: bwU8qz
         version_id: kbTdLWL
         url: https://semgrep.dev/playground/r/kbTdLWL/typescript.aws-cdk.security.audit.awscdk-bucket-encryption.awscdk-bucket-encryption
@@ -43846,6 +45530,8 @@ rules:
     shortlink: https://sg.run/vqBX
     semgrep.dev:
       rule:
+        r_id: 15277
+        rv_id: 111070
         rule_id: NbUN8B
         version_id: w8T9DWR
         url: https://semgrep.dev/playground/r/w8T9DWR/typescript.aws-cdk.security.audit.awscdk-bucket-enforcessl.aws-cdk-bucket-enforcessl
@@ -43897,6 +45583,8 @@ rules:
     shortlink: https://sg.run/d23P
     semgrep.dev:
       rule:
+        r_id: 15278
+        rv_id: 111071
         rule_id: kxUwqO
         version_id: xyTKpR8
         url: https://semgrep.dev/playground/r/xyTKpR8/typescript.aws-cdk.security.audit.awscdk-sqs-unencryptedqueue.awscdk-sqs-unencryptedqueue
@@ -43958,6 +45646,8 @@ rules:
     shortlink: https://sg.run/Z4p7
     semgrep.dev:
       rule:
+        r_id: 15279
+        rv_id: 111072
         rule_id: wdUjZK
         version_id: O9TNdQQ
         url: https://semgrep.dev/playground/r/O9TNdQQ/typescript.aws-cdk.security.awscdk-bucket-grantpublicaccessmethod.awscdk-bucket-grantpublicaccessmethod
@@ -44010,6 +45700,8 @@ rules:
     shortlink: https://sg.run/nK7G
     semgrep.dev:
       rule:
+        r_id: 15280
+        rv_id: 111073
         rule_id: x8UxXZ
         version_id: e1T034b
         url: https://semgrep.dev/playground/r/e1T034b/typescript.aws-cdk.security.awscdk-codebuild-project-public.awscdk-codebuild-project-public
@@ -44063,6 +45755,8 @@ rules:
     shortlink: https://sg.run/rAx6
     semgrep.dev:
       rule:
+        r_id: 9769
+        rv_id: 111091
         rule_id: x8UWvK
         version_id: A8T9XEl
         url: https://semgrep.dev/playground/r/A8T9XEl/typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml
@@ -44219,6 +45913,8 @@ rules:
     shortlink: https://sg.run/E5x8
     semgrep.dev:
       rule:
+        r_id: 9781
+        rv_id: 111103
         rule_id: QrU68w
         version_id: RGTDRnQ
         url: https://semgrep.dev/playground/r/RGTDRnQ/typescript.react.security.audit.react-unsanitized-method.react-unsanitized-method
@@ -44372,6 +46068,8 @@ rules:
     shortlink: https://sg.run/70Zv
     semgrep.dev:
       rule:
+        r_id: 9782
+        rv_id: 111104
         rule_id: 3qUBl4
         version_id: A8T9X0z
         url: https://semgrep.dev/playground/r/A8T9X0z/typescript.react.security.audit.react-unsanitized-property.react-unsanitized-property
@@ -44538,6 +46236,8 @@ rules:
     shortlink: https://sg.run/1n0b
     semgrep.dev:
       rule:
+        r_id: 9766
+        rv_id: 111106
         rule_id: NbUA3O
         version_id: DkT6YXK
         url: https://semgrep.dev/playground/r/DkT6YXK/typescript.react.security.react-insecure-request.react-insecure-request
@@ -44614,6 +46314,8 @@ rules:
     shortlink: https://sg.run/yqeZ
     semgrep.dev:
       rule:
+        r_id: 40768
+        rv_id: 111108
         rule_id: 10U0zW
         version_id: 0bTLegr
         url: https://semgrep.dev/playground/r/0bTLegr/yaml.argo.security.argo-workflow-parameter-command-injection.argo-workflow-parameter-command-injection
@@ -44717,6 +46419,8 @@ rules:
     shortlink: https://sg.run/AlX0
     semgrep.dev:
       rule:
+        r_id: 10006
+        rv_id: 111111
         rule_id: DbUW17
         version_id: l4T46ox
         url: https://semgrep.dev/playground/r/l4T46ox/yaml.docker-compose.security.privileged-service.privileged-service
@@ -44760,6 +46464,8 @@ rules:
     shortlink: https://sg.run/qq78
     semgrep.dev:
       rule:
+        r_id: 13412
+        rv_id: 111115
         rule_id: EwUQ9x
         version_id: zyTKDNL
         url: https://semgrep.dev/playground/r/zyTKDNL/yaml.github-actions.security.allowed-unsecure-commands.allowed-unsecure-commands
@@ -44804,6 +46510,8 @@ rules:
     shortlink: https://sg.run/g1G0
     semgrep.dev:
       rule:
+        r_id: 31441
+        rv_id: 111117
         rule_id: OrUQvK
         version_id: 2KTz355
         url: https://semgrep.dev/playground/r/2KTz355/yaml.github-actions.security.github-script-injection.github-script-injection
@@ -44883,6 +46591,8 @@ rules:
     shortlink: https://sg.run/pkzk
     semgrep.dev:
       rule:
+        r_id: 13162
+        rv_id: 111119
         rule_id: v8UjQj
         version_id: jQTgyDN
         url: https://semgrep.dev/playground/r/jQTgyDN/yaml.github-actions.security.run-shell-injection.run-shell-injection
@@ -44954,6 +46664,8 @@ rules:
     shortlink: https://sg.run/A0p6
     semgrep.dev:
       rule:
+        r_id: 35494
+        rv_id: 111121
         rule_id: 4bU8E4
         version_id: 9lTd5qE
         url: https://semgrep.dev/playground/r/9lTd5qE/yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
@@ -45047,6 +46759,8 @@ rules:
     shortlink: https://sg.run/eleR
     semgrep.dev:
       rule:
+        r_id: 47276
+        rv_id: 255675
         rule_id: WAU5J6
         version_id: JdT315R
         url: https://semgrep.dev/playground/r/JdT315R/yaml.kubernetes.security.allow-privilege-escalation-no-securitycontext.allow-privilege-escalation-no-securitycontext
@@ -45116,6 +46830,8 @@ rules:
     shortlink: https://sg.run/vw3W
     semgrep.dev:
       rule:
+        r_id: 47277
+        rv_id: 111126
         rule_id: 0oUkqQ
         version_id: kbTdL3y
         url: https://semgrep.dev/playground/r/kbTdL3y/yaml.kubernetes.security.allow-privilege-escalation-true.allow-privilege-escalation-true
@@ -45188,6 +46904,8 @@ rules:
     shortlink: https://sg.run/ljp6
     semgrep.dev:
       rule:
+        r_id: 10057
+        rv_id: 255676
         rule_id: 6JUqEO
         version_id: 5PTPJk1
         url: https://semgrep.dev/playground/r/5PTPJk1/yaml.kubernetes.security.allow-privilege-escalation.allow-privilege-escalation
@@ -45230,6 +46948,8 @@ rules:
     shortlink: https://sg.run/v0pR
     semgrep.dev:
       rule:
+        r_id: 10133
+        rv_id: 111129
         rule_id: d8Uz6v
         version_id: O9TNdEz
         url: https://semgrep.dev/playground/r/O9TNdEz/yaml.kubernetes.security.exposing-docker-socket-hostpath.exposing-docker-socket-hostpath
@@ -45291,6 +47011,8 @@ rules:
     shortlink: https://sg.run/x6Dz
     semgrep.dev:
       rule:
+        r_id: 73474
+        rv_id: 113538
         rule_id: GdUR2A
         version_id: o5TgbOJ
         url: https://semgrep.dev/playground/r/o5TgbOJ/yaml.kubernetes.security.legacy-api-clusterrole-excessive-permissions.legacy-api-clusterrole-excessive-permissions
@@ -45343,6 +47065,8 @@ rules:
     shortlink: https://sg.run/Ygr5
     semgrep.dev:
       rule:
+        r_id: 10058
+        rv_id: 111133
         rule_id: oqUz2p
         version_id: ZRTQpxY
         url: https://semgrep.dev/playground/r/ZRTQpxY/yaml.kubernetes.security.privileged-container.privileged-container
@@ -45387,6 +47111,8 @@ rules:
     shortlink: https://sg.run/6rgY
     semgrep.dev:
       rule:
+        r_id: 10059
+        rv_id: 111139
         rule_id: zdUynw
         version_id: gET3OEw
         url: https://semgrep.dev/playground/r/gET3OEw/yaml.kubernetes.security.seccomp-confinement-disabled.seccomp-confinement-disabled
@@ -45442,6 +47168,8 @@ rules:
     shortlink: https://sg.run/KyL6
     semgrep.dev:
       rule:
+        r_id: 20055
+        rv_id: 111140
         rule_id: YGUYEb
         version_id: QkTWwA4
         url: https://semgrep.dev/playground/r/QkTWwA4/yaml.kubernetes.security.secrets-in-config-file.secrets-in-config-file
@@ -45480,6 +47208,8 @@ rules:
     shortlink: https://sg.run/okyn
     semgrep.dev:
       rule:
+        r_id: 10116
+        rv_id: 111141
         rule_id: zdUyWx
         version_id: 3ZTkrWd
         url: https://semgrep.dev/playground/r/3ZTkrWd/yaml.kubernetes.security.skip-tls-verify-cluster.skip-tls-verify-cluster
@@ -45518,6 +47248,8 @@ rules:
     shortlink: https://sg.run/zk10
     semgrep.dev:
       rule:
+        r_id: 10117
+        rv_id: 111142
         rule_id: pKUGXr
         version_id: 44TR653
         url: https://semgrep.dev/playground/r/44TR653/yaml.kubernetes.security.skip-tls-verify-service.skip-tls-verify-service
@@ -45525,3 +47257,56 @@ rules:
   languages:
   - yaml
   severity: WARNING
+- id: yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+  languages:
+  - yaml
+  message: Basic authentication is considered weak and should be avoided.  Use a different
+    authentication scheme, such of OAuth2, OpenID Connect, or mTLS.
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      openapi: $VERSION
+      ...
+      components:
+        ...
+        securitySchemes:
+          ...
+          $SCHEME:
+            ...
+  - metavariable-regex:
+      metavariable: "$VERSION"
+      regex: 3.*
+  - pattern: |
+      type: http
+      ...
+      scheme: basic
+  metadata:
+    category: security
+    subcategory:
+    - vuln
+    technology:
+    - openapi
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: HIGH
+    cwe: 'CWE-287: Improper Authentication'
+    owasp:
+    - A04:2021 Insecure Design
+    - A07:2021 Identification and Authentication Failures
+    references:
+    - https://cwe.mitre.org/data/definitions/287.html
+    - https://owasp.org/Top10/A04_2021-Insecure_Design/
+    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Improper Authentication
+    source: https://semgrep.dev/r/yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+    shortlink: https://sg.run/v8wNW
+    semgrep.dev:
+      rule:
+        r_id: 133077
+        rv_id: 751095
+        rule_id: zdUKgEX
+        version_id: zyTn3RL
+        url: https://semgrep.dev/playground/r/zyTn3RL/yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+        origin: community

--- a/assets/semgrep_rules/generated/oss/audit.yaml
+++ b/assets/semgrep_rules/generated/oss/audit.yaml
@@ -2267,6 +2267,8 @@ rules:
     shortlink: https://sg.run/qNLGR
     semgrep.dev:
       rule:
+        r_id: 113212
+        rv_id: 723874
         rule_id: ReUD0BO
         version_id: WrTNkvB
         url: https://semgrep.dev/playground/r/WrTNkvB/trailofbits.generic.container-privileged.container-privileged
@@ -2316,6 +2318,8 @@ rules:
     shortlink: https://sg.run/lBKyB
     semgrep.dev:
       rule:
+        r_id: 113213
+        rv_id: 253283
         rule_id: AbU9gy9
         version_id: d6TqRxp
         url: https://semgrep.dev/playground/r/d6TqRxp/trailofbits.generic.container-user-root.container-user-root
@@ -2353,6 +2357,8 @@ rules:
     shortlink: https://sg.run/YG37D
     semgrep.dev:
       rule:
+        r_id: 113214
+        rv_id: 253284
         rule_id: BYUXkQx
         version_id: ZRT6EAy
         url: https://semgrep.dev/playground/r/ZRT6EAy/trailofbits.generic.curl-insecure.curl-insecure
@@ -2384,6 +2390,8 @@ rules:
     shortlink: https://sg.run/6JldW
     semgrep.dev:
       rule:
+        r_id: 113215
+        rv_id: 723875
         rule_id: DbU6R39
         version_id: 0bTrQAn
         url: https://semgrep.dev/playground/r/0bTrQAn/trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url
@@ -2418,6 +2426,8 @@ rules:
     shortlink: https://sg.run/oqLJx
     semgrep.dev:
       rule:
+        r_id: 113216
+        rv_id: 253286
         rule_id: WAUWqko
         version_id: ExTRkxb
         url: https://semgrep.dev/playground/r/ExTRkxb/trailofbits.generic.gpg-insecure-flags.gpg-insecure-flags
@@ -2458,6 +2468,8 @@ rules:
     shortlink: https://sg.run/zdLlk
     semgrep.dev:
       rule:
+        r_id: 113217
+        rv_id: 253287
         rule_id: 0oULKQE
         version_id: 7ZTD73J
         url: https://semgrep.dev/playground/r/7ZTD73J/trailofbits.generic.installer-allow-untrusted.installer-allow-untrusted
@@ -2487,6 +2499,8 @@ rules:
     shortlink: https://sg.run/pKL5k
     semgrep.dev:
       rule:
+        r_id: 113218
+        rv_id: 253288
         rule_id: KxUvKPY
         version_id: LjT7Ygd
         url: https://semgrep.dev/playground/r/LjT7Ygd/trailofbits.generic.openssl-insecure-flags.openssl-insecure-flags
@@ -2522,6 +2536,8 @@ rules:
     shortlink: https://sg.run/2ZWd8
     semgrep.dev:
       rule:
+        r_id: 113219
+        rv_id: 253289
         rule_id: qNU2R9X
         version_id: 8KT42rO
         url: https://semgrep.dev/playground/r/8KT42rO/trailofbits.generic.ssh-disable-host-key-checking.ssh-disable-host-key-checking
@@ -2551,6 +2567,8 @@ rules:
     shortlink: https://sg.run/X5RyN
     semgrep.dev:
       rule:
+        r_id: 113220
+        rv_id: 258314
         rule_id: lBU4JeW
         version_id: 6xT5vWg
         url: https://semgrep.dev/playground/r/6xT5vWg/trailofbits.generic.tar-insecure-flags.tar-insecure-flags
@@ -2586,6 +2604,8 @@ rules:
     shortlink: https://sg.run/j2WyD
     semgrep.dev:
       rule:
+        r_id: 113221
+        rv_id: 253291
         rule_id: PeUJREx
         version_id: QkT8yqY
         url: https://semgrep.dev/playground/r/QkT8yqY/trailofbits.generic.wget-no-check-certificate.wget-no-check-certificate
@@ -2617,6 +2637,8 @@ rules:
     shortlink: https://sg.run/10Ddk
     semgrep.dev:
       rule:
+        r_id: 113222
+        rv_id: 253292
         rule_id: JDUNz2o
         version_id: 3ZTlJXZ
         url: https://semgrep.dev/playground/r/3ZTlJXZ/trailofbits.generic.wget-unencrypted-url.wget-unencrypted-url
@@ -2650,6 +2672,8 @@ rules:
     shortlink: https://sg.run/WWQ2
     semgrep.dev:
       rule:
+        r_id: 17197
+        rv_id: 258507
         rule_id: kxU6Xb
         version_id: A8Tr9vQ
         url: https://semgrep.dev/playground/r/A8Tr9vQ/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
@@ -2721,6 +2745,8 @@ rules:
     shortlink: https://sg.run/08jj
     semgrep.dev:
       rule:
+        r_id: 17198
+        rv_id: 95081
         rule_id: wdUlww
         version_id: QkTW6zJ
         url: https://semgrep.dev/playground/r/QkTW6zJ/trailofbits.go.iterate-over-empty-map.iterate-over-empty-map
@@ -2779,6 +2805,8 @@ rules:
     shortlink: https://sg.run/65WB
     semgrep.dev:
       rule:
+        r_id: 11759
+        rv_id: 95088
         rule_id: 4bU2AZ
         version_id: RGTDPPg
         url: https://semgrep.dev/playground/r/RGTDPPg/trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
@@ -2906,6 +2934,8 @@ rules:
     shortlink: https://sg.run/ORxR
     semgrep.dev:
       rule:
+        r_id: 60575
+        rv_id: 95095
         rule_id: v8UlNl
         version_id: qkT2oo4
         url: https://semgrep.dev/playground/r/qkT2oo4/trailofbits.javascript.apollo-graphql.v3-cors-audit.v3-potentially-bad-cors
@@ -2953,6 +2983,8 @@ rules:
     shortlink: https://sg.run/yyLqk
     semgrep.dev:
       rule:
+        r_id: 113224
+        rv_id: 253295
         rule_id: GdUvk46
         version_id: JdT5gxX
         url: https://semgrep.dev/playground/r/JdT5gxX/trailofbits.jvm.mongo-hostname-verification-disabled.mongo-hostname-verification-disabled
@@ -2984,6 +3016,8 @@ rules:
     shortlink: https://sg.run/jz5N
     semgrep.dev:
       rule:
+        r_id: 17165
+        rv_id: 250821
         rule_id: WAUN1Z
         version_id: 8KT4boW
         url: https://semgrep.dev/playground/r/8KT4boW/trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
@@ -3018,6 +3052,8 @@ rules:
     shortlink: https://sg.run/rqGP
     semgrep.dev:
       rule:
+        r_id: 43925
+        rv_id: 95104
         rule_id: GdUgN8
         version_id: jQTgqq9
         url: https://semgrep.dev/playground/r/jQTgqq9/trailofbits.python.numpy-distutils.numpy-distutils
@@ -3052,6 +3088,8 @@ rules:
     shortlink: https://sg.run/bEdP
     semgrep.dev:
       rule:
+        r_id: 43926
+        rv_id: 95105
         rule_id: ReUdJ0
         version_id: 1QTOZZ0
         url: https://semgrep.dev/playground/r/1QTOZZ0/trailofbits.python.numpy-f2py-compile.numpy-f2py-compile
@@ -3087,6 +3125,8 @@ rules:
     shortlink: https://sg.run/dnR6
     semgrep.dev:
       rule:
+        r_id: 44134
+        rv_id: 250822
         rule_id: KxURLn
         version_id: gET6q8p
         url: https://semgrep.dev/playground/r/gET6q8p/trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
@@ -3124,6 +3164,8 @@ rules:
     shortlink: https://sg.run/NXkL
     semgrep.dev:
       rule:
+        r_id: 43927
+        rv_id: 95108
         rule_id: AbUxDq
         version_id: rxTykkg
         url: https://semgrep.dev/playground/r/rxTykkg/trailofbits.python.numpy-load-library.numpy-load-library
@@ -3156,6 +3198,8 @@ rules:
     shortlink: https://sg.run/kRd1
     semgrep.dev:
       rule:
+        r_id: 43928
+        rv_id: 95109
         rule_id: BYUoqy
         version_id: bZTbOOD
         url: https://semgrep.dev/playground/r/bZTbOOD/trailofbits.python.onnx-session-options.onnx-session-options
@@ -3196,6 +3240,8 @@ rules:
     shortlink: https://sg.run/bwJed
     semgrep.dev:
       rule:
+        r_id: 124726
+        rv_id: 733075
         rule_id: ReUDw9J
         version_id: 2KTLoZO
         url: https://semgrep.dev/playground/r/2KTLoZO/trailofbits.python.pandas-eval.pandas-eval
@@ -3248,6 +3294,8 @@ rules:
     shortlink: https://sg.run/nD6d
     semgrep.dev:
       rule:
+        r_id: 44136
+        rv_id: 95114
         rule_id: lBUYD9
         version_id: O9TNGGw
         url: https://semgrep.dev/playground/r/O9TNGGw/trailofbits.python.pytorch-classes-load-library.pytorch-classes-load-library
@@ -3282,6 +3330,8 @@ rules:
     shortlink: https://sg.run/EK35
     semgrep.dev:
       rule:
+        r_id: 44137
+        rv_id: 95115
         rule_id: PeUKGk
         version_id: e1T0vvB
         url: https://semgrep.dev/playground/r/e1T0vvB/trailofbits.python.pytorch-package.pytorch-package
@@ -3313,6 +3363,8 @@ rules:
     shortlink: https://sg.run/xp0j
     semgrep.dev:
       rule:
+        r_id: 43930
+        rv_id: 95119
         rule_id: WAUgBJ
         version_id: nWTxYYN
         url: https://semgrep.dev/playground/r/nWTxYYN/trailofbits.python.tensorflow-load-library.tensorflow-load-library
@@ -3348,6 +3400,8 @@ rules:
     shortlink: https://sg.run/WpeL
     semgrep.dev:
       rule:
+        r_id: 13697
+        rv_id: 95121
         rule_id: 2ZUPQ3
         version_id: 7ZTgeey
         url: https://semgrep.dev/playground/r/7ZTgeey/trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result
@@ -3408,6 +3462,8 @@ rules:
     shortlink: https://sg.run/r68RP
     semgrep.dev:
       rule:
+        r_id: 113225
+        rv_id: 253296
         rule_id: ReUD0BR
         version_id: 5PTk51b
         url: https://semgrep.dev/playground/r/5PTk51b/trailofbits.yaml.ansible.apt-key-unencrypted-url.apt-key-unencrypted-url
@@ -3454,6 +3510,8 @@ rules:
     shortlink: https://sg.run/bwPnP
     semgrep.dev:
       rule:
+        r_id: 113226
+        rv_id: 253297
         rule_id: AbU9gyg
         version_id: GxTjwed
         url: https://semgrep.dev/playground/r/GxTjwed/trailofbits.yaml.ansible.apt-key-validate-certs-disabled.apt-key-validate-certs-disabled
@@ -3503,6 +3561,8 @@ rules:
     shortlink: https://sg.run/NbW3L
     semgrep.dev:
       rule:
+        r_id: 113227
+        rv_id: 253298
         rule_id: BYUXkQb
         version_id: RGTevLG
         url: https://semgrep.dev/playground/r/RGTevLG/trailofbits.yaml.ansible.apt-unencrypted-url.apt-unencrypted-url
@@ -3550,6 +3610,8 @@ rules:
     shortlink: https://sg.run/kx0y1
     semgrep.dev:
       rule:
+        r_id: 113228
+        rv_id: 253299
         rule_id: DbU6R3w
         version_id: A8TkYdl
         url: https://semgrep.dev/playground/r/A8TkYdl/trailofbits.yaml.ansible.dnf-unencrypted-url.dnf-unencrypted-url
@@ -3600,6 +3662,8 @@ rules:
     shortlink: https://sg.run/wdL06
     semgrep.dev:
       rule:
+        r_id: 113229
+        rv_id: 253300
         rule_id: WAUWqkG
         version_id: BjTxYZZ
         url: https://semgrep.dev/playground/r/BjTxYZZ/trailofbits.yaml.ansible.dnf-validate-certs-disabled.dnf-validate-certs-disabled
@@ -3649,6 +3713,8 @@ rules:
     shortlink: https://sg.run/x8LKj
     semgrep.dev:
       rule:
+        r_id: 113230
+        rv_id: 253301
         rule_id: 0oULKQq
         version_id: DkTq8bj
         url: https://semgrep.dev/playground/r/DkTq8bj/trailofbits.yaml.ansible.get-url-unencrypted-url.get-url-unencrypted-url
@@ -3702,6 +3768,8 @@ rules:
     shortlink: https://sg.run/Or0N7
     semgrep.dev:
       rule:
+        r_id: 113231
+        rv_id: 253302
         rule_id: KxUvKPQ
         version_id: WrTOxK1
         url: https://semgrep.dev/playground/r/WrTOxK1/trailofbits.yaml.ansible.get-url-validate-certs-disabled.get-url-validate-certs-disabled
@@ -3758,6 +3826,8 @@ rules:
     shortlink: https://sg.run/eqGkR
     semgrep.dev:
       rule:
+        r_id: 113232
+        rv_id: 253303
         rule_id: qNU2R9K
         version_id: 0bTyOzA
         url: https://semgrep.dev/playground/r/0bTyOzA/trailofbits.yaml.ansible.rpm-key-unencrypted-url.rpm-key-unencrypted-url
@@ -3804,6 +3874,8 @@ rules:
     shortlink: https://sg.run/v8LWW
     semgrep.dev:
       rule:
+        r_id: 113233
+        rv_id: 253304
         rule_id: lBU4Jee
         version_id: K3Tnykp
         url: https://semgrep.dev/playground/r/K3Tnykp/trailofbits.yaml.ansible.rpm-key-validate-certs-disabled.rpm-key-validate-certs-disabled
@@ -3852,6 +3924,8 @@ rules:
     shortlink: https://sg.run/d85yn
     semgrep.dev:
       rule:
+        r_id: 113234
+        rv_id: 253305
         rule_id: YGUpZzx
         version_id: qkT5q7N
         url: https://semgrep.dev/playground/r/qkT5q7N/trailofbits.yaml.ansible.unarchive-unencrypted-url.unarchive-unencrypted-url
@@ -3897,6 +3971,8 @@ rules:
     shortlink: https://sg.run/ZqByA
     semgrep.dev:
       rule:
+        r_id: 113235
+        rv_id: 253306
         rule_id: 6JUv2A4
         version_id: l4TlPRP
         url: https://semgrep.dev/playground/r/l4TlPRP/trailofbits.yaml.ansible.unarchive-validate-certs-disabled.unarchive-validate-certs-disabled
@@ -3944,6 +4020,8 @@ rules:
     shortlink: https://sg.run/nJlP1
     semgrep.dev:
       rule:
+        r_id: 113236
+        rv_id: 253307
         rule_id: oqUgbWQ
         version_id: YDTNPeX
         url: https://semgrep.dev/playground/r/YDTNPeX/trailofbits.yaml.ansible.wrm-cert-validation-ignore.wrm-cert-validation-ignore
@@ -3974,6 +4052,8 @@ rules:
     shortlink: https://sg.run/Ew4NE
     semgrep.dev:
       rule:
+        r_id: 113237
+        rv_id: 253308
         rule_id: zdUKbXv
         version_id: JdT5gj1
         url: https://semgrep.dev/playground/r/JdT5gj1/trailofbits.yaml.ansible.yum-unencrypted-url.yum-unencrypted-url
@@ -4021,6 +4101,8 @@ rules:
     shortlink: https://sg.run/7Kvdw
     semgrep.dev:
       rule:
+        r_id: 113238
+        rv_id: 253309
         rule_id: pKU10q4
         version_id: 5PTk5zd
         url: https://semgrep.dev/playground/r/5PTk5zd/trailofbits.yaml.ansible.yum-validate-certs-disabled.yum-validate-certs-disabled
@@ -4068,6 +4150,8 @@ rules:
     shortlink: https://sg.run/L1Bkn
     semgrep.dev:
       rule:
+        r_id: 113239
+        rv_id: 253310
         rule_id: 2ZUzvAk
         version_id: GxTjwRj
         url: https://semgrep.dev/playground/r/GxTjwRj/trailofbits.yaml.ansible.zypper-repository-unencrypted-url.zypper-repository-unencrypted-url
@@ -4114,6 +4198,8 @@ rules:
     shortlink: https://sg.run/8GLdB
     semgrep.dev:
       rule:
+        r_id: 113240
+        rv_id: 253311
         rule_id: X5UQzo1
         version_id: RGTevlQ
         url: https://semgrep.dev/playground/r/RGTevlQ/trailofbits.yaml.ansible.zypper-unencrypted-url.zypper-unencrypted-url

--- a/assets/semgrep_rules/generated/oss/others.yaml
+++ b/assets/semgrep_rules/generated/oss/others.yaml
@@ -13,6 +13,8 @@ rules:
     shortlink: https://sg.run/O81B
     semgrep.dev:
       rule:
+        r_id: 11875
+        rv_id: 13242
         rule_id: 6JU6qd
         version_id: l4TzRP
         url: https://semgrep.dev/playground/r/l4TzRP/gitlab.bandit.B108-1
@@ -42,6 +44,8 @@ rules:
     shortlink: https://sg.run/nq5r
     semgrep.dev:
       rule:
+        r_id: 11536
+        rv_id: 73118
         rule_id: 9AUOKZ
         version_id: WrTw4p
         url: https://semgrep.dev/playground/r/WrTw4p/gitlab.bandit.B303-3
@@ -71,6 +75,8 @@ rules:
     shortlink: https://sg.run/E5GB
     semgrep.dev:
       rule:
+        r_id: 11537
+        rv_id: 73119
         rule_id: yyUvLN
         version_id: 0bTXP3
         url: https://semgrep.dev/playground/r/0bTXP3/gitlab.bandit.B303-4
@@ -101,6 +107,8 @@ rules:
     shortlink: https://sg.run/70eQ
     semgrep.dev:
       rule:
+        r_id: 11538
+        rv_id: 73120
         rule_id: r6UkYj
         version_id: K3TXWk
         url: https://semgrep.dev/playground/r/K3TXWk/gitlab.bandit.B303-5
@@ -131,6 +139,8 @@ rules:
     shortlink: https://sg.run/L0KY
     semgrep.dev:
       rule:
+        r_id: 11539
+        rv_id: 73121
         rule_id: bwUOkX
         version_id: qkTy8y
         url: https://semgrep.dev/playground/r/qkTy8y/gitlab.bandit.B303-6
@@ -156,6 +166,8 @@ rules:
     shortlink: https://sg.run/58xj
     semgrep.dev:
       rule:
+        r_id: 11547
+        rv_id: 13275
         rule_id: d8UzRp
         version_id: JdTQjX
         url: https://semgrep.dev/playground/r/JdTQjX/gitlab.bandit.B308.B703
@@ -195,6 +207,8 @@ rules:
     shortlink: https://sg.run/DJ5G
     semgrep.dev:
       rule:
+        r_id: 11552
+        rv_id: 13281
         rule_id: L1U4Yd
         version_id: DkTKjj
         url: https://semgrep.dev/playground/r/DkTKjj/gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410
@@ -230,6 +244,8 @@ rules:
     shortlink: https://sg.run/plRe
     semgrep.dev:
       rule:
+        r_id: 11562
+        rv_id: 13295
         rule_id: ReUPvG
         version_id: 1QTeld
         url: https://semgrep.dev/playground/r/1QTeld/gitlab.bandit.B502.B503
@@ -272,6 +288,8 @@ rules:
     shortlink: https://sg.run/8nbQ
     semgrep.dev:
       rule:
+        r_id: 11584
+        rv_id: 56280
         rule_id: NbUAnd
         version_id: rxTqor
         url: https://semgrep.dev/playground/r/rxTqor/gitlab.eslint.detect-object-injection
@@ -306,6 +324,8 @@ rules:
     shortlink: https://sg.run/YeEe
     semgrep.dev:
       rule:
+        r_id: 43714
+        rv_id: 78318
         rule_id: L1UJDJ
         version_id: PkTpOL
         url: https://semgrep.dev/playground/r/PkTpOL/mobsf.mobsfscan.android.hidden_ui.android_hidden_ui
@@ -365,6 +385,8 @@ rules:
     shortlink: https://sg.run/6pQo
     semgrep.dev:
       rule:
+        r_id: 43715
+        rv_id: 78319
         rule_id: 8GU0OP
         version_id: JdTJe7
         url: https://semgrep.dev/playground/r/JdTJe7/mobsf.mobsfscan.android.logging.android_logging
@@ -399,6 +421,8 @@ rules:
     shortlink: https://sg.run/p02g
     semgrep.dev:
       rule:
+        r_id: 43718
+        rv_id: 89493
         rule_id: 3qUgDz
         version_id: WrTWOdb
         url: https://semgrep.dev/playground/r/WrTWOdb/mobsf.mobsfscan.android.secrets.hardcoded_api_key
@@ -433,6 +457,8 @@ rules:
     shortlink: https://sg.run/oWp9
     semgrep.dev:
       rule:
+        r_id: 43716
+        rv_id: 89491
         rule_id: gxUpG8
         version_id: BjTXxew
         url: https://semgrep.dev/playground/r/BjTXxew/mobsf.mobsfscan.android.secrets.hardcoded_password
@@ -467,6 +493,8 @@ rules:
     shortlink: https://sg.run/23O0
     semgrep.dev:
       rule:
+        r_id: 43719
+        rv_id: 89494
         rule_id: 4bUJWL
         version_id: 0bTLywO
         url: https://semgrep.dev/playground/r/0bTLywO/mobsf.mobsfscan.android.secrets.hardcoded_secret
@@ -501,6 +529,8 @@ rules:
     shortlink: https://sg.run/zXGG
     semgrep.dev:
       rule:
+        r_id: 43717
+        rv_id: 89492
         rule_id: QrULll
         version_id: DkT6qGO
         url: https://semgrep.dev/playground/r/DkT6qGO/mobsf.mobsfscan.android.secrets.hardcoded_username
@@ -527,6 +557,8 @@ rules:
     shortlink: https://sg.run/XxEK
     semgrep.dev:
       rule:
+        r_id: 43720
+        rv_id: 78324
         rule_id: PeUKq9
         version_id: BjT9GN
         url: https://semgrep.dev/playground/r/BjT9GN/mobsf.mobsfscan.android.word_readable_writable.world_readable
@@ -554,6 +586,8 @@ rules:
     shortlink: https://sg.run/jGlY
     semgrep.dev:
       rule:
+        r_id: 43721
+        rv_id: 78325
         rule_id: JDU4Ab
         version_id: DkTOeW
         url: https://semgrep.dev/playground/r/DkTOeW/mobsf.mobsfscan.android.word_readable_writable.world_writeable
@@ -590,6 +624,8 @@ rules:
     shortlink: https://sg.run/1lOw
     semgrep.dev:
       rule:
+        r_id: 43722
+        rv_id: 78326
         rule_id: 5rUx0W
         version_id: WrTR6P
         url: https://semgrep.dev/playground/r/WrTR6P/mobsf.mobsfscan.best_practices.android_safetynetapi.android_safetynet_api
@@ -638,6 +674,8 @@ rules:
     shortlink: https://sg.run/9jOY
     semgrep.dev:
       rule:
+        r_id: 43723
+        rv_id: 78327
         rule_id: GdUg51
         version_id: 0bT462
         url: https://semgrep.dev/playground/r/0bT462/mobsf.mobsfscan.best_practices.flag_secure.android_prevent_screenshot
@@ -672,6 +710,8 @@ rules:
     shortlink: https://sg.run/y25x
     semgrep.dev:
       rule:
+        r_id: 43724
+        rv_id: 78328
         rule_id: ReUdYj
         version_id: K3TpO5
         url: https://semgrep.dev/playground/r/K3TpO5/mobsf.mobsfscan.best_practices.root_detection.android_root_detection
@@ -698,6 +738,8 @@ rules:
     shortlink: https://sg.run/rqjn
     semgrep.dev:
       rule:
+        r_id: 43725
+        rv_id: 78329
         rule_id: AbUx1o
         version_id: qkT0KQ
         url: https://semgrep.dev/playground/r/qkT0KQ/mobsf.mobsfscan.best_practices.tapjacking.android_detect_tapjacking
@@ -732,6 +774,8 @@ rules:
     shortlink: https://sg.run/bERp
     semgrep.dev:
       rule:
+        r_id: 43726
+        rv_id: 78330
         rule_id: BYUoO0
         version_id: l4TLNX
         url: https://semgrep.dev/playground/r/l4TLNX/mobsf.mobsfscan.best_practices.tls_certificate_transparency.android_certificate_transparency
@@ -802,6 +846,8 @@ rules:
     shortlink: https://sg.run/NXEp
     semgrep.dev:
       rule:
+        r_id: 43727
+        rv_id: 78331
         rule_id: DbUL4y
         version_id: YDT38v
         url: https://semgrep.dev/playground/r/YDT38v/mobsf.mobsfscan.best_practices.tls_pinning.android_certificate_pinning
@@ -830,6 +876,8 @@ rules:
     shortlink: https://sg.run/kRY7
     semgrep.dev:
       rule:
+        r_id: 43728
+        rv_id: 78332
         rule_id: WAUg2K
         version_id: 6xTL0J
         url: https://semgrep.dev/playground/r/6xTL0J/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode
@@ -858,6 +906,8 @@ rules:
     shortlink: https://sg.run/wzPY
     semgrep.dev:
       rule:
+        r_id: 43729
+        rv_id: 78333
         rule_id: 0oUZRX
         version_id: o5T759
         url: https://semgrep.dev/playground/r/o5T759/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode_default
@@ -890,6 +940,8 @@ rules:
     shortlink: https://sg.run/xpJz
     semgrep.dev:
       rule:
+        r_id: 43730
+        rv_id: 78334
         rule_id: KxURB0
         version_id: zyTxeb
         url: https://semgrep.dev/playground/r/zyTxeb/mobsf.mobsfscan.crypto.aes_encryption_keys.aes_hardcoded_key
@@ -932,6 +984,8 @@ rules:
     shortlink: https://sg.run/OjEB
     semgrep.dev:
       rule:
+        r_id: 43731
+        rv_id: 78335
         rule_id: qNUrzk
         version_id: pZTBQn
         url: https://semgrep.dev/playground/r/pZTBQn/mobsf.mobsfscan.crypto.cbc_padding_oracle.cbc_padding_oracle
@@ -968,6 +1022,8 @@ rules:
     shortlink: https://sg.run/egDb
     semgrep.dev:
       rule:
+        r_id: 43732
+        rv_id: 78336
         rule_id: lBUYwL
         version_id: 2KTD6R
         url: https://semgrep.dev/playground/r/2KTD6R/mobsf.mobsfscan.crypto.cbc_static_iv.cbc_static_iv
@@ -997,6 +1053,8 @@ rules:
     shortlink: https://sg.run/vo4A
     semgrep.dev:
       rule:
+        r_id: 43733
+        rv_id: 78337
         rule_id: PeUKqY
         version_id: X0TvJk
         url: https://semgrep.dev/playground/r/X0TvJk/mobsf.mobsfscan.crypto.insecure_random.java_insecure_random
@@ -1023,6 +1081,8 @@ rules:
     shortlink: https://sg.run/dnBZ
     semgrep.dev:
       rule:
+        r_id: 43734
+        rv_id: 78338
         rule_id: JDU4Ag
         version_id: jQTE9J
         url: https://semgrep.dev/playground/r/jQTE9J/mobsf.mobsfscan.crypto.insecure_ssl_v3.insecure_sslv3
@@ -1057,6 +1117,8 @@ rules:
     shortlink: https://sg.run/ZZED
     semgrep.dev:
       rule:
+        r_id: 43735
+        rv_id: 89495
         rule_id: 5rUx0n
         version_id: K3TvnrN
         url: https://semgrep.dev/playground/r/K3TvnrN/mobsf.mobsfscan.crypto.rsa_no_oeap.rsa_no_oeap
@@ -1092,6 +1154,8 @@ rules:
     shortlink: https://sg.run/nDyX
     semgrep.dev:
       rule:
+        r_id: 43736
+        rv_id: 78340
         rule_id: GdUgKL
         version_id: 9lTjnn
         url: https://semgrep.dev/playground/r/9lTjnn/mobsf.mobsfscan.crypto.sha1_hash.sha1_hash
@@ -1120,6 +1184,8 @@ rules:
     shortlink: https://sg.run/EKZw
     semgrep.dev:
       rule:
+        r_id: 43737
+        rv_id: 78341
         rule_id: ReUdZD
         version_id: yeT6dQ
         url: https://semgrep.dev/playground/r/yeT6dQ/mobsf.mobsfscan.crypto.weak_ciphers.weak_cipher
@@ -1156,6 +1222,8 @@ rules:
     shortlink: https://sg.run/72wZ
     semgrep.dev:
       rule:
+        r_id: 43738
+        rv_id: 78342
         rule_id: AbUxZk
         version_id: rxT58X
         url: https://semgrep.dev/playground/r/rxT58X/mobsf.mobsfscan.crypto.weak_hashes.weak_hash
@@ -1193,6 +1261,8 @@ rules:
     shortlink: https://sg.run/LpZr
     semgrep.dev:
       rule:
+        r_id: 43739
+        rv_id: 78343
         rule_id: BYUonD
         version_id: bZTY4P
         url: https://semgrep.dev/playground/r/bZTY4P/mobsf.mobsfscan.crypto.weak_iv.weak_iv
@@ -1253,6 +1323,8 @@ rules:
     shortlink: https://sg.run/8Xey
     semgrep.dev:
       rule:
+        r_id: 43740
+        rv_id: 78344
         rule_id: DbULZp
         version_id: NdTxQW
         url: https://semgrep.dev/playground/r/NdTxQW/mobsf.mobsfscan.crypto.weak_key_size.weak_key_size
@@ -1283,6 +1355,8 @@ rules:
     shortlink: https://sg.run/gPzJ
     semgrep.dev:
       rule:
+        r_id: 43741
+        rv_id: 78345
         rule_id: WAUgAZ
         version_id: kbToZ0
         url: https://semgrep.dev/playground/r/kbToZ0/mobsf.mobsfscan.deserialization.jackson_deserialization.jackson_deserialization
@@ -1313,6 +1387,8 @@ rules:
     shortlink: https://sg.run/QxZ4
     semgrep.dev:
       rule:
+        r_id: 43742
+        rv_id: 78346
         rule_id: 0oUZYJ
         version_id: w8Te0B
         url: https://semgrep.dev/playground/r/w8Te0B/mobsf.mobsfscan.deserialization.object_deserialization.object_deserialization
@@ -1341,6 +1417,8 @@ rules:
     shortlink: https://sg.run/36wr
     semgrep.dev:
       rule:
+        r_id: 43743
+        rv_id: 78347
         rule_id: KxUR67
         version_id: xyTY3g
         url: https://semgrep.dev/playground/r/xyTY3g/mobsf.mobsfscan.injection.command_injection.command_injection
@@ -1413,6 +1491,8 @@ rules:
     shortlink: https://sg.run/4oQl
     semgrep.dev:
       rule:
+        r_id: 43744
+        rv_id: 78348
         rule_id: qNUrPW
         version_id: O9TPZ9
         url: https://semgrep.dev/playground/r/O9TPZ9/mobsf.mobsfscan.injection.command_injection_formated.command_injection_warning
@@ -1464,6 +1544,8 @@ rules:
     shortlink: https://sg.run/PxZY
     semgrep.dev:
       rule:
+        r_id: 43745
+        rv_id: 78349
         rule_id: lBUYAy
         version_id: e1T6A5
         url: https://semgrep.dev/playground/r/e1T6A5/mobsf.mobsfscan.injection.sqlite_injection.sqlite_injection
@@ -1540,6 +1622,8 @@ rules:
     shortlink: https://sg.run/JoZw
     semgrep.dev:
       rule:
+        r_id: 43746
+        rv_id: 78350
         rule_id: YGUxKY
         version_id: vdTZ3e
         url: https://semgrep.dev/playground/r/vdTZ3e/mobsf.mobsfscan.network.accept_self_signed.accept_self_signed_certificate
@@ -1567,9 +1651,53 @@ rules:
     shortlink: https://sg.run/5zwA
     semgrep.dev:
       rule:
+        r_id: 43747
+        rv_id: 78351
         rule_id: 6JUkwx
         version_id: d6TBbY
         url: https://semgrep.dev/playground/r/d6TBbY/mobsf.mobsfscan.network.default_http_client_tls.default_http_client_tls
+        origin: community
+- id: mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
+  patterns:
+  - pattern-either:
+    - pattern: 'setAllowFileAccessFromFileURLs(true)
+
+        '
+    - pattern: "$W.setAllowFileAccessFromFileURLs(true)\n"
+    - pattern: |
+        $X = true;
+        ...
+        $W.setAllowFileAccessFromFileURLs($X);
+    - pattern: 'setAllowUniversalAccessFromFileURLs(true)
+
+        '
+    - pattern: "$W.setAllowUniversalAccessFromFileURLs(true)\n"
+    - pattern: |
+        $X = true;
+        ...
+        $W.setAllowUniversalAccessFromFileURLs($X);
+  message: Ensure that user controlled URLs never reaches the Webview. Enabling file
+    access from URLs in WebView can leak sensitive information from the file system.
+  languages:
+  - java
+  severity: WARNING
+  metadata:
+    cwe: cwe-200
+    owasp-mobile: m1
+    masvs: platform-7
+    reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#static-analysis-6
+    license: LGPL-3.0-or-later
+    vulnerability_class:
+    - Other
+    source: https://semgrep.dev/r/mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
+    shortlink: https://sg.run/wdPz0
+    semgrep.dev:
+      rule:
+        r_id: 134573
+        rv_id: 756521
+        rule_id: QrUWlLB
+        version_id: vdT4P7g
+        url: https://semgrep.dev/playground/r/vdT4P7g/mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
         origin: community
 - id: mobsf.mobsfscan.webview.webview_debugging.webview_debugging
   patterns:
@@ -1596,6 +1724,8 @@ rules:
     shortlink: https://sg.run/G3Zp
     semgrep.dev:
       rule:
+        r_id: 43748
+        rv_id: 78352
         rule_id: oqUPpl
         version_id: ZRTLyo
         url: https://semgrep.dev/playground/r/ZRTLyo/mobsf.mobsfscan.webview.webview_debugging.webview_debugging
@@ -1633,6 +1763,8 @@ rules:
     shortlink: https://sg.run/Rx3O
     semgrep.dev:
       rule:
+        r_id: 43749
+        rv_id: 78353
         rule_id: zdU90D
         version_id: nWT6wg
         url: https://semgrep.dev/playground/r/nWT6wg/mobsf.mobsfscan.webview.webview_external_storage.webview_external_storage
@@ -1658,6 +1790,8 @@ rules:
     shortlink: https://sg.run/ABgp
     semgrep.dev:
       rule:
+        r_id: 43750
+        rv_id: 78354
         rule_id: pKUJ40
         version_id: ExT9YD
         url: https://semgrep.dev/playground/r/ExT9YD/mobsf.mobsfscan.webview.webview_file_access.webview_set_allow_file_access
@@ -1687,6 +1821,8 @@ rules:
     shortlink: https://sg.run/BDgW
     semgrep.dev:
       rule:
+        r_id: 43751
+        rv_id: 78355
         rule_id: 2ZUXop
         version_id: 7ZTLYR
         url: https://semgrep.dev/playground/r/7ZTLYR/mobsf.mobsfscan.webview.webview_ignore_ssl_errors.ignore_ssl_certificate_errors
@@ -1715,6 +1851,8 @@ rules:
     shortlink: https://sg.run/D0LY
     semgrep.dev:
       rule:
+        r_id: 43752
+        rv_id: 78356
         rule_id: X5Up0Y
         version_id: LjT1pg
         url: https://semgrep.dev/playground/r/LjT1pg/mobsf.mobsfscan.webview.webview_javascript_interface.webview_javascript_interface
@@ -1760,6 +1898,8 @@ rules:
     shortlink: https://sg.run/WxP4
     semgrep.dev:
       rule:
+        r_id: 43753
+        rv_id: 78357
         rule_id: j2Up0D
         version_id: 8KTdLZ
         url: https://semgrep.dev/playground/r/8KTdLZ/mobsf.mobsfscan.xxe.xmldecoder_xxe.xml_decoder_xxe
@@ -1787,6 +1927,8 @@ rules:
     shortlink: https://sg.run/0qwv
     semgrep.dev:
       rule:
+        r_id: 43754
+        rv_id: 78358
         rule_id: 10UnwQ
         version_id: gETb5l
         url: https://semgrep.dev/playground/r/gETb5l/mobsf.mobsfscan.xxe.xmlfactory_external_entities_enabled.xmlinputfactory_xxe_enabled
@@ -1829,6 +1971,8 @@ rules:
     shortlink: https://sg.run/KzZ7
     semgrep.dev:
       rule:
+        r_id: 43755
+        rv_id: 78359
         rule_id: 9AUL9X
         version_id: QkT4Qb
         url: https://semgrep.dev/playground/r/QkT4Qb/mobsf.mobsfscan.xxe.xmlfactory_xxe.xmlinputfactory_xxe
@@ -1860,6 +2004,8 @@ rules:
     shortlink: https://sg.run/9ApQ0
     semgrep.dev:
       rule:
+        r_id: 113223
+        rv_id: 253294
         rule_id: 5rUdoB9
         version_id: PkTDL34
         url: https://semgrep.dev/playground/r/PkTDL34/trailofbits.jvm.gc-call.gc-call
@@ -1889,6 +2035,8 @@ rules:
     shortlink: https://sg.run/9vxr
     semgrep.dev:
       rule:
+        r_id: 17167
+        rv_id: 733074
         rule_id: KxU507
         version_id: pZTz48j
         url: https://semgrep.dev/playground/r/pZTz48j/trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
@@ -1921,6 +2069,8 @@ rules:
     shortlink: https://sg.run/72xG
     semgrep.dev:
       rule:
+        r_id: 44138
+        rv_id: 95116
         rule_id: JDU4RQ
         version_id: vdTY55y
         url: https://semgrep.dev/playground/r/vdTY55y/trailofbits.python.pytorch-tensor.pytorch-tensor

--- a/assets/semgrep_rules/generated/oss/security_noaudit_novuln.yaml
+++ b/assets/semgrep_rules/generated/oss/security_noaudit_novuln.yaml
@@ -56,6 +56,8 @@ rules:
     shortlink: https://sg.run/Y4yX
     semgrep.dev:
       rule:
+        r_id: 21214
+        rv_id: 26889
         rule_id: ReU2vo
         version_id: rxT4Zk
         url: https://semgrep.dev/playground/r/rxT4Zk/gitlab.find_sec_bugs.HARD_CODE_KEY-1
@@ -88,6 +90,8 @@ rules:
     shortlink: https://sg.run/obGN
     semgrep.dev:
       rule:
+        r_id: 21216
+        rv_id: 26891
         rule_id: BYUKYz
         version_id: NdTo8N
         url: https://semgrep.dev/playground/r/NdTo8N/gitlab.find_sec_bugs.HARD_CODE_KEY-2
@@ -115,6 +119,8 @@ rules:
     shortlink: https://sg.run/z561
     semgrep.dev:
       rule:
+        r_id: 21217
+        rv_id: 26892
         rule_id: DbU28G
         version_id: kbTLq6
         url: https://semgrep.dev/playground/r/kbTLq6/gitlab.find_sec_bugs.HARD_CODE_KEY-3
@@ -156,6 +162,8 @@ rules:
     shortlink: https://sg.run/6kO6
     semgrep.dev:
       rule:
+        r_id: 21215
+        rv_id: 26890
         rule_id: AbUNYQ
         version_id: bZT9qN
         url: https://semgrep.dev/playground/r/bZT9qN/gitlab.find_sec_bugs.HARD_CODE_KEY-4
@@ -401,6 +409,8 @@ rules:
     shortlink: https://sg.run/WD1A
     semgrep.dev:
       rule:
+        r_id: 21209
+        rv_id: 57077
         rule_id: lBUXP4
         version_id: YDT5zl
         url: https://semgrep.dev/playground/r/YDT5zl/gitlab.find_sec_bugs.SQL_INJECTION_SPRING_JDBC-1.SQL_INJECTION_JPA-1.SQL_INJECTION_JDO-1.SQL_INJECTION_JDBC-1.SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE-1

--- a/assets/semgrep_rules/generated/oss/vulns.yaml
+++ b/assets/semgrep_rules/generated/oss/vulns.yaml
@@ -37,6 +37,8 @@ rules:
     shortlink: https://sg.run/KlRL
     semgrep.dev:
       rule:
+        r_id: 9211
+        rv_id: 109749
         rule_id: j2Uv7B
         version_id: jQTgYdy
         url: https://semgrep.dev/playground/r/jQTgYdy/java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer
@@ -98,6 +100,8 @@ rules:
     shortlink: https://sg.run/Dw8o
     semgrep.dev:
       rule:
+        r_id: 11752
+        rv_id: 95079
         rule_id: EwUQp2
         version_id: 8KTQEjp
         url: https://semgrep.dev/playground/r/8KTQEjp/trailofbits.go.hanging-goroutine.hanging-goroutine
@@ -212,6 +216,8 @@ rules:
     shortlink: https://sg.run/9r40
     semgrep.dev:
       rule:
+        r_id: 14223
+        rv_id: 733070
         rule_id: 8GUzNK
         version_id: YDTAKBW
         url: https://semgrep.dev/playground/r/YDTAKBW/trailofbits.go.missing-runlock-on-rwmutex.missing-runlock-on-rwmutex
@@ -274,6 +280,8 @@ rules:
     shortlink: https://sg.run/18Bk
     semgrep.dev:
       rule:
+        r_id: 14222
+        rv_id: 733071
         rule_id: L1U5Gz
         version_id: 6xTEwrB
         url: https://semgrep.dev/playground/r/6xTEwrB/trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
@@ -334,6 +342,8 @@ rules:
     shortlink: https://sg.run/05g5
     semgrep.dev:
       rule:
+        r_id: 11754
+        rv_id: 95084
         rule_id: L1Ur2r
         version_id: PkTJkk5
         url: https://semgrep.dev/playground/r/PkTJkk5/trailofbits.go.nil-check-after-call.nil-check-after-call
@@ -422,6 +432,8 @@ rules:
     shortlink: https://sg.run/jkNY
     semgrep.dev:
       rule:
+        r_id: 11865
+        rv_id: 104226
         rule_id: ReUoP7
         version_id: WrTWdKp
         url: https://semgrep.dev/playground/r/WrTWdKp/trailofbits.go.racy-append-to-slice.racy-append-to-slice
@@ -488,6 +500,8 @@ rules:
     shortlink: https://sg.run/1Gnw
     semgrep.dev:
       rule:
+        r_id: 11866
+        rv_id: 104227
         rule_id: AbUGWD
         version_id: 0bTLwz3
         url: https://semgrep.dev/playground/r/0bTLwz3/trailofbits.go.racy-write-to-map.racy-write-to-map
@@ -542,6 +556,8 @@ rules:
     shortlink: https://sg.run/lx09
     semgrep.dev:
       rule:
+        r_id: 11757
+        rv_id: 95087
         rule_id: QrUp7k
         version_id: GxTv00x
         url: https://semgrep.dev/playground/r/GxTv00x/trailofbits.go.servercodec-readrequestbody-unhandled-nil.servercodec-readrequestbody-unhandled-nil
@@ -589,6 +605,8 @@ rules:
     shortlink: https://sg.run/owlR
     semgrep.dev:
       rule:
+        r_id: 11760
+        rv_id: 95089
         rule_id: PeUBW1
         version_id: A8T9WWW
         url: https://semgrep.dev/playground/r/A8T9WWW/trailofbits.go.sync-mutex-value-copied.sync-mutex-value-copied
@@ -637,6 +655,8 @@ rules:
     shortlink: https://sg.run/poE3
     semgrep.dev:
       rule:
+        r_id: 40518
+        rv_id: 95090
         rule_id: pKUQBW
         version_id: BjTXBB7
         url: https://semgrep.dev/playground/r/BjTXBB7/trailofbits.go.unsafe-dll-loading.unsafe-dll-loading
@@ -691,6 +711,8 @@ rules:
     shortlink: https://sg.run/z98W
     semgrep.dev:
       rule:
+        r_id: 11761
+        rv_id: 95091
         rule_id: JDUQ3v
         version_id: DkT6WW1
         url: https://semgrep.dev/playground/r/DkT6WW1/trailofbits.go.waitgroup-add-called-inside-goroutine.waitgroup-add-called-inside-goroutine
@@ -748,6 +770,8 @@ rules:
     shortlink: https://sg.run/pkGL
     semgrep.dev:
       rule:
+        r_id: 11762
+        rv_id: 95092
         rule_id: 5rU8Po
         version_id: WrTWZZN
         url: https://semgrep.dev/playground/r/WrTWZZN/trailofbits.go.waitgroup-wait-inside-loop.waitgroup-wait-inside-loop
@@ -840,6 +864,8 @@ rules:
     shortlink: https://sg.run/wE2N
     semgrep.dev:
       rule:
+        r_id: 60573
+        rv_id: 250820
         rule_id: OrU1Oz
         version_id: LjT70dp
         url: https://semgrep.dev/playground/r/LjT70dp/trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
@@ -878,6 +904,8 @@ rules:
     shortlink: https://sg.run/xE20
     semgrep.dev:
       rule:
+        r_id: 60574
+        rv_id: 95094
         rule_id: eqUB1Q
         version_id: K3Tv44w
         url: https://semgrep.dev/playground/r/K3Tv44w/trailofbits.javascript.apollo-graphql.use-of-graphql-upload.use-of-graphql-upload
@@ -913,6 +941,8 @@ rules:
     shortlink: https://sg.run/vE1n
     semgrep.dev:
       rule:
+        r_id: 60577
+        rv_id: 95097
         rule_id: ZqUbNY
         version_id: YDTprrn
         url: https://semgrep.dev/playground/r/YDTprrn/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-bad-cors
@@ -983,6 +1013,8 @@ rules:
     shortlink: https://sg.run/eNE0
     semgrep.dev:
       rule:
+        r_id: 60576
+        rv_id: 95096
         rule_id: d8UYAJ
         version_id: l4T4ddv
         url: https://semgrep.dev/playground/r/l4T4ddv/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-no-cors
@@ -1028,6 +1060,8 @@ rules:
     shortlink: https://sg.run/Zo3x
     semgrep.dev:
       rule:
+        r_id: 60579
+        rv_id: 95099
         rule_id: EwUZNW
         version_id: o5Tgzzd
         url: https://semgrep.dev/playground/r/o5Tgzzd/trailofbits.javascript.apollo-graphql.v3-cors.v3-bad-cors
@@ -1095,6 +1129,8 @@ rules:
     shortlink: https://sg.run/dbNX
     semgrep.dev:
       rule:
+        r_id: 60578
+        rv_id: 95098
         rule_id: nJU3P4
         version_id: 6xTvqq2
         url: https://semgrep.dev/playground/r/6xTvqq2/trailofbits.javascript.apollo-graphql.v3-cors.v3-no-cors
@@ -1143,6 +1179,8 @@ rules:
     shortlink: https://sg.run/nEGg
     semgrep.dev:
       rule:
+        r_id: 60580
+        rv_id: 95100
         rule_id: 7KU8o3
         version_id: zyTKyyB
         url: https://semgrep.dev/playground/r/zyTKyyB/trailofbits.javascript.apollo-graphql.v3-csrf-prevention.v3-csrf-prevention
@@ -1184,6 +1222,8 @@ rules:
     shortlink: https://sg.run/Eb1P
     semgrep.dev:
       rule:
+        r_id: 60581
+        rv_id: 253293
         rule_id: L1UjQ3
         version_id: 44T73jp
         url: https://semgrep.dev/playground/r/44T73jp/trailofbits.javascript.apollo-graphql.v4-csrf-prevention.v4-csrf-prevention
@@ -1218,6 +1258,8 @@ rules:
     shortlink: https://sg.run/1z1G
     semgrep.dev:
       rule:
+        r_id: 17166
+        rv_id: 733072
         rule_id: 0oUrdJ
         version_id: o5T2pO6
         url: https://semgrep.dev/playground/r/o5T2pO6/trailofbits.python.lxml-in-pandas.lxml-in-pandas
@@ -1273,6 +1315,8 @@ rules:
     shortlink: https://sg.run/r6pr1
     semgrep.dev:
       rule:
+        r_id: 124725
+        rv_id: 733073
         rule_id: GdUvWBy
         version_id: zyTn0O7
         url: https://semgrep.dev/playground/r/zyTn0O7/trailofbits.python.msgpack-numpy.msgpack-numpy
@@ -1323,6 +1367,8 @@ rules:
     shortlink: https://sg.run/NbJRG
     semgrep.dev:
       rule:
+        r_id: 124727
+        rv_id: 733076
         rule_id: AbU9npB
         version_id: X0Tg01y
         url: https://semgrep.dev/playground/r/X0Tg01y/trailofbits.python.pickles-in-keras-deprecation.pickles-in-keras-deprecation
@@ -1371,6 +1417,8 @@ rules:
     shortlink: https://sg.run/kxK8o
     semgrep.dev:
       rule:
+        r_id: 124728
+        rv_id: 733077
         rule_id: BYUXGv6
         version_id: jQTQ082
         url: https://semgrep.dev/playground/r/jQTQ082/trailofbits.python.pickles-in-keras.pickles-in-keras
@@ -1416,6 +1464,8 @@ rules:
     shortlink: https://sg.run/ryKe
     semgrep.dev:
       rule:
+        r_id: 17169
+        rv_id: 250823
         rule_id: lBUWjy
         version_id: QkT8J3R
         url: https://semgrep.dev/playground/r/QkT8J3R/trailofbits.python.pickles-in-numpy.pickles-in-numpy
@@ -1464,6 +1514,8 @@ rules:
     shortlink: https://sg.run/bXQW
     semgrep.dev:
       rule:
+        r_id: 17170
+        rv_id: 95111
         rule_id: PeU06j
         version_id: kbTdRRB
         url: https://semgrep.dev/playground/r/kbTdRRB/trailofbits.python.pickles-in-pandas.pickles-in-pandas
@@ -1506,6 +1558,8 @@ rules:
     shortlink: https://sg.run/ZZxW
     semgrep.dev:
       rule:
+        r_id: 44135
+        rv_id: 95112
         rule_id: qNUrw1
         version_id: w8T988E
         url: https://semgrep.dev/playground/r/w8T988E/trailofbits.python.pickles-in-pytorch-distributed.pickles-in-pytorch-distributed
@@ -1544,6 +1598,8 @@ rules:
     shortlink: https://sg.run/NwQy
     semgrep.dev:
       rule:
+        r_id: 17171
+        rv_id: 733078
         rule_id: JDU6WD
         version_id: 1QT5wrl
         url: https://semgrep.dev/playground/r/1QT5wrl/trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
@@ -1587,6 +1643,8 @@ rules:
     shortlink: https://sg.run/wd5jn
     semgrep.dev:
       rule:
+        r_id: 124729
+        rv_id: 733079
         rule_id: DbU6e7r
         version_id: 9lTZ9vg
         url: https://semgrep.dev/playground/r/9lTZ9vg/trailofbits.python.pickles-in-tensorflow.pickles-in-tensorflow
@@ -1621,6 +1679,8 @@ rules:
     shortlink: https://sg.run/wzW6
     semgrep.dev:
       rule:
+        r_id: 43929
+        rv_id: 95117
         rule_id: DbULlX
         version_id: d6Trzzd
         url: https://semgrep.dev/playground/r/d6Trzzd/trailofbits.python.scikit-joblib-load.scikit-joblib-load
@@ -1655,6 +1715,8 @@ rules:
     shortlink: https://sg.run/2RLD
     semgrep.dev:
       rule:
+        r_id: 11763
+        rv_id: 95118
         rule_id: GdUZxq
         version_id: ZRTQqqP
         url: https://semgrep.dev/playground/r/ZRTQqqP/trailofbits.python.tarfile-extractall-traversal.tarfile-extractall-traversal
@@ -1708,6 +1770,8 @@ rules:
     shortlink: https://sg.run/LpoX
     semgrep.dev:
       rule:
+        r_id: 44139
+        rv_id: 95120
         rule_id: 5rUxGL
         version_id: ExTj44x
         url: https://semgrep.dev/playground/r/ExTj44x/trailofbits.python.waiting-with-pytorch-distributed.waiting-with-pytorch-distributed


### PR DESCRIPTION
```
@ nonfree.audit (+1, -14)
+ go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
- generic.secrets.security.detected-github-token.detected-github-token
- generic.secrets.security.detected-google-gcm-service-account.detected-google-gcm-service-account
- generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token
- generic.secrets.security.detected-heroku-api-key.detected-heroku-api-key
- generic.secrets.security.detected-hockeyapp.detected-hockeyapp
- generic.secrets.security.detected-jwt-token.detected-jwt-token
- generic.secrets.security.detected-kolide-api-key.detected-kolide-api-key
- generic.secrets.security.detected-mailchimp-api-key.detected-mailchimp-api-key
- generic.secrets.security.detected-mailgun-api-key.detected-mailgun-api-key
- generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token
- generic.secrets.security.detected-outlook-team.detected-outlook-team
- generic.secrets.security.detected-paypal-braintree-access-token.detected-paypal-braintree-access-token
- generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
- go.lang.security.audit.net.use-tls.use-tls
@ nonfree.others (+0, -0)
@ nonfree.security_noaudit_novuln (+0, -0)
@ nonfree.vulns (+7, -0)
+ php.lang.security.injection.printed-request.printed-request
+ solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
+ yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+ python.twilio.security.twiml-injection.twiml-injection
+ generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
+ generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
+ generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
@ oss.audit (+0, -0)
@ oss.others (+1, -0)
+ mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
@ oss.security_noaudit_novuln (+0, -0)
@ oss.vulns (+0, -0)
```