### PR TITLE
Add `ExecuteJavaScript` to brave-execute-script.yaml

### DIFF
--- a/assets/semgrep_rules/client/brave-execute-script.cpp
+++ b/assets/semgrep_rules/client/brave-execute-script.cpp
@@ -5,4 +5,6 @@ int main() {
       blink::WebScriptSource(
           blink::WebString::FromUTF16(foobar)),
       blink::BackForwardCacheAware::kAllow);
+  // ruleid: brave-execute-script
+  web_contents()->GetPrimaryMainFrame()->ExecuteJavaScript(k_script, base::NullCallback());
 }

--- a/assets/semgrep_rules/client/brave-execute-script.yaml
+++ b/assets/semgrep_rules/client/brave-execute-script.yaml
@@ -22,4 +22,4 @@ rules:
       - pattern: $OBJ.$FUNC(...)
       - metavariable-regex:
           metavariable: $FUNC
-          regex: ^(.*ExecuteScript.*|ExecuteMethodAndReturnValue|CallFunctionEvenIfScriptDisabled)$
+          regex: ^(.*ExecuteScript.*|ExecuteMethodAndReturnValue|CallFunctionEvenIfScriptDisabled|ExecuteJavaScript)$


### PR DESCRIPTION
As title says, this PR adds a new function call to the rule.