### PR TITLE
semgrep rules: August 2024 Update

### DIFF
--- a/assets/semgrep_rules/generated/nonfree/audit.yaml
+++ b/assets/semgrep_rules/generated/nonfree/audit.yaml
@@ -34,10 +34,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14555
-        rv_id: 108995
+        rv_id: 833375
         rule_id: qNUXrw
-        version_id: pZT1yLp
-        url: https://semgrep.dev/playground/r/pZT1yLp/bash.curl.security.curl-pipe-bash.curl-pipe-bash
+        version_id: bZTBe4Z
+        url: https://semgrep.dev/playground/r/bZTBe4Z/bash.curl.security.curl-pipe-bash.curl-pipe-bash
         origin: community
   patterns:
   - pattern-either:
@@ -81,10 +81,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14842
-        rv_id: 109000
+        rv_id: 833380
         rule_id: WAUy9q
-        version_id: 9lTdW5W
-        url: https://semgrep.dev/playground/r/9lTdW5W/bash.lang.security.ifs-tampering.ifs-tampering
+        version_id: O9TJWZZ
+        url: https://semgrep.dev/playground/r/O9TJWZZ/bash.lang.security.ifs-tampering.ifs-tampering
         origin: community
 - id: c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
   message: Use %s, %d, %c... to format your variables, otherwise this could leak information.
@@ -111,10 +111,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8833
-        rv_id: 257629
+        rv_id: 833387
         rule_id: 5rUOlg
-        version_id: ExTpjpr
-        url: https://semgrep.dev/playground/r/ExTpjpr/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
+        version_id: 7ZTx9Yl
+        url: https://semgrep.dev/playground/r/7ZTx9Yl/c.lang.security.info-leak-on-non-formatted-string.info-leak-on-non-formated-string
         origin: community
   languages:
   - c
@@ -145,10 +145,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8834
-        rv_id: 109008
+        rv_id: 833388
         rule_id: GdU7OE
-        version_id: O9TNOdZ
-        url: https://semgrep.dev/playground/r/O9TNOdZ/c.lang.security.insecure-use-gets-fn.insecure-use-gets-fn
+        version_id: LjTEbpn
+        url: https://semgrep.dev/playground/r/LjTEbpn/c.lang.security.insecure-use-gets-fn.insecure-use-gets-fn
         origin: community
   languages:
   - c
@@ -193,10 +193,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18213
-        rv_id: 109009
+        rv_id: 833389
         rule_id: d8UK7D
-        version_id: e1T013E
-        url: https://semgrep.dev/playground/r/e1T013E/c.lang.security.insecure-use-memset.insecure-use-memset
+        version_id: 8KTGkLX
+        url: https://semgrep.dev/playground/r/8KTGkLX/c.lang.security.insecure-use-memset.insecure-use-memset
         origin: community
 - id: c.lang.security.insecure-use-scanf-fn.insecure-use-scanf-fn
   pattern: scanf(...)
@@ -224,10 +224,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8836
-        rv_id: 109011
+        rv_id: 833391
         rule_id: AbUzPd
-        version_id: d6TrAvO
-        url: https://semgrep.dev/playground/r/d6TrAvO/c.lang.security.insecure-use-scanf-fn.insecure-use-scanf-fn
+        version_id: QkTkrQ9
+        url: https://semgrep.dev/playground/r/QkTkrQ9/c.lang.security.insecure-use-scanf-fn.insecure-use-scanf-fn
         origin: community
   languages:
   - c
@@ -261,10 +261,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8837
-        rv_id: 109012
+        rv_id: 833392
         rule_id: BYUNjA
-        version_id: ZRTQNpR
-        url: https://semgrep.dev/playground/r/ZRTQNpR/c.lang.security.insecure-use-strcat-fn.insecure-use-strcat-fn
+        version_id: 3ZT3Axy
+        url: https://semgrep.dev/playground/r/3ZT3Axy/c.lang.security.insecure-use-strcat-fn.insecure-use-strcat-fn
         origin: community
   languages:
   - c
@@ -301,10 +301,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8838
-        rv_id: 109013
+        rv_id: 833393
         rule_id: DbUpo5
-        version_id: nWTxPoA
-        url: https://semgrep.dev/playground/r/nWTxPoA/c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn
+        version_id: 44TQPY0
+        url: https://semgrep.dev/playground/r/44TQPY0/c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn
         origin: community
   languages:
   - c
@@ -336,10 +336,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8839
-        rv_id: 109014
+        rv_id: 833394
         rule_id: WAUo5v
-        version_id: ExTjNA3
-        url: https://semgrep.dev/playground/r/ExTjNA3/c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn
+        version_id: PkTxrnr
+        url: https://semgrep.dev/playground/r/PkTxrnr/c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn
         origin: community
   languages:
   - c
@@ -387,10 +387,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8840
-        rv_id: 109015
+        rv_id: 833395
         rule_id: 0oU5k4
-        version_id: 7ZTgonl
-        url: https://semgrep.dev/playground/r/7ZTgonl/c.lang.security.random-fd-exhaustion.random-fd-exhaustion
+        version_id: JdTlrZR
+        url: https://semgrep.dev/playground/r/JdTlrZR/c.lang.security.random-fd-exhaustion.random-fd-exhaustion
         origin: community
   languages:
   - c
@@ -428,10 +428,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18214
-        rv_id: 109180
+        rv_id: 833409
         rule_id: ZqUlxE
-        version_id: YDTp2kw
-        url: https://semgrep.dev/playground/r/YDTp2kw/csharp.dotnet.security.mvc-missing-antiforgery.mvc-missing-antiforgery
+        version_id: o5TBEWz
+        url: https://semgrep.dev/playground/r/o5TBEWz/csharp.dotnet.security.mvc-missing-antiforgery.mvc-missing-antiforgery
         origin: community
   languages:
   - csharp
@@ -486,10 +486,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17324
-        rv_id: 109181
+        rv_id: 833410
         rule_id: 0oUrvj
-        version_id: JdTNpGG
-        url: https://semgrep.dev/playground/r/JdTNpGG/csharp.dotnet.security.net-webconfig-debug.net-webconfig-debug
+        version_id: zyTWJX1
+        url: https://semgrep.dev/playground/r/zyTWJX1/csharp.dotnet.security.net-webconfig-debug.net-webconfig-debug
         origin: community
   languages:
   - generic
@@ -531,10 +531,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18215
-        rv_id: 109182
+        rv_id: 833411
         rule_id: nJUyJq
-        version_id: 5PTdArE
-        url: https://semgrep.dev/playground/r/5PTdArE/csharp.dotnet.security.net-webconfig-trace-enabled.net-webconfig-trace-enabled
+        version_id: pZTXjqp
+        url: https://semgrep.dev/playground/r/pZTXjqp/csharp.dotnet.security.net-webconfig-trace-enabled.net-webconfig-trace-enabled
         origin: community
   languages:
   - generic
@@ -580,10 +580,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18217
-        rv_id: 109188
+        rv_id: 833417
         rule_id: 7KUxPg
-        version_id: WrTWQG5
-        url: https://semgrep.dev/playground/r/WrTWQG5/csharp.dotnet.security.web-config-insecure-cookie-settings.web-config-insecure-cookie-settings
+        version_id: yeTN1QZ
+        url: https://semgrep.dev/playground/r/yeTN1QZ/csharp.dotnet.security.web-config-insecure-cookie-settings.web-config-insecure-cookie-settings
         origin: community
   languages:
   - generic
@@ -650,10 +650,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 28955
-        rv_id: 109193
+        rv_id: 833422
         rule_id: bwU5kK
-        version_id: YDTp2k5
-        url: https://semgrep.dev/playground/r/YDTp2k5/csharp.lang.security.ad.jwt-tokenvalidationparameters-no-expiry-validation.jwt-tokenvalidationparameters-no-expiry-validation
+        version_id: w8TAx45
+        url: https://semgrep.dev/playground/r/w8TAx45/csharp.lang.security.ad.jwt-tokenvalidationparameters-no-expiry-validation.jwt-tokenvalidationparameters-no-expiry-validation
         origin: community
   languages:
   - csharp
@@ -689,10 +689,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11479
-        rv_id: 255672
+        rv_id: 833428
         rule_id: 9AUOjg
-        version_id: 3ZTpYly
-        url: https://semgrep.dev/playground/r/3ZTpYly/csharp.lang.security.injections.os-command.os-command-injection
+        version_id: ZRTlPBR
+        url: https://semgrep.dev/playground/r/ZRTlPBR/csharp.lang.security.injections.os-command.os-command-injection
         origin: community
   message: The software constructs all or part of an OS command using externally-influenced
     input from an upstream component, but it does not neutralize or incorrectly neutralizes
@@ -792,10 +792,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18224
-        rv_id: 109201
+        rv_id: 833430
         rule_id: PeUxb0
-        version_id: 1QTOY3v
-        url: https://semgrep.dev/playground/r/1QTOY3v/csharp.lang.security.insecure-deserialization.data-contract-resolver.data-contract-resolver
+        version_id: ExTrDd3
+        url: https://semgrep.dev/playground/r/ExTrDd3/csharp.lang.security.insecure-deserialization.data-contract-resolver.data-contract-resolver
         origin: community
   message: Only use DataContractResolver if you are completely sure of what information
     is being serialized. Malicious types can cause unexpected behavior.
@@ -833,10 +833,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11136
-        rv_id: 109202
+        rv_id: 833431
         rule_id: NbUAwk
-        version_id: 9lTdWqB
-        url: https://semgrep.dev/playground/r/9lTdWqB/csharp.lang.security.insecure-deserialization.fast-json.insecure-fastjson-deserialization
+        version_id: 7ZTx95l
+        url: https://semgrep.dev/playground/r/7ZTx95l/csharp.lang.security.insecure-deserialization.fast-json.insecure-fastjson-deserialization
         origin: community
   message: "$type extension has the potential to be unsafe, so use it with common
     sense and known json sources and not public facing ones to be safe"
@@ -880,10 +880,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18225
-        rv_id: 109204
+        rv_id: 833433
         rule_id: JDUlKl
-        version_id: rxTyLl5
-        url: https://semgrep.dev/playground/r/rxTyLl5/csharp.lang.security.insecure-deserialization.insecure-typefilterlevel-full.insecure-typefilterlevel-full
+        version_id: 8KTGkWX
+        url: https://semgrep.dev/playground/r/8KTGkWX/csharp.lang.security.insecure-deserialization.insecure-typefilterlevel-full.insecure-typefilterlevel-full
         origin: community
   message: Using a .NET remoting service can lead to RCE, even if you try to configure
     TypeFilterLevel. Recommended to switch from .NET Remoting to WCF https://docs.microsoft.com/en-us/dotnet/framework/wcf/migrating-from-net-remoting-to-wcf
@@ -938,10 +938,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11198
-        rv_id: 109205
+        rv_id: 833434
         rule_id: PeUkrK
-        version_id: bZTb1QG
-        url: https://semgrep.dev/playground/r/bZTb1QG/csharp.lang.security.insecure-deserialization.javascript-serializer.insecure-javascriptserializer-deserialization
+        version_id: gETy2Ld
+        url: https://semgrep.dev/playground/r/gETy2Ld/csharp.lang.security.insecure-deserialization.javascript-serializer.insecure-javascriptserializer-deserialization
         origin: community
   message: The SimpleTypeResolver class is insecure and should not be used. Using
     SimpleTypeResolver to deserialize JSON could allow the remote client to execute
@@ -1005,10 +1005,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11140
-        rv_id: 109208
+        rv_id: 833437
         rule_id: OrUGgl
-        version_id: w8T9n51
-        url: https://semgrep.dev/playground/r/w8T9n51/csharp.lang.security.insecure-deserialization.newtonsoft.insecure-newtonsoft-deserialization
+        version_id: 44TQPx0
+        url: https://semgrep.dev/playground/r/44TQPx0/csharp.lang.security.insecure-deserialization.newtonsoft.insecure-newtonsoft-deserialization
         origin: community
 - id: csharp.lang.security.memory.memory-marshal-create-span.memory-marshal-create-span
   severity: WARNING
@@ -1040,10 +1040,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18226
-        rv_id: 109210
+        rv_id: 833439
         rule_id: 5rUyEN
-        version_id: O9TNOBk
-        url: https://semgrep.dev/playground/r/O9TNOBk/csharp.lang.security.memory.memory-marshal-create-span.memory-marshal-create-span
+        version_id: JdTlr2R
+        url: https://semgrep.dev/playground/r/JdTlr2R/csharp.lang.security.memory.memory-marshal-create-span.memory-marshal-create-span
         origin: community
   message: MemoryMarshal.CreateSpan and MemoryMarshal.CreateReadOnlySpan should be
     used with caution, as the length argument is not checked.
@@ -1078,10 +1078,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18227
-        rv_id: 109213
+        rv_id: 833442
         rule_id: GdUDBP
-        version_id: d6TrALz
-        url: https://semgrep.dev/playground/r/d6TrALz/csharp.lang.security.regular-expression-dos.regular-expression-dos-infinite-timeout.regular-expression-dos-infinite-timeout
+        version_id: RGTKGBz
+        url: https://semgrep.dev/playground/r/RGTKGBz/csharp.lang.security.regular-expression-dos.regular-expression-dos-infinite-timeout.regular-expression-dos-infinite-timeout
         origin: community
   message: 'Specifying the regex timeout leaves the system vulnerable to a regex-based
     Denial of Service (DoS) attack. Consider setting the timeout to a short amount
@@ -1128,10 +1128,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12005
-        rv_id: 109214
+        rv_id: 833443
         rule_id: 4bU2gd
-        version_id: ZRTQNWg
-        url: https://semgrep.dev/playground/r/ZRTQNWg/csharp.lang.security.regular-expression-dos.regular-expression-dos.regular-expression-dos
+        version_id: A8T37yA
+        url: https://semgrep.dev/playground/r/A8T37yA/csharp.lang.security.regular-expression-dos.regular-expression-dos.regular-expression-dos
         origin: community
   message: When using `System.Text.RegularExpressions` to process untrusted input,
     pass a timeout.  A malicious user can provide input to `RegularExpressions` that
@@ -1186,7 +1186,9 @@ rules:
 
             '
         - focus-metavariable: "$CMD"
-      - pattern: "$CMD.$PATTERN = ...;\n"
+      - patterns:
+        - pattern: "$CMD.$PATTERN = $VALUE;\n"
+        - focus-metavariable: "$VALUE"
     - metavariable-regex:
         metavariable: "$PATTERN"
         regex: "^(SqlCommand|CommandText|OleDbCommand|OdbcCommand|OracleCommand)$"
@@ -1226,10 +1228,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15078
-        rv_id: 113530
+        rv_id: 875150
         rule_id: x8UxeP
-        version_id: DkT6Rg2
-        url: https://semgrep.dev/playground/r/DkT6Rg2/csharp.lang.security.sqli.csharp-sqli.csharp-sqli
+        version_id: 44TelRP
+        url: https://semgrep.dev/playground/r/44TelRP/csharp.lang.security.sqli.csharp-sqli.csharp-sqli
         origin: community
   languages:
   - csharp
@@ -1263,10 +1265,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13700
-        rv_id: 109216
+        rv_id: 833445
         rule_id: 10UdbE
-        version_id: ExTjN6q
-        url: https://semgrep.dev/playground/r/ExTjN6q/csharp.lang.security.ssrf.http-client.ssrf
+        version_id: DkTG03Q
+        url: https://semgrep.dev/playground/r/DkTG03Q/csharp.lang.security.ssrf.http-client.ssrf
         origin: community
   message: SSRF is an attack vector that abuses an application to interact with the
     internal/external network or the machine itself.
@@ -1340,10 +1342,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13701
-        rv_id: 109217
+        rv_id: 833446
         rule_id: 9AURoq
-        version_id: 7ZTgoPx
-        url: https://semgrep.dev/playground/r/7ZTgoPx/csharp.lang.security.ssrf.rest-client.ssrf
+        version_id: WrTdpkx
+        url: https://semgrep.dev/playground/r/WrTdpkx/csharp.lang.security.ssrf.rest-client.ssrf
         origin: community
   message: SSRF is an attack vector that abuses an application to interact with the
     internal/external network or the machine itself.
@@ -1395,10 +1397,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13702
-        rv_id: 109218
+        rv_id: 833447
         rule_id: yyUPBe
-        version_id: LjTqQBz
-        url: https://semgrep.dev/playground/r/LjTqQBz/csharp.lang.security.ssrf.web-client.ssrf
+        version_id: 0bTwbQW
+        url: https://semgrep.dev/playground/r/0bTwbQW/csharp.lang.security.ssrf.web-client.ssrf
         origin: community
   message: SSRF is an attack vector that abuses an application to interact with the
     internal/external network or the machine itself.
@@ -1491,10 +1493,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13703
-        rv_id: 109219
+        rv_id: 833448
         rule_id: r6UwoG
-        version_id: 8KTQ9nK
-        url: https://semgrep.dev/playground/r/8KTQ9nK/csharp.lang.security.ssrf.web-request.ssrf
+        version_id: K3TrqR2
+        url: https://semgrep.dev/playground/r/K3TrqR2/csharp.lang.security.ssrf.web-request.ssrf
         origin: community
   message: The web server receives a URL or similar request from an upstream component
     and retrieves the contents of this URL, but it does not sufficiently ensure that
@@ -1564,10 +1566,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26720
-        rv_id: 109220
+        rv_id: 833449
         rule_id: lBU6Dv
-        version_id: gET3x0x
-        url: https://semgrep.dev/playground/r/gET3x0x/csharp.lang.security.stacktrace-disclosure.stacktrace-disclosure
+        version_id: qkTQnr2
+        url: https://semgrep.dev/playground/r/qkTQnr2/csharp.lang.security.stacktrace-disclosure.stacktrace-disclosure
         origin: community
   languages:
   - csharp
@@ -1609,10 +1611,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13489
-        rv_id: 109224
+        rv_id: 833453
         rule_id: lBUzPw
-        version_id: PkTJ1be
-        url: https://semgrep.dev/playground/r/PkTJ1be/csharp.razor.security.html-raw-json.html-raw-json
+        version_id: 5PTyDx4
+        url: https://semgrep.dev/playground/r/5PTyDx4/csharp.razor.security.html-raw-json.html-raw-json
         origin: community
   paths:
     include:
@@ -1661,10 +1663,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20147
-        rv_id: 675962
+        rv_id: 833484
         rule_id: ReU2n5
-        version_id: kbTw78l
-        url: https://semgrep.dev/playground/r/kbTw78l/dockerfile.security.last-user-is-root.last-user-is-root
+        version_id: d6TKGEx
+        url: https://semgrep.dev/playground/r/d6TKGEx/dockerfile.security.last-user-is-root.last-user-is-root
         origin: community
 - id: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
   patterns:
@@ -1707,10 +1709,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 47272
-        rv_id: 109256
+        rv_id: 833485
         rule_id: ReUW9E
-        version_id: vdTYNBn
-        url: https://semgrep.dev/playground/r/vdTYNBn/dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
+        version_id: ZRTlPJZ
+        url: https://semgrep.dev/playground/r/ZRTlPJZ/dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
         origin: community
 - id: dockerfile.security.missing-user.missing-user
   patterns:
@@ -1753,10 +1755,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20148
-        rv_id: 109257
+        rv_id: 833486
         rule_id: AbUN06
-        version_id: d6TrApz
-        url: https://semgrep.dev/playground/r/d6TrApz/dockerfile.security.missing-user.missing-user
+        version_id: nWTy4lK
+        url: https://semgrep.dev/playground/r/nWTy4lK/dockerfile.security.missing-user.missing-user
         origin: community
 - id: dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile
   patterns:
@@ -1789,10 +1791,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66384
-        rv_id: 109258
+        rv_id: 833487
         rule_id: kxUlx1
-        version_id: ZRTQNXg
-        url: https://semgrep.dev/playground/r/ZRTQNXg/dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile
+        version_id: ExTrDbJ
+        url: https://semgrep.dev/playground/r/ExTrDbJ/dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile
         origin: community
   languages:
   - dockerfile
@@ -1822,10 +1824,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16200
-        rv_id: 109325
+        rv_id: 833554
         rule_id: gxUJrJ
-        version_id: PkTJ1nv
-        url: https://semgrep.dev/playground/r/PkTJ1nv/generic.ci.security.bash-reverse-shell.bash_reverse_shell
+        version_id: 5PTyDlE
+        url: https://semgrep.dev/playground/r/5PTyDlE/generic.ci.security.bash-reverse-shell.bash_reverse_shell
         origin: community
   message: Semgrep found a bash reverse shell
   severity: ERROR
@@ -1898,10 +1900,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9035
-        rv_id: 109343
+        rv_id: 833568
         rule_id: 5rUOjq
-        version_id: 2KTzrAQ
-        url: https://semgrep.dev/playground/r/2KTzrAQ/generic.nginx.security.alias-path-traversal.alias-path-traversal
+        version_id: zyTWJgE
+        url: https://semgrep.dev/playground/r/zyTWJgE/generic.nginx.security.alias-path-traversal.alias-path-traversal
         origin: community
 - id: generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
   paths:
@@ -1941,10 +1943,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9036
-        rv_id: 109344
+        rv_id: 833569
         rule_id: GdU7yl
-        version_id: X0TQxo8
-        url: https://semgrep.dev/playground/r/X0TQxo8/generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
+        version_id: pZTXjg7
+        url: https://semgrep.dev/playground/r/pZTXjg7/generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
         origin: community
   pattern-either:
   - pattern: proxy_pass $SCHEME://$$HOST ...;
@@ -1986,10 +1988,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9037
-        rv_id: 109345
+        rv_id: 833570
         rule_id: ReUg7n
-        version_id: jQTgYLq
-        url: https://semgrep.dev/playground/r/jQTgYLq/generic.nginx.security.dynamic-proxy-scheme.dynamic-proxy-scheme
+        version_id: 2KT7xNx
+        url: https://semgrep.dev/playground/r/2KT7xNx/generic.nginx.security.dynamic-proxy-scheme.dynamic-proxy-scheme
         origin: community
   pattern: proxy_pass $$SCHEME:// ...;
 - id: generic.nginx.security.header-injection.header-injection
@@ -2037,10 +2039,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9038
-        rv_id: 109346
+        rv_id: 833571
         rule_id: AbUz8p
-        version_id: 1QTOY0e
-        url: https://semgrep.dev/playground/r/1QTOY0e/generic.nginx.security.header-injection.header-injection
+        version_id: X0T5NeK
+        url: https://semgrep.dev/playground/r/X0T5NeK/generic.nginx.security.header-injection.header-injection
         origin: community
 - id: generic.nginx.security.header-redefinition.header-redefinition
   patterns:
@@ -2095,10 +2097,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9039
-        rv_id: 109347
+        rv_id: 833572
         rule_id: BYUN58
-        version_id: 9lTdWER
-        url: https://semgrep.dev/playground/r/9lTdWER/generic.nginx.security.header-redefinition.header-redefinition
+        version_id: jQTrXe5
+        url: https://semgrep.dev/playground/r/jQTrXe5/generic.nginx.security.header-redefinition.header-redefinition
         origin: community
 - id: generic.nginx.security.insecure-redirect.insecure-redirect
   patterns:
@@ -2144,10 +2146,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9040
-        rv_id: 109348
+        rv_id: 833573
         rule_id: DbUpJe
-        version_id: yeTR2QA
-        url: https://semgrep.dev/playground/r/yeTR2QA/generic.nginx.security.insecure-redirect.insecure-redirect
+        version_id: 1QTPLWv
+        url: https://semgrep.dev/playground/r/1QTPLWv/generic.nginx.security.insecure-redirect.insecure-redirect
         origin: community
 - id: generic.nginx.security.insecure-ssl-version.insecure-ssl-version
   patterns:
@@ -2193,10 +2195,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9041
-        rv_id: 109349
+        rv_id: 833574
         rule_id: WAUo9k
-        version_id: rxTyLbD
-        url: https://semgrep.dev/playground/r/rxTyLbD/generic.nginx.security.insecure-ssl-version.insecure-ssl-version
+        version_id: 9lTJ0NB
+        url: https://semgrep.dev/playground/r/9lTJ0NB/generic.nginx.security.insecure-ssl-version.insecure-ssl-version
         origin: community
 - id: generic.nginx.security.missing-ssl-version.missing-ssl-version
   patterns:
@@ -2240,10 +2242,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9043
-        rv_id: 109351
+        rv_id: 833576
         rule_id: KxUbeA
-        version_id: NdT3d5q
-        url: https://semgrep.dev/playground/r/NdT3d5q/generic.nginx.security.missing-ssl-version.missing-ssl-version
+        version_id: rxTDzg5
+        url: https://semgrep.dev/playground/r/rxTDzg5/generic.nginx.security.missing-ssl-version.missing-ssl-version
         origin: community
 - id: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
   patterns:
@@ -2309,10 +2311,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10562
-        rv_id: 109352
+        rv_id: 833577
         rule_id: 6JUq0Z
-        version_id: kbTdxrx
-        url: https://semgrep.dev/playground/r/kbTdxrx/generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
+        version_id: bZTBeWG
+        url: https://semgrep.dev/playground/r/bZTBeWG/generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
         origin: community
 - id: generic.nginx.security.request-host-used.request-host-used
   pattern-either:
@@ -2355,10 +2357,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9044
-        rv_id: 109353
+        rv_id: 833578
         rule_id: qNUjGg
-        version_id: w8T9n4D
-        url: https://semgrep.dev/playground/r/w8T9n4D/generic.nginx.security.request-host-used.request-host-used
+        version_id: NdTB2WO
+        url: https://semgrep.dev/playground/r/NdTB2WO/generic.nginx.security.request-host-used.request-host-used
         origin: community
 - id: generic.secrets.security.detected-amazon-mws-auth-token.detected-amazon-mws-auth-token
   pattern-regex: amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
@@ -2393,10 +2395,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9045
-        rv_id: 109519
+        rv_id: 833754
         rule_id: lBU9bw
-        version_id: ExTjNPp
-        url: https://semgrep.dev/playground/r/ExTjNPp/generic.secrets.security.detected-amazon-mws-auth-token.detected-amazon-mws-auth-token
+        version_id: YDTl0BP
+        url: https://semgrep.dev/playground/r/YDTl0BP/generic.secrets.security.detected-amazon-mws-auth-token.detected-amazon-mws-auth-token
         origin: community
 - id: generic.secrets.security.detected-artifactory-password.detected-artifactory-password
   patterns:
@@ -2452,10 +2454,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9046
-        rv_id: 109520
+        rv_id: 833755
         rule_id: YGUR5K
-        version_id: 7ZTgoqQ
-        url: https://semgrep.dev/playground/r/7ZTgoqQ/generic.secrets.security.detected-artifactory-password.detected-artifactory-password
+        version_id: JdTlrE7
+        url: https://semgrep.dev/playground/r/JdTlrE7/generic.secrets.security.detected-artifactory-password.detected-artifactory-password
         origin: community
 - id: generic.secrets.security.detected-artifactory-token.detected-artifactory-token
   patterns:
@@ -2507,10 +2509,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9047
-        rv_id: 109521
+        rv_id: 833756
         rule_id: 6JUj3l
-        version_id: LjTqQD4
-        url: https://semgrep.dev/playground/r/LjTqQD4/generic.secrets.security.detected-artifactory-token.detected-artifactory-token
+        version_id: 5PTyDjJ
+        url: https://semgrep.dev/playground/r/5PTyDjJ/generic.secrets.security.detected-artifactory-token.detected-artifactory-token
         origin: community
 - id: generic.secrets.security.detected-aws-account-id.detected-aws-account-id
   patterns:
@@ -2579,10 +2581,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9049
-        rv_id: 253873
+        rv_id: 833758
         rule_id: zdUkdd
-        version_id: pZTk9GY
-        url: https://semgrep.dev/playground/r/pZTk9GY/generic.secrets.security.detected-aws-account-id.detected-aws-account-id
+        version_id: RGTKG7e
+        url: https://semgrep.dev/playground/r/RGTKG7e/generic.secrets.security.detected-aws-account-id.detected-aws-account-id
         origin: community
 - id: generic.secrets.security.detected-aws-appsync-graphql-key.detected-aws-appsync-graphql-key
   pattern-regex: da2-[a-z0-9]{26}
@@ -2617,10 +2619,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9050
-        rv_id: 109524
+        rv_id: 833759
         rule_id: pKUOoZ
-        version_id: QkTW0ln
-        url: https://semgrep.dev/playground/r/QkTW0ln/generic.secrets.security.detected-aws-appsync-graphql-key.detected-aws-appsync-graphql-key
+        version_id: A8T378r
+        url: https://semgrep.dev/playground/r/A8T378r/generic.secrets.security.detected-aws-appsync-graphql-key.detected-aws-appsync-graphql-key
         origin: community
 - id: generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key
   patterns:
@@ -2657,10 +2659,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9051
-        rv_id: 109525
+        rv_id: 833760
         rule_id: 2ZUbe8
-        version_id: 3ZTkQD3
-        url: https://semgrep.dev/playground/r/3ZTkQD3/generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key
+        version_id: BjTe05N
+        url: https://semgrep.dev/playground/r/BjTe05N/generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key
         origin: community
 - id: generic.secrets.security.detected-aws-session-token.detected-aws-session-token
   patterns:
@@ -2700,10 +2702,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9052
-        rv_id: 109526
+        rv_id: 833761
         rule_id: X5U8Er
-        version_id: 44TRlWe
-        url: https://semgrep.dev/playground/r/44TRlWe/generic.secrets.security.detected-aws-session-token.detected-aws-session-token
+        version_id: DkTG0JW
+        url: https://semgrep.dev/playground/r/DkTG0JW/generic.secrets.security.detected-aws-session-token.detected-aws-session-token
         origin: community
 - id: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
   pattern-regex: "\\$2[aby]?\\$[\\d]+\\$[./A-Za-z0-9]{53}"
@@ -2737,10 +2739,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10043
-        rv_id: 109527
+        rv_id: 833762
         rule_id: PeUk0Q
-        version_id: PkTJ1qQ
-        url: https://semgrep.dev/playground/r/PkTJ1qQ/generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
+        version_id: WrTdp9P
+        url: https://semgrep.dev/playground/r/WrTdp9P/generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
         origin: community
 - id: generic.secrets.security.detected-codeclimate.detected-codeclimate
   pattern-regex: (?i)codeclima.{0,50}["|'|`]?[0-9a-f]{64}["|'|`]?
@@ -2775,10 +2777,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9053
-        rv_id: 109528
+        rv_id: 833763
         rule_id: j2UvW7
-        version_id: JdTNpAp
-        url: https://semgrep.dev/playground/r/JdTNpAp/generic.secrets.security.detected-codeclimate.detected-codeclimate
+        version_id: 0bTwbB2
+        url: https://semgrep.dev/playground/r/0bTwbB2/generic.secrets.security.detected-codeclimate.detected-codeclimate
         origin: community
 - id: generic.secrets.security.detected-etc-shadow.detected-etc-shadow
   patterns:
@@ -2813,10 +2815,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10044
-        rv_id: 258243
+        rv_id: 833764
         rule_id: JDUP6p
-        version_id: PkTWJ2o
-        url: https://semgrep.dev/playground/r/PkTWJ2o/generic.secrets.security.detected-etc-shadow.detected-etc-shadow
+        version_id: K3Trqe5
+        url: https://semgrep.dev/playground/r/K3Trqe5/generic.secrets.security.detected-etc-shadow.detected-etc-shadow
         origin: community
 - id: generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token
   pattern-either:
@@ -2854,10 +2856,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9054
-        rv_id: 109530
+        rv_id: 833765
         rule_id: 10UKBL
-        version_id: GxTv65k
-        url: https://semgrep.dev/playground/r/GxTv65k/generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token
+        version_id: qkTQnGQ
+        url: https://semgrep.dev/playground/r/qkTQnGQ/generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token
         origin: community
 - id: generic.secrets.security.detected-facebook-oauth.detected-facebook-oauth
   pattern-regex: '[fF][aA][cC][eE][bB][oO][oO][kK].*[tT][oO][kK][eE][nN].*[''|"]?[0-9a-f]{32}[''|"]?'
@@ -2892,10 +2894,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9055
-        rv_id: 109531
+        rv_id: 833766
         rule_id: 9AU127
-        version_id: RGTDkYp
-        url: https://semgrep.dev/playground/r/RGTDkYp/generic.secrets.security.detected-facebook-oauth.detected-facebook-oauth
+        version_id: l4TyObX
+        url: https://semgrep.dev/playground/r/l4TyObX/generic.secrets.security.detected-facebook-oauth.detected-facebook-oauth
         origin: community
 - id: generic.secrets.security.detected-generic-api-key.detected-generic-api-key
   patterns:
@@ -2933,10 +2935,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9056
-        rv_id: 109532
+        rv_id: 833767
         rule_id: yyUn8p
-        version_id: A8T951E
-        url: https://semgrep.dev/playground/r/A8T951E/generic.secrets.security.detected-generic-api-key.detected-generic-api-key
+        version_id: YDTl05v
+        url: https://semgrep.dev/playground/r/YDTl05v/generic.secrets.security.detected-generic-api-key.detected-generic-api-key
         origin: community
 - id: generic.secrets.security.detected-generic-secret.detected-generic-secret
   patterns:
@@ -2974,10 +2976,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9057
-        rv_id: 109533
+        rv_id: 833768
         rule_id: r6Urqe
-        version_id: BjTXrOJ
-        url: https://semgrep.dev/playground/r/BjTXrOJ/generic.secrets.security.detected-generic-secret.detected-generic-secret
+        version_id: 6xTDg3J
+        url: https://semgrep.dev/playground/r/6xTDg3J/generic.secrets.security.detected-generic-secret.detected-generic-secret
         origin: community
 - id: generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
   pattern-regex: sk_live_[0-9a-z]{32}
@@ -3012,10 +3014,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9069
-        rv_id: 109550
+        rv_id: 833785
         rule_id: EwU274
-        version_id: yeTR291
-        url: https://semgrep.dev/playground/r/yeTR291/generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
+        version_id: e1TDk55
+        url: https://semgrep.dev/playground/r/e1TDk55/generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
         origin: community
 - id: generic.secrets.security.detected-private-key.detected-private-key
   patterns:
@@ -3063,10 +3065,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9070
-        rv_id: 109551
+        rv_id: 833786
         rule_id: 7KUQ0p
-        version_id: rxTyLRv
-        url: https://semgrep.dev/playground/r/rxTyLRv/generic.secrets.security.detected-private-key.detected-private-key
+        version_id: vdTOzge
+        url: https://semgrep.dev/playground/r/vdTOzge/generic.secrets.security.detected-private-key.detected-private-key
         origin: community
 - id: generic.secrets.security.detected-sauce-token.detected-sauce-token
   pattern-regex: (?i)sauce.{0,50}(\\\"|'|`)?[0-9a-f-]{36}(\\\"|'|`)?
@@ -3101,10 +3103,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9071
-        rv_id: 109552
+        rv_id: 833787
         rule_id: L1UyZ5
-        version_id: bZTb1D3
-        url: https://semgrep.dev/playground/r/bZTb1D3/generic.secrets.security.detected-sauce-token.detected-sauce-token
+        version_id: d6TKG1Y
+        url: https://semgrep.dev/playground/r/d6TKG1Y/generic.secrets.security.detected-sauce-token.detected-sauce-token
         origin: community
 - id: generic.secrets.security.detected-sendgrid-api-key.detected-sendgrid-api-key
   pattern-regex: SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9-]{43}\b
@@ -3139,10 +3141,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12856
-        rv_id: 109553
+        rv_id: 833788
         rule_id: x8U2EG
-        version_id: NdT3d0j
-        url: https://semgrep.dev/playground/r/NdT3d0j/generic.secrets.security.detected-sendgrid-api-key.detected-sendgrid-api-key
+        version_id: ZRTlPno
+        url: https://semgrep.dev/playground/r/ZRTlPno/generic.secrets.security.detected-sendgrid-api-key.detected-sendgrid-api-key
         origin: community
 - id: generic.secrets.security.detected-slack-token.detected-slack-token
   pattern-either:
@@ -3179,10 +3181,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9072
-        rv_id: 109554
+        rv_id: 833789
         rule_id: 8GUjRA
-        version_id: kbTdx0X
-        url: https://semgrep.dev/playground/r/kbTdx0X/generic.secrets.security.detected-slack-token.detected-slack-token
+        version_id: nWTy4jg
+        url: https://semgrep.dev/playground/r/nWTy4jg/generic.secrets.security.detected-slack-token.detected-slack-token
         origin: community
 - id: generic.secrets.security.detected-slack-webhook.detected-slack-webhook
   pattern-regex: https://hooks\.slack\.com/services/T[a-zA-Z0-9_]{8,10}/B[a-zA-Z0-9_]{8,10}/[a-zA-Z0-9_]{24}
@@ -3217,10 +3219,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9073
-        rv_id: 109555
+        rv_id: 833790
         rule_id: gxU1dy
-        version_id: w8T9ndZ
-        url: https://semgrep.dev/playground/r/w8T9ndZ/generic.secrets.security.detected-slack-webhook.detected-slack-webhook
+        version_id: ExTrDOD
+        url: https://semgrep.dev/playground/r/ExTrDOD/generic.secrets.security.detected-slack-webhook.detected-slack-webhook
         origin: community
 - id: generic.secrets.security.detected-snyk-api-key.detected-snyk-api-key
   pattern-regex: (?i)snyk.{0,50}['|"|`]?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"\s]?
@@ -3254,10 +3256,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12857
-        rv_id: 109556
+        rv_id: 833791
         rule_id: OrUD9J
-        version_id: xyTKZyY
-        url: https://semgrep.dev/playground/r/xyTKZyY/generic.secrets.security.detected-snyk-api-key.detected-snyk-api-key
+        version_id: 7ZTx9dR
+        url: https://semgrep.dev/playground/r/7ZTx9dR/generic.secrets.security.detected-snyk-api-key.detected-snyk-api-key
         origin: community
 - id: generic.secrets.security.detected-softlayer-api-key.detected-softlayer-api-key
   pattern-regex: (?i)softlayer.{0,50}["|'|`]?[a-z0-9]{64}["|'|`]?
@@ -3292,10 +3294,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12858
-        rv_id: 109557
+        rv_id: 833792
         rule_id: eqUplZ
-        version_id: O9TNOKy
-        url: https://semgrep.dev/playground/r/O9TNOKy/generic.secrets.security.detected-softlayer-api-key.detected-softlayer-api-key
+        version_id: LjTEbOg
+        url: https://semgrep.dev/playground/r/LjTEbOg/generic.secrets.security.detected-softlayer-api-key.detected-softlayer-api-key
         origin: community
 - id: generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
   pattern-regex: (?i)sonar.{0,50}(\\\"|'|`)?[0-9a-f]{40}(\\\"|'|`)?
@@ -3343,10 +3345,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9074
-        rv_id: 109558
+        rv_id: 833793
         rule_id: QrUzP1
-        version_id: e1T01Xd
-        url: https://semgrep.dev/playground/r/e1T01Xd/generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
+        version_id: 8KTGkXZ
+        url: https://semgrep.dev/playground/r/8KTGkXZ/generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
         origin: community
 - id: generic.secrets.security.detected-square-access-token.detected-square-access-token
   pattern-regex: sq0atp-[0-9A-Za-z\-_]{22}
@@ -3381,10 +3383,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9075
-        rv_id: 109559
+        rv_id: 833794
         rule_id: 3qUPqO
-        version_id: vdTYNxW
-        url: https://semgrep.dev/playground/r/vdTYNxW/generic.secrets.security.detected-square-access-token.detected-square-access-token
+        version_id: gETy2jl
+        url: https://semgrep.dev/playground/r/gETy2jl/generic.secrets.security.detected-square-access-token.detected-square-access-token
         origin: community
 - id: generic.secrets.security.detected-square-oauth-secret.detected-square-oauth-secret
   pattern-regex: sq0csp-[0-9A-Za-z\\\-_]{43}
@@ -3419,10 +3421,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9076
-        rv_id: 109560
+        rv_id: 833795
         rule_id: 4bUk4l
-        version_id: d6TrA5w
-        url: https://semgrep.dev/playground/r/d6TrA5w/generic.secrets.security.detected-square-oauth-secret.detected-square-oauth-secret
+        version_id: QkTkrDb
+        url: https://semgrep.dev/playground/r/QkTkrDb/generic.secrets.security.detected-square-oauth-secret.detected-square-oauth-secret
         origin: community
 - id: generic.secrets.security.detected-ssh-password.detected-ssh-password
   pattern-regex: sshpass -p\s*['|\\\"][^%]
@@ -3457,10 +3459,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9077
-        rv_id: 724918
+        rv_id: 833796
         rule_id: PeUZ4d
-        version_id: 3ZT6geb
-        url: https://semgrep.dev/playground/r/3ZT6geb/generic.secrets.security.detected-ssh-password.detected-ssh-password
+        version_id: 3ZT3Ano
+        url: https://semgrep.dev/playground/r/3ZT3Ano/generic.secrets.security.detected-ssh-password.detected-ssh-password
         origin: community
 - id: generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key
   pattern-regex: sk_live_[0-9a-zA-Z]{24}
@@ -3495,10 +3497,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9078
-        rv_id: 109562
+        rv_id: 833797
         rule_id: JDUy0z
-        version_id: nWTxP1O
-        url: https://semgrep.dev/playground/r/nWTxP1O/generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key
+        version_id: 44TQPpo
+        url: https://semgrep.dev/playground/r/44TQPpo/generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key
         origin: community
 - id: generic.secrets.security.detected-stripe-restricted-api-key.detected-stripe-restricted-api-key
   pattern-regex: rk_live_[0-9a-zA-Z]{24}
@@ -3533,10 +3535,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9079
-        rv_id: 109563
+        rv_id: 833798
         rule_id: 5rUOWq
-        version_id: ExTjN3p
-        url: https://semgrep.dev/playground/r/ExTjN3p/generic.secrets.security.detected-stripe-restricted-api-key.detected-stripe-restricted-api-key
+        version_id: PkTxrvL
+        url: https://semgrep.dev/playground/r/PkTxrvL/generic.secrets.security.detected-stripe-restricted-api-key.detected-stripe-restricted-api-key
         origin: community
 - id: generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key
   patterns:
@@ -3574,10 +3576,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9080
-        rv_id: 109564
+        rv_id: 833799
         rule_id: GdU7Nl
-        version_id: 7ZTgojQ
-        url: https://semgrep.dev/playground/r/7ZTgojQ/generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key
+        version_id: JdTlrb7
+        url: https://semgrep.dev/playground/r/JdTlrb7/generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key
         origin: community
 - id: generic.secrets.security.detected-twilio-api-key.detected-twilio-api-key
   pattern-regex: SK[0-9a-fA-F]{32}
@@ -3612,10 +3614,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9081
-        rv_id: 109565
+        rv_id: 833800
         rule_id: ReUgJn
-        version_id: LjTqQo4
-        url: https://semgrep.dev/playground/r/LjTqQo4/generic.secrets.security.detected-twilio-api-key.detected-twilio-api-key
+        version_id: 5PTyDWJ
+        url: https://semgrep.dev/playground/r/5PTyDWJ/generic.secrets.security.detected-twilio-api-key.detected-twilio-api-key
         origin: community
 - id: generic.secrets.security.google-maps-apikeyleak.google-maps-apikeyleak
   patterns:
@@ -3650,10 +3652,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 52196
-        rv_id: 109567
+        rv_id: 833802
         rule_id: EwU3kN
-        version_id: gET3xog
-        url: https://semgrep.dev/playground/r/gET3xog/generic.secrets.security.google-maps-apikeyleak.google-maps-apikeyleak
+        version_id: RGTKGJe
+        url: https://semgrep.dev/playground/r/RGTKGJe/generic.secrets.security.google-maps-apikeyleak.google-maps-apikeyleak
         origin: community
 - id: generic.unicode.security.bidi.contains-bidirectional-characters
   patterns:
@@ -3697,10 +3699,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14880
-        rv_id: 109568
+        rv_id: 833803
         rule_id: d8UeX4
-        version_id: QkTW0jn
-        url: https://semgrep.dev/playground/r/QkTW0jn/generic.unicode.security.bidi.contains-bidirectional-characters
+        version_id: A8T37Dr
+        url: https://semgrep.dev/playground/r/A8T37Dr/generic.unicode.security.bidi.contains-bidirectional-characters
         origin: community
   languages:
   - bash
@@ -3761,10 +3763,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9088
-        rv_id: 109576
+        rv_id: 833811
         rule_id: qNUj6g
-        version_id: A8T95ZE
-        url: https://semgrep.dev/playground/r/A8T95ZE/go.gorilla.security.audit.session-cookie-missing-httponly.session-cookie-missing-httponly
+        version_id: YDTl0Wv
+        url: https://semgrep.dev/playground/r/YDTl0Wv/go.gorilla.security.audit.session-cookie-missing-httponly.session-cookie-missing-httponly
         origin: community
   fix-regex:
     regex: "(HttpOnly\\s*:\\s+)false"
@@ -3811,10 +3813,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9089
-        rv_id: 109577
+        rv_id: 833812
         rule_id: lBU9kw
-        version_id: BjTXrnJ
-        url: https://semgrep.dev/playground/r/BjTXrnJ/go.gorilla.security.audit.session-cookie-missing-secure.session-cookie-missing-secure
+        version_id: 6xTDgnJ
+        url: https://semgrep.dev/playground/r/6xTDgnJ/go.gorilla.security.audit.session-cookie-missing-secure.session-cookie-missing-secure
         origin: community
   fix-regex:
     regex: "(Secure\\s*:\\s+)false"
@@ -3859,10 +3861,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 133074
-        rv_id: 751089
+        rv_id: 833813
         rule_id: YGUpGd4
-        version_id: K3T5Lyr
-        url: https://semgrep.dev/playground/r/K3T5Lyr/go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
+        version_id: o5TBEq9
+        url: https://semgrep.dev/playground/r/o5TBEq9/go.gorilla.security.audit.session-cookie-samesitenone.session-cookie-samesitenone
         origin: community
   fix-regex:
     regex: "(SameSite\\s*:\\s+)http.SameSiteNoneMode"
@@ -3916,10 +3918,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18430
-        rv_id: 109578
+        rv_id: 833814
         rule_id: ReUKdz
-        version_id: DkT6nZ7
-        url: https://semgrep.dev/playground/r/DkT6nZ7/go.gorilla.security.audit.websocket-missing-origin-check.websocket-missing-origin-check
+        version_id: zyTWJob
+        url: https://semgrep.dev/playground/r/zyTWJob/go.gorilla.security.audit.websocket-missing-origin-check.websocket-missing-origin-check
         origin: community
 - id: go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
   metadata:
@@ -3945,10 +3947,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9090
-        rv_id: 109580
+        rv_id: 833816
         rule_id: PeUZ4X
-        version_id: 0bTLlY6
-        url: https://semgrep.dev/playground/r/0bTLlY6/go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
+        version_id: 2KT7xyR
+        url: https://semgrep.dev/playground/r/2KT7xyR/go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
         origin: community
   message: 'Found an insecure gRPC connection using ''grpc.WithInsecure()''. This
     creates a connection without encryption to a gRPC server. A malicious attacker
@@ -3987,10 +3989,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9091
-        rv_id: 109581
+        rv_id: 833817
         rule_id: JDUy0B
-        version_id: K3Tvj6P
-        url: https://semgrep.dev/playground/r/K3Tvj6P/go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
+        version_id: X0T5NDk
+        url: https://semgrep.dev/playground/r/X0T5NDk/go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
         origin: community
   message: Found an insecure gRPC server without 'grpc.Creds()' or options with credentials.
     This allows for a connection without encryption to this server. A malicious attacker
@@ -4044,10 +4046,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9094
-        rv_id: 109582
+        rv_id: 833818
         rule_id: ReUgJJ
-        version_id: qkT2xPr
-        url: https://semgrep.dev/playground/r/qkT2xPr/go.jwt-go.security.audit.jwt-parse-unverified.jwt-go-parse-unverified
+        version_id: jQTrXdJ
+        url: https://semgrep.dev/playground/r/jQTrXdJ/go.jwt-go.security.audit.jwt-parse-unverified.jwt-go-parse-unverified
         origin: community
   languages:
   - go
@@ -4087,10 +4089,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9092
-        rv_id: 378644
+        rv_id: 833819
         rule_id: 5rUOWQ
-        version_id: 0bT59Rk
-        url: https://semgrep.dev/playground/r/0bT59Rk/go.jwt-go.security.jwt-none-alg.jwt-go-none-algorithm
+        version_id: 1QTPL6k
+        url: https://semgrep.dev/playground/r/1QTPL6k/go.jwt-go.security.jwt-none-alg.jwt-go-none-algorithm
         origin: community
   languages:
   - go
@@ -4137,10 +4139,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9113
-        rv_id: 109596
+        rv_id: 833832
         rule_id: yyUnov
-        version_id: l4T4vAR
-        url: https://semgrep.dev/playground/r/l4T4vAR/go.lang.security.audit.crypto.bad_imports.insecure-module-used
+        version_id: ZRTlP0o
+        url: https://semgrep.dev/playground/r/ZRTlP0o/go.lang.security.audit.crypto.bad_imports.insecure-module-used
         origin: community
   languages:
   - go
@@ -4183,10 +4185,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9114
-        rv_id: 109597
+        rv_id: 833833
         rule_id: r6UrW9
-        version_id: YDTp2K7
-        url: https://semgrep.dev/playground/r/YDTp2K7/go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key
+        version_id: nWTy4Xg
+        url: https://semgrep.dev/playground/r/nWTy4Xg/go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key
         origin: community
   languages:
   - go
@@ -4228,10 +4230,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9116
-        rv_id: 828672
+        rv_id: 833835
         rule_id: NbUk4X
-        version_id: bZTB2b4
-        url: https://semgrep.dev/playground/r/bZTB2b4/go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
+        version_id: 7ZTx90R
+        url: https://semgrep.dev/playground/r/7ZTx90R/go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
         origin: community
   languages:
   - go
@@ -4276,10 +4278,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9123
-        rv_id: 109606
+        rv_id: 833842
         rule_id: d8UjY3
-        version_id: 9lTdWGe
-        url: https://semgrep.dev/playground/r/9lTdWGe/go.lang.security.audit.crypto.use_of_weak_rsa_key.use-of-weak-rsa-key
+        version_id: PkTxr4L
+        url: https://semgrep.dev/playground/r/PkTxr4L/go.lang.security.audit.crypto.use_of_weak_rsa_key.use-of-weak-rsa-key
         origin: community
   patterns:
   - pattern-either:
@@ -4354,10 +4356,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9107
-        rv_id: 109607
+        rv_id: 833843
         rule_id: pKUOZ9
-        version_id: yeTR24B
-        url: https://semgrep.dev/playground/r/yeTR24B/go.lang.security.audit.dangerous-command-write.dangerous-command-write
+        version_id: JdTlr07
+        url: https://semgrep.dev/playground/r/JdTlr07/go.lang.security.audit.dangerous-command-write.dangerous-command-write
         origin: community
 - id: go.lang.security.audit.dangerous-exec-cmd.dangerous-exec-cmd
   patterns:
@@ -4456,10 +4458,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9108
-        rv_id: 109608
+        rv_id: 833844
         rule_id: 2ZUb8l
-        version_id: rxTyLpr
-        url: https://semgrep.dev/playground/r/rxTyLpr/go.lang.security.audit.dangerous-exec-cmd.dangerous-exec-cmd
+        version_id: 5PTyDZJ
+        url: https://semgrep.dev/playground/r/5PTyDZJ/go.lang.security.audit.dangerous-exec-cmd.dangerous-exec-cmd
         origin: community
   severity: ERROR
   languages:
@@ -4538,10 +4540,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9109
-        rv_id: 109609
+        rv_id: 833845
         rule_id: X5U8RQ
-        version_id: bZTb17O
-        url: https://semgrep.dev/playground/r/bZTb17O/go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+        version_id: GxTDE1v
+        url: https://semgrep.dev/playground/r/GxTDE1v/go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
         origin: community
   severity: ERROR
   languages:
@@ -4653,10 +4655,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9110
-        rv_id: 109610
+        rv_id: 833846
         rule_id: j2UvPl
-        version_id: NdT3dKY
-        url: https://semgrep.dev/playground/r/NdT3dKY/go.lang.security.audit.dangerous-syscall-exec.dangerous-syscall-exec
+        version_id: RGTKGye
+        url: https://semgrep.dev/playground/r/RGTKGye/go.lang.security.audit.dangerous-syscall-exec.dangerous-syscall-exec
         origin: community
   severity: ERROR
   languages:
@@ -4696,10 +4698,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9124
-        rv_id: 258604
+        rv_id: 833847
         rule_id: ZqU5bD
-        version_id: JdT3NAn
-        url: https://semgrep.dev/playground/r/JdT3NAn/go.lang.security.audit.database.string-formatted-query.string-formatted-query
+        version_id: A8T37Br
+        url: https://semgrep.dev/playground/r/A8T37Br/go.lang.security.audit.database.string-formatted-query.string-formatted-query
         origin: community
   patterns:
   - metavariable-regex:
@@ -4812,10 +4814,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9125
-        rv_id: 109613
+        rv_id: 833849
         rule_id: nJUz3J
-        version_id: xyTKZgN
-        url: https://semgrep.dev/playground/r/xyTKZgN/go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
+        version_id: DkTG0EW
+        url: https://semgrep.dev/playground/r/DkTG0EW/go.lang.security.audit.net.bind_all.avoid-bind-to-all-interfaces
         origin: community
   pattern-either:
   - pattern: tls.Listen($NETWORK, "=~/^0.0.0.0:.*$/", ...)
@@ -4853,10 +4855,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9129
-        rv_id: 109617
+        rv_id: 833853
         rule_id: 8GUjDW
-        version_id: d6TrA0v
-        url: https://semgrep.dev/playground/r/d6TrA0v/go.lang.security.audit.net.formatted-template-string.formatted-template-string
+        version_id: qkTQnDQ
+        url: https://semgrep.dev/playground/r/qkTQnDQ/go.lang.security.audit.net.formatted-template-string.formatted-template-string
         origin: community
   languages:
   - go
@@ -4914,10 +4916,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9130
-        rv_id: 109619
+        rv_id: 833855
         rule_id: gxU1Kp
-        version_id: nWTxPb9
-        url: https://semgrep.dev/playground/r/nWTxPb9/go.lang.security.audit.net.pprof.pprof-debug-exposure
+        version_id: YDTl0Lv
+        url: https://semgrep.dev/playground/r/YDTl0Lv/go.lang.security.audit.net.pprof.pprof-debug-exposure
         origin: community
   message: The profiling 'pprof' endpoint is automatically exposed on /debug/pprof.
     This could leak information about the server. Instead, use `import "net/http/pprof"`.
@@ -4973,10 +4975,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9131
-        rv_id: 109620
+        rv_id: 833856
         rule_id: QrUz9R
-        version_id: ExTjNLe
-        url: https://semgrep.dev/playground/r/ExTjNLe/go.lang.security.audit.net.unescaped-data-in-htmlattr.unescaped-data-in-htmlattr
+        version_id: JdTlrXp
+        url: https://semgrep.dev/playground/r/JdTlrXp/go.lang.security.audit.net.unescaped-data-in-htmlattr.unescaped-data-in-htmlattr
         origin: community
   languages:
   - go
@@ -5039,10 +5041,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9132
-        rv_id: 109621
+        rv_id: 833857
         rule_id: 3qUP8K
-        version_id: 7ZTgolZ
-        url: https://semgrep.dev/playground/r/7ZTgolZ/go.lang.security.audit.net.unescaped-data-in-js.unescaped-data-in-js
+        version_id: 5PTyDZe
+        url: https://semgrep.dev/playground/r/5PTyDZe/go.lang.security.audit.net.unescaped-data-in-js.unescaped-data-in-js
         origin: community
   languages:
   - go
@@ -5106,10 +5108,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9133
-        rv_id: 109622
+        rv_id: 833858
         rule_id: 4bUkDW
-        version_id: LjTqQWB
-        url: https://semgrep.dev/playground/r/LjTqQWB/go.lang.security.audit.net.unescaped-data-in-url.unescaped-data-in-url
+        version_id: GxTDE1k
+        url: https://semgrep.dev/playground/r/GxTDE1k/go.lang.security.audit.net.unescaped-data-in-url.unescaped-data-in-url
         origin: community
   languages:
   - go
@@ -5169,10 +5171,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9111
-        rv_id: 109625
+        rv_id: 833861
         rule_id: 10UKGb
-        version_id: QkTW0YB
-        url: https://semgrep.dev/playground/r/QkTW0YB/go.lang.security.audit.reflect-makefunc.reflect-makefunc
+        version_id: BjTe0RJ
+        url: https://semgrep.dev/playground/r/BjTe0RJ/go.lang.security.audit.reflect-makefunc.reflect-makefunc
         origin: community
   severity: ERROR
   pattern: reflect.MakeFunc(...)
@@ -5222,10 +5224,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10005
-        rv_id: 109630
+        rv_id: 833866
         rule_id: BYUBdJ
-        version_id: 5PTdAR2
-        url: https://semgrep.dev/playground/r/5PTdAR2/go.lang.security.audit.unsafe-reflect-by-name.unsafe-reflect-by-name
+        version_id: qkTQnDr
+        url: https://semgrep.dev/playground/r/qkTQnDr/go.lang.security.audit.unsafe-reflect-by-name.unsafe-reflect-by-name
         origin: community
   severity: WARNING
   languages:
@@ -5260,10 +5262,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9112
-        rv_id: 109631
+        rv_id: 833867
         rule_id: 9AU1p1
-        version_id: GxTv6nn
-        url: https://semgrep.dev/playground/r/GxTv6nn/go.lang.security.audit.unsafe.use-of-unsafe-block
+        version_id: l4TyOE3
+        url: https://semgrep.dev/playground/r/l4TyOE3/go.lang.security.audit.unsafe.use-of-unsafe-block
         origin: community
   pattern: unsafe.$FUNC(...)
 - id: go.lang.security.audit.xss.import-text-template.import-text-template
@@ -5302,10 +5304,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9136
-        rv_id: 109632
+        rv_id: 833868
         rule_id: 5rUOZQ
-        version_id: RGTDk68
-        url: https://semgrep.dev/playground/r/RGTDk68/go.lang.security.audit.xss.import-text-template.import-text-template
+        version_id: YDTl0LG
+        url: https://semgrep.dev/playground/r/YDTl0LG/go.lang.security.audit.xss.import-text-template.import-text-template
         origin: community
   severity: WARNING
   patterns:
@@ -5354,10 +5356,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9137
-        rv_id: 109633
+        rv_id: 833869
         rule_id: GdU71y
-        version_id: A8T95O8
-        url: https://semgrep.dev/playground/r/A8T95O8/go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+        version_id: 6xTDgBO
+        url: https://semgrep.dev/playground/r/6xTDgBO/go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
         origin: community
   patterns:
   - pattern-either:
@@ -5409,10 +5411,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9138
-        rv_id: 109634
+        rv_id: 833870
         rule_id: ReUgyJ
-        version_id: BjTXrgq
-        url: https://semgrep.dev/playground/r/BjTXrgq/go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter
+        version_id: o5TBEAp
+        url: https://semgrep.dev/playground/r/o5TBEAp/go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter
         origin: community
   severity: WARNING
   patterns:
@@ -5462,10 +5464,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9139
-        rv_id: 109635
+        rv_id: 833871
         rule_id: AbUzBB
-        version_id: DkT6nPE
-        url: https://semgrep.dev/playground/r/DkT6nPE/go.lang.security.audit.xss.no-interpolation-in-tag.no-interpolation-in-tag
+        version_id: zyTWJzw
+        url: https://semgrep.dev/playground/r/zyTWJzw/go.lang.security.audit.xss.no-interpolation-in-tag.no-interpolation-in-tag
         origin: community
   languages:
   - generic
@@ -5512,10 +5514,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9140
-        rv_id: 109636
+        rv_id: 833872
         rule_id: BYUNR6
-        version_id: WrTWQX0
-        url: https://semgrep.dev/playground/r/WrTWQX0/go.lang.security.audit.xss.no-interpolation-js-template-string.no-interpolation-js-template-string
+        version_id: pZTXjE8
+        url: https://semgrep.dev/playground/r/pZTXjE8/go.lang.security.audit.xss.no-interpolation-js-template-string.no-interpolation-js-template-string
         origin: community
   languages:
   - generic
@@ -5562,10 +5564,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9141
-        rv_id: 109637
+        rv_id: 833873
         rule_id: DbUpEr
-        version_id: 0bTLl8P
-        url: https://semgrep.dev/playground/r/0bTLl8P/go.lang.security.audit.xss.no-io-writestring-to-responsewriter.no-io-writestring-to-responsewriter
+        version_id: 2KT7x8e
+        url: https://semgrep.dev/playground/r/2KT7x8e/go.lang.security.audit.xss.no-io-writestring-to-responsewriter.no-io-writestring-to-responsewriter
         origin: community
   severity: WARNING
   patterns:
@@ -5613,10 +5615,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9142
-        rv_id: 109638
+        rv_id: 833874
         rule_id: WAUoLp
-        version_id: K3TvjDq
-        url: https://semgrep.dev/playground/r/K3TvjDq/go.lang.security.audit.xss.no-printf-in-responsewriter.no-printf-in-responsewriter
+        version_id: X0T5NRD
+        url: https://semgrep.dev/playground/r/X0T5NRD/go.lang.security.audit.xss.no-printf-in-responsewriter.no-printf-in-responsewriter
         origin: community
   severity: WARNING
   patterns:
@@ -5666,10 +5668,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9143
-        rv_id: 109639
+        rv_id: 833875
         rule_id: 0oU5n3
-        version_id: qkT2xdw
-        url: https://semgrep.dev/playground/r/qkT2xdw/go.lang.security.audit.xss.template-html-does-not-escape.unsafe-template-type
+        version_id: jQTrXPP
+        url: https://semgrep.dev/playground/r/jQTrXPP/go.lang.security.audit.xss.template-html-does-not-escape.unsafe-template-type
         origin: community
   languages:
   - go
@@ -5714,10 +5716,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9104
-        rv_id: 109641
+        rv_id: 833877
         rule_id: 6JUjnL
-        version_id: YDTp217
-        url: https://semgrep.dev/playground/r/YDTp217/go.lang.security.bad_tmp.bad-tmp-file-creation
+        version_id: 9lTJ0pP
+        url: https://semgrep.dev/playground/r/9lTJ0pP/go.lang.security.bad_tmp.bad-tmp-file-creation
         origin: community
   pattern-either:
   - pattern: ioutil.WriteFile("=~//tmp/.*$/", ...)
@@ -5790,10 +5792,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9105
-        rv_id: 258244
+        rv_id: 833878
         rule_id: oqUeqn
-        version_id: JdT3NG6
-        url: https://semgrep.dev/playground/r/JdT3NG6/go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
+        version_id: yeTN1o1
+        url: https://semgrep.dev/playground/r/yeTN1o1/go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
         origin: community
 - id: go.lang.security.zip.path-traversal-inside-zip-extraction
   message: File traversal when extracting zip archive
@@ -5825,10 +5827,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9106
-        rv_id: 109647
+        rv_id: 833884
         rule_id: zdUkoR
-        version_id: X0TQxjB
-        url: https://semgrep.dev/playground/r/X0TQxjB/go.lang.security.zip.path-traversal-inside-zip-extraction
+        version_id: xyTNe6Y
+        url: https://semgrep.dev/playground/r/xyTNe6Y/go.lang.security.zip.path-traversal-inside-zip-extraction
         origin: community
   languages:
   - go
@@ -5870,10 +5872,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9144
-        rv_id: 109648
+        rv_id: 833885
         rule_id: KxUbxk
-        version_id: jQTgY8k
-        url: https://semgrep.dev/playground/r/jQTgY8k/go.otto.security.audit.dangerous-execution.dangerous-execution
+        version_id: O9TJW1y
+        url: https://semgrep.dev/playground/r/O9TJW1y/go.otto.security.audit.dangerous-execution.dangerous-execution
         origin: community
   severity: ERROR
   patterns:
@@ -5929,10 +5931,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9987
-        rv_id: 109673
+        rv_id: 833908
         rule_id: JDUPQ7
-        version_id: JdTNpEA
-        url: https://semgrep.dev/playground/r/JdTNpEA/java.jboss.security.seam-log-injection.seam-log-injection
+        version_id: 0bTwbj6
+        url: https://semgrep.dev/playground/r/0bTwbj6/java.jboss.security.seam-log-injection.seam-log-injection
         origin: community
   severity: ERROR
 - id: java.jjwt.security.jwt-none-alg.jjwt-none-alg
@@ -5970,10 +5972,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9154
-        rv_id: 109675
+        rv_id: 833910
         rule_id: j2Uvol
-        version_id: GxTv63n
-        url: https://semgrep.dev/playground/r/GxTv63n/java.jjwt.security.jwt-none-alg.jjwt-none-alg
+        version_id: qkTQn3r
+        url: https://semgrep.dev/playground/r/qkTQn3r/java.jjwt.security.jwt-none-alg.jjwt-none-alg
         origin: community
   languages:
   - java
@@ -6016,10 +6018,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9165
-        rv_id: 109680
+        rv_id: 833915
         rule_id: eqU8J3
-        version_id: WrTWQD0
-        url: https://semgrep.dev/playground/r/WrTWQD0/java.lang.security.audit.anonymous-ldap-bind.anonymous-ldap-bind
+        version_id: zyTWJEw
+        url: https://semgrep.dev/playground/r/zyTWJEw/java.lang.security.audit.anonymous-ldap-bind.anonymous-ldap-bind
         origin: community
   message: Detected anonymous LDAP bind. This permits anonymous users to execute LDAP
     statements. Consider enforcing authentication for LDAP. See https://docs.oracle.com/javase/tutorial/jndi/ldap/auth_mechs.html
@@ -6055,10 +6057,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9166
-        rv_id: 109681
+        rv_id: 833916
         rule_id: v8Uny0
-        version_id: 0bTLlDP
-        url: https://semgrep.dev/playground/r/0bTLlDP/java.lang.security.audit.bad-hexa-conversion.bad-hexa-conversion
+        version_id: pZTXj58
+        url: https://semgrep.dev/playground/r/pZTXj58/java.lang.security.audit.bad-hexa-conversion.bad-hexa-conversion
         origin: community
   message: '''Integer.toHexString()'' strips leading zeroes from each byte if read
     byte-by-byte. This mistake weakens the hash value computed since it introduces
@@ -6106,10 +6108,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9167
-        rv_id: 109682
+        rv_id: 833917
         rule_id: d8UjJ3
-        version_id: K3TvjZq
-        url: https://semgrep.dev/playground/r/K3TvjZq/java.lang.security.audit.blowfish-insufficient-key-size.blowfish-insufficient-key-size
+        version_id: 2KT7x9e
+        url: https://semgrep.dev/playground/r/2KT7x9e/java.lang.security.audit.blowfish-insufficient-key-size.blowfish-insufficient-key-size
         origin: community
   message: Using less than 128 bits for Blowfish is considered insecure. Use 128 bits
     or more, or switch to use AES instead.
@@ -6156,10 +6158,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9168
-        rv_id: 109683
+        rv_id: 833918
         rule_id: ZqU5oD
-        version_id: qkT2xEw
-        url: https://semgrep.dev/playground/r/qkT2xEw/java.lang.security.audit.cbc-padding-oracle.cbc-padding-oracle
+        version_id: X0T5NrD
+        url: https://semgrep.dev/playground/r/X0T5NrD/java.lang.security.audit.cbc-padding-oracle.cbc-padding-oracle
         origin: community
   severity: WARNING
   fix: '"AES/GCM/NoPadding"
@@ -6274,10 +6276,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9169
-        rv_id: 109684
+        rv_id: 833919
         rule_id: nJUzvJ
-        version_id: l4T4vgR
-        url: https://semgrep.dev/playground/r/l4T4vgR/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
+        version_id: jQTrXoP
+        url: https://semgrep.dev/playground/r/jQTrXoP/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
         origin: community
   severity: ERROR
   languages:
@@ -6463,10 +6465,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9941
-        rv_id: 109685
+        rv_id: 833920
         rule_id: 4bUzzo
-        version_id: YDTp2B7
-        url: https://semgrep.dev/playground/r/YDTp2B7/java.lang.security.audit.command-injection-process-builder.command-injection-process-builder
+        version_id: 1QTPL11
+        url: https://semgrep.dev/playground/r/1QTPL11/java.lang.security.audit.command-injection-process-builder.command-injection-process-builder
         origin: community
   severity: ERROR
   languages:
@@ -6501,10 +6503,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9170
-        rv_id: 109686
+        rv_id: 833921
         rule_id: EwU2z6
-        version_id: JdTNpEW
-        url: https://semgrep.dev/playground/r/JdTNpEW/java.lang.security.audit.cookie-missing-httponly.cookie-missing-httponly
+        version_id: 9lTJ0xP
+        url: https://semgrep.dev/playground/r/9lTJ0xP/java.lang.security.audit.cookie-missing-httponly.cookie-missing-httponly
         origin: community
   message: A cookie was detected without setting the 'HttpOnly' flag. The 'HttpOnly'
     flag for cookies instructs the browser to forbid client-side scripts from reading
@@ -6550,10 +6552,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9172
-        rv_id: 109688
+        rv_id: 833922
         rule_id: L1Uyvp
-        version_id: GxTv63G
-        url: https://semgrep.dev/playground/r/GxTv63G/java.lang.security.audit.cookie-missing-secure-flag.cookie-missing-secure-flag
+        version_id: yeTN1K1
+        url: https://semgrep.dev/playground/r/yeTN1K1/java.lang.security.audit.cookie-missing-secure-flag.cookie-missing-secure-flag
         origin: community
   message: A cookie was detected without setting the 'secure' flag. The 'secure' flag
     for cookies prevents the client from transmitting the cookie over insecure channels
@@ -6600,10 +6602,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9201
-        rv_id: 109698
+        rv_id: 833932
         rule_id: KxUbW4
-        version_id: YDTp25Q
-        url: https://semgrep.dev/playground/r/YDTp25Q/java.lang.security.audit.crypto.ssl.avoid-implementing-custom-digests.avoid-implementing-custom-digests
+        version_id: d6TKGdw
+        url: https://semgrep.dev/playground/r/d6TKGdw/java.lang.security.audit.crypto.ssl.avoid-implementing-custom-digests.avoid-implementing-custom-digests
         origin: community
   message: 'Cryptographic algorithms are notoriously difficult to get right. By implementing
     a custom message digest, you risk introducing security issues into your program.
@@ -6647,10 +6649,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9202
-        rv_id: 109699
+        rv_id: 833933
         rule_id: qNUj8b
-        version_id: 6xTvJ31
-        url: https://semgrep.dev/playground/r/6xTvJ31/java.lang.security.audit.crypto.ssl.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
+        version_id: ZRTlPYQ
+        url: https://semgrep.dev/playground/r/ZRTlPYQ/java.lang.security.audit.crypto.ssl.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
         origin: community
   message: DefaultHttpClient is deprecated. Further, it does not support connections
     using TLS1.2, which makes using DefaultHttpClient a security hazard. Use HttpClientBuilder
@@ -6696,10 +6698,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9203
-        rv_id: 109700
+        rv_id: 833934
         rule_id: lBU9n8
-        version_id: o5Tglv2
-        url: https://semgrep.dev/playground/r/o5Tglv2/java.lang.security.audit.crypto.ssl.insecure-hostname-verifier.insecure-hostname-verifier
+        version_id: nWTy4gO
+        url: https://semgrep.dev/playground/r/nWTy4gO/java.lang.security.audit.crypto.ssl.insecure-hostname-verifier.insecure-hostname-verifier
         origin: community
   severity: WARNING
   languages:
@@ -6748,10 +6750,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9204
-        rv_id: 109701
+        rv_id: 833935
         rule_id: YGUR9A
-        version_id: zyTK8dW
-        url: https://semgrep.dev/playground/r/zyTK8dW/java.lang.security.audit.crypto.ssl.insecure-trust-manager.insecure-trust-manager
+        version_id: ExTrD0p
+        url: https://semgrep.dev/playground/r/ExTrD0p/java.lang.security.audit.crypto.ssl.insecure-trust-manager.insecure-trust-manager
         origin: community
   message: Detected empty trust manager implementations. This is dangerous because
     it accepts any certificate, enabling man-in-the-middle attacks. Consider using
@@ -6817,10 +6819,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17327
-        rv_id: 109711
+        rv_id: 833945
         rule_id: lBUW5D
-        version_id: NdT3dLr
-        url: https://semgrep.dev/playground/r/NdT3dLr/java.lang.security.audit.crypto.weak-random.weak-random
+        version_id: 5PTyDge
+        url: https://semgrep.dev/playground/r/5PTyDge/java.lang.security.audit.crypto.weak-random.weak-random
         origin: community
   pattern-either:
   - pattern: 'new java.util.Random(...).$FUNC(...)
@@ -6878,10 +6880,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10091
-        rv_id: 109713
+        rv_id: 833947
         rule_id: ReUPKp
-        version_id: w8T9nr4
-        url: https://semgrep.dev/playground/r/w8T9nr4/java.lang.security.audit.dangerous-groovy-shell.dangerous-groovy-shell
+        version_id: RGTKG4p
+        url: https://semgrep.dev/playground/r/RGTKG4p/java.lang.security.audit.dangerous-groovy-shell.dangerous-groovy-shell
         origin: community
   languages:
   - java
@@ -6912,10 +6914,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9174
-        rv_id: 109714
+        rv_id: 833948
         rule_id: gxU1Np
-        version_id: xyTKZO1
-        url: https://semgrep.dev/playground/r/xyTKZO1/java.lang.security.audit.el-injection.el-injection
+        version_id: A8T37oE
+        url: https://semgrep.dev/playground/r/A8T37oE/java.lang.security.audit.el-injection.el-injection
         origin: community
   message: An expression is built with a dynamic value. The source of the value(s)
     should be verified to avoid that unfiltered values fall into this risky code evaluation.
@@ -7083,10 +7085,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11928
-        rv_id: 109718
+        rv_id: 833952
         rule_id: KxUY7b
-        version_id: d6TrA15
-        url: https://semgrep.dev/playground/r/d6TrA15/java.lang.security.audit.java-reverse-shell.java-reverse-shell
+        version_id: 0bTwbP6
+        url: https://semgrep.dev/playground/r/0bTwbP6/java.lang.security.audit.java-reverse-shell.java-reverse-shell
         origin: community
   languages:
   - java
@@ -7124,10 +7126,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9178
-        rv_id: 109719
+        rv_id: 833953
         rule_id: PeUZNX
-        version_id: ZRTQNn9
-        url: https://semgrep.dev/playground/r/ZRTQNn9/java.lang.security.audit.jdbc-sql-formatted-string.jdbc-sql-formatted-string
+        version_id: K3TrqWP
+        url: https://semgrep.dev/playground/r/K3TrqWP/java.lang.security.audit.jdbc-sql-formatted-string.jdbc-sql-formatted-string
         origin: community
   message: 'Possible JDBC injection detected. Use the parameterized query feature
     available in queryForObject instead of concatenating or formatting strings: ''jdbc.queryForObject("select
@@ -7253,10 +7255,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9179
-        rv_id: 109720
+        rv_id: 833954
         rule_id: JDUy8B
-        version_id: nWTxPjE
-        url: https://semgrep.dev/playground/r/nWTxPjE/java.lang.security.audit.ldap-entry-poisoning.ldap-entry-poisoning
+        version_id: qkTQn8r
+        url: https://semgrep.dev/playground/r/qkTQn8r/java.lang.security.audit.ldap-entry-poisoning.ldap-entry-poisoning
         origin: community
   message: An object-returning LDAP search will allow attackers to control the LDAP
     response. This could lead to Remote Code Execution.
@@ -7306,10 +7308,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9180
-        rv_id: 109721
+        rv_id: 833955
         rule_id: 5rUObQ
-        version_id: ExTjNOO
-        url: https://semgrep.dev/playground/r/ExTjNOO/java.lang.security.audit.ldap-injection.ldap-injection
+        version_id: l4TyOn3
+        url: https://semgrep.dev/playground/r/l4TyOn3/java.lang.security.audit.ldap-injection.ldap-injection
         origin: community
   severity: WARNING
   languages:
@@ -7393,10 +7395,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9181
-        rv_id: 109723
+        rv_id: 833957
         rule_id: GdU7py
-        version_id: LjTqQOj
-        url: https://semgrep.dev/playground/r/LjTqQOj/java.lang.security.audit.object-deserialization.object-deserialization
+        version_id: JdTlr9A
+        url: https://semgrep.dev/playground/r/JdTlr9A/java.lang.security.audit.object-deserialization.object-deserialization
         origin: community
   message: Found object deserialization using ObjectInputStream. Deserializing entire
     Java objects is dangerous because malicious actors can create Java object streams
@@ -7436,10 +7438,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9182
-        rv_id: 109724
+        rv_id: 833958
         rule_id: ReUgjJ
-        version_id: 8KTQ9Xw
-        url: https://semgrep.dev/playground/r/8KTQ9Xw/java.lang.security.audit.ognl-injection.ognl-injection
+        version_id: 5PTyDg2
+        url: https://semgrep.dev/playground/r/5PTyDg2/java.lang.security.audit.ognl-injection.ognl-injection
         origin: community
   severity: WARNING
   languages:
@@ -8294,10 +8296,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9183
-        rv_id: 109725
+        rv_id: 833959
         rule_id: AbUzwB
-        version_id: gET3xjQ
-        url: https://semgrep.dev/playground/r/gET3xjQ/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission
+        version_id: GxTDEdn
+        url: https://semgrep.dev/playground/r/GxTDEdn/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission
         origin: community
   pattern-either:
   - pattern: java.nio.file.Files.setPosixFilePermissions($FILE, java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/"));
@@ -8349,10 +8351,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9184
-        rv_id: 109726
+        rv_id: 833960
         rule_id: BYUN66
-        version_id: QkTW0Dr
-        url: https://semgrep.dev/playground/r/QkTW0Dr/java.lang.security.audit.permissive-cors.permissive-cors
+        version_id: RGTKG48
+        url: https://semgrep.dev/playground/r/RGTKG48/java.lang.security.audit.permissive-cors.permissive-cors
         origin: community
   severity: WARNING
   languages:
@@ -8432,10 +8434,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9185
-        rv_id: 109727
+        rv_id: 833961
         rule_id: DbUpAr
-        version_id: 3ZTkQnw
-        url: https://semgrep.dev/playground/r/3ZTkQnw/java.lang.security.audit.script-engine-injection.script-engine-injection
+        version_id: A8T37o8
+        url: https://semgrep.dev/playground/r/A8T37o8/java.lang.security.audit.script-engine-injection.script-engine-injection
         origin: community
   severity: WARNING
   languages:
@@ -8573,10 +8575,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9205
-        rv_id: 109728
+        rv_id: 833962
         rule_id: 6JUjPD
-        version_id: 44TRlpj
-        url: https://semgrep.dev/playground/r/44TRlpj/java.lang.security.audit.sqli.hibernate-sqli.hibernate-sqli
+        version_id: BjTe03q
+        url: https://semgrep.dev/playground/r/BjTe03q/java.lang.security.audit.sqli.hibernate-sqli.hibernate-sqli
         origin: community
   languages:
   - java
@@ -8650,10 +8652,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9206
-        rv_id: 109729
+        rv_id: 833963
         rule_id: oqUe8K
-        version_id: PkTJ1vy
-        url: https://semgrep.dev/playground/r/PkTJ1vy/java.lang.security.audit.sqli.jdbc-sqli.jdbc-sqli
+        version_id: DkTG0rE
+        url: https://semgrep.dev/playground/r/DkTG0rE/java.lang.security.audit.sqli.jdbc-sqli.jdbc-sqli
         origin: community
 - id: java.lang.security.audit.sqli.jdo-sqli.jdo-sqli
   pattern-either:
@@ -8756,10 +8758,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9207
-        rv_id: 109730
+        rv_id: 833964
         rule_id: zdUk7l
-        version_id: JdTNpbW
-        url: https://semgrep.dev/playground/r/JdTNpbW/java.lang.security.audit.sqli.jdo-sqli.jdo-sqli
+        version_id: WrTdp40
+        url: https://semgrep.dev/playground/r/WrTdp40/java.lang.security.audit.sqli.jdo-sqli.jdo-sqli
         origin: community
 - id: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
   message: Detected a formatted string in a SQL statement. This could lead to SQL
@@ -8830,10 +8832,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9208
-        rv_id: 109731
+        rv_id: 833965
         rule_id: pKUO7y
-        version_id: 5PTdAjX
-        url: https://semgrep.dev/playground/r/5PTdAjX/java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
+        version_id: 0bTwbPP
+        url: https://semgrep.dev/playground/r/0bTwbPP/java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
         origin: community
 - id: java.lang.security.audit.sqli.turbine-sqli.turbine-sqli
   pattern-either:
@@ -8935,10 +8937,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9209
-        rv_id: 109733
+        rv_id: 833967
         rule_id: 2ZUbJ3
-        version_id: RGTDk7b
-        url: https://semgrep.dev/playground/r/RGTDk7b/java.lang.security.audit.sqli.turbine-sqli.turbine-sqli
+        version_id: qkTQn8w
+        url: https://semgrep.dev/playground/r/qkTQn8w/java.lang.security.audit.sqli.turbine-sqli.turbine-sqli
         origin: community
 - id: java.lang.security.audit.sqli.vertx-sqli.vertx-sqli
   message: Detected a formatted string in a SQL statement. This could lead to SQL
@@ -9016,10 +9018,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9210
-        rv_id: 109734
+        rv_id: 833968
         rule_id: X5U86z
-        version_id: A8T958Y
-        url: https://semgrep.dev/playground/r/A8T958Y/java.lang.security.audit.sqli.vertx-sqli.vertx-sqli
+        version_id: l4TyOnR
+        url: https://semgrep.dev/playground/r/l4TyOnR/java.lang.security.audit.sqli.vertx-sqli.vertx-sqli
         origin: community
 - id: java.lang.security.audit.unsafe-reflection.unsafe-reflection
   patterns:
@@ -9063,10 +9065,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9993
-        rv_id: 109740
+        rv_id: 833974
         rule_id: DbUW1W
-        version_id: qkT2x6j
-        url: https://semgrep.dev/playground/r/qkT2x6j/java.lang.security.audit.unsafe-reflection.unsafe-reflection
+        version_id: 2KT7xJ0
+        url: https://semgrep.dev/playground/r/2KT7xJ0/java.lang.security.audit.unsafe-reflection.unsafe-reflection
         origin: community
   severity: WARNING
   languages:
@@ -9098,10 +9100,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9188
-        rv_id: 109743
+        rv_id: 833977
         rule_id: KxUb1k
-        version_id: 6xTvJn1
-        url: https://semgrep.dev/playground/r/6xTvJn1/java.lang.security.audit.weak-ssl-context.weak-ssl-context
+        version_id: 1QTPLLO
+        url: https://semgrep.dev/playground/r/1QTPLLO/java.lang.security.audit.weak-ssl-context.weak-ssl-context
         origin: community
   message: An insecure SSL context was detected. TLS versions 1.0, 1.1, and all SSL
     versions are considered weak encryption and are deprecated. Use SSLContext.getInstance("TLSv1.2")
@@ -9150,10 +9152,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9189
-        rv_id: 109744
+        rv_id: 833978
         rule_id: qNUj3y
-        version_id: o5Tglq2
-        url: https://semgrep.dev/playground/r/o5Tglq2/java.lang.security.audit.xml-decoder.xml-decoder
+        version_id: 9lTJ00e
+        url: https://semgrep.dev/playground/r/9lTJ00e/java.lang.security.audit.xml-decoder.xml-decoder
         origin: community
   severity: WARNING
   languages:
@@ -9205,10 +9207,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9212
-        rv_id: 109745
+        rv_id: 833979
         rule_id: 10UKqE
-        version_id: zyTK8oW
-        url: https://semgrep.dev/playground/r/zyTK8oW/java.lang.security.audit.xss.jsf.autoescape-disabled.autoescape-disabled
+        version_id: yeTN11B
+        url: https://semgrep.dev/playground/r/yeTN11B/java.lang.security.audit.xss.jsf.autoescape-disabled.autoescape-disabled
         origin: community
   pattern-regex: ".*escape.*?=.*?false.*"
   paths:
@@ -9247,10 +9249,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9190
-        rv_id: 109750
+        rv_id: 833984
         rule_id: lBU9Gj
-        version_id: 1QTOY6y
-        url: https://semgrep.dev/playground/r/1QTOY6y/java.lang.security.audit.xssrequestwrapper-is-insecure.xssrequestwrapper-is-insecure
+        version_id: w8TAxxl
+        url: https://semgrep.dev/playground/r/w8TAxxl/java.lang.security.audit.xssrequestwrapper-is-insecure.xssrequestwrapper-is-insecure
         origin: community
   message: It looks like you're using an implementation of XSSRequestWrapper from
     dzone. (https://www.javacodegeeks.com/2012/07/anti-cross-site-scripting-xss-filter.html)
@@ -9297,10 +9299,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9159
-        rv_id: 109757
+        rv_id: 833991
         rule_id: bwUw28
-        version_id: w8T9nX4
-        url: https://semgrep.dev/playground/r/w8T9nX4/java.lang.security.do-privileged-use.do-privileged-use
+        version_id: nWTy449
+        url: https://semgrep.dev/playground/r/nWTy449/java.lang.security.do-privileged-use.do-privileged-use
         origin: community
   message: Marking code as privileged enables a piece of trusted code to temporarily
     enable access to more resources than are available directly to the code that called
@@ -9389,10 +9391,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 56948
-        rv_id: 109760
+        rv_id: 833994
         rule_id: QrUD20
-        version_id: e1T01QP
-        url: https://semgrep.dev/playground/r/e1T01QP/java.lang.security.jackson-unsafe-deserialization.jackson-unsafe-deserialization
+        version_id: LjTEbbB
+        url: https://semgrep.dev/playground/r/LjTEbbB/java.lang.security.jackson-unsafe-deserialization.jackson-unsafe-deserialization
         origin: community
 - id: java.lang.security.use-snakeyaml-constructor.use-snakeyaml-constructor
   languages:
@@ -9423,10 +9425,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12683
-        rv_id: 109762
+        rv_id: 833996
         rule_id: 6JU67x
-        version_id: d6TrAX5
-        url: https://semgrep.dev/playground/r/d6TrAX5/java.lang.security.use-snakeyaml-constructor.use-snakeyaml-constructor
+        version_id: gETy225
+        url: https://semgrep.dev/playground/r/gETy225/java.lang.security.use-snakeyaml-constructor.use-snakeyaml-constructor
         origin: community
   message: Used SnakeYAML org.yaml.snakeyaml.Yaml() constructor with no arguments,
     which is vulnerable to deserialization attacks. Use the one-argument Yaml(...)
@@ -9472,10 +9474,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9163
-        rv_id: 745879
+        rv_id: 833997
         rule_id: x8Unkq
-        version_id: WrTN4En
-        url: https://semgrep.dev/playground/r/WrTN4En/java.lang.security.xmlinputfactory-external-entities-enabled.xmlinputfactory-external-entities-enabled
+        version_id: QkTkrrB
+        url: https://semgrep.dev/playground/r/QkTkrrB/java.lang.security.xmlinputfactory-external-entities-enabled.xmlinputfactory-external-entities-enabled
         origin: community
   message: XML external entities are enabled for this XMLInputFactory. This is vulnerable
     to XML external entity attacks. Disable external entities by setting "javax.xml.stream.isSupportingExternalEntities"
@@ -9522,10 +9524,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9216
-        rv_id: 109767
+        rv_id: 834000
         rule_id: bwUwj4
-        version_id: LjTqQZj
-        url: https://semgrep.dev/playground/r/LjTqQZj/java.rmi.security.server-dangerous-class-deserialization.server-dangerous-class-deserialization
+        version_id: PkTxrrw
+        url: https://semgrep.dev/playground/r/PkTxrrw/java.rmi.security.server-dangerous-class-deserialization.server-dangerous-class-deserialization
         origin: community
   message: Using a non-primitive class with Java RMI may be an insecure deserialization
     vulnerability. Depending on the underlying implementation. This object could be
@@ -9572,10 +9574,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9217
-        rv_id: 109768
+        rv_id: 834001
         rule_id: NbUkw5
-        version_id: 8KTQ9Rw
-        url: https://semgrep.dev/playground/r/8KTQ9Rw/java.rmi.security.server-dangerous-object-deserialization.server-dangerous-object-deserialization
+        version_id: JdTlrrA
+        url: https://semgrep.dev/playground/r/JdTlrrA/java.rmi.security.server-dangerous-object-deserialization.server-dangerous-object-deserialization
         origin: community
   message: Using an arbitrary object ('$PARAMTYPE $PARAM') with Java RMI is an insecure
     deserialization vulnerability. This object can be manipulated by a malicious actor
@@ -9658,10 +9660,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9218
-        rv_id: 230005
+        rv_id: 834002
         rule_id: kxUkn9
-        version_id: xyTvPr0
-        url: https://semgrep.dev/playground/r/xyTvPr0/java.servlets.security.cookie-issecure-false.cookie-issecure-false
+        version_id: 5PTyDD2
+        url: https://semgrep.dev/playground/r/5PTyDD2/java.servlets.security.cookie-issecure-false.cookie-issecure-false
         origin: community
   languages:
   - java
@@ -9694,10 +9696,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9220
-        rv_id: 109770
+        rv_id: 834004
         rule_id: x8Un7b
-        version_id: QkTW0Pr
-        url: https://semgrep.dev/playground/r/QkTW0Pr/java.spring.security.audit.spel-injection.spel-injection
+        version_id: RGTKGG8
+        url: https://semgrep.dev/playground/r/RGTKGG8/java.spring.security.audit.spel-injection.spel-injection
         origin: community
   severity: WARNING
   languages:
@@ -9812,10 +9814,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9221
-        rv_id: 109775
+        rv_id: 834009
         rule_id: OrU3gK
-        version_id: 5PTdAWX
-        url: https://semgrep.dev/playground/r/5PTdAWX/java.spring.security.audit.spring-csrf-disabled.spring-csrf-disabled
+        version_id: 0bTwbbP
+        url: https://semgrep.dev/playground/r/0bTwbbP/java.spring.security.audit.spring-csrf-disabled.spring-csrf-disabled
         origin: community
   severity: WARNING
   languages:
@@ -9853,10 +9855,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9942
-        rv_id: 109776
+        rv_id: 834010
         rule_id: PeUkkL
-        version_id: GxTv6NG
-        url: https://semgrep.dev/playground/r/GxTv6NG/java.spring.security.audit.spring-jsp-eval.spring-jsp-eval
+        version_id: K3Trqqq
+        url: https://semgrep.dev/playground/r/K3Trqqq/java.spring.security.audit.spring-jsp-eval.spring-jsp-eval
         origin: community
   paths:
     include:
@@ -9905,10 +9907,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9219
-        rv_id: 109785
+        rv_id: 834018
         rule_id: wdUJ7q
-        version_id: l4T4vEd
-        url: https://semgrep.dev/playground/r/l4T4vEd/java.spring.security.unrestricted-request-mapping.unrestricted-request-mapping
+        version_id: 2KT7xx0
+        url: https://semgrep.dev/playground/r/2KT7xx0/java.spring.security.unrestricted-request-mapping.unrestricted-request-mapping
         origin: community
   languages:
   - java
@@ -9939,10 +9941,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13578
-        rv_id: 109786
+        rv_id: 834019
         rule_id: PeUo5X
-        version_id: YDTp2LQ
-        url: https://semgrep.dev/playground/r/YDTp2LQ/javascript.ajv.security.audit.ajv-allerrors-true.ajv-allerrors-true
+        version_id: X0T5NNB
+        url: https://semgrep.dev/playground/r/X0T5NNB/javascript.ajv.security.audit.ajv-allerrors-true.ajv-allerrors-true
         origin: community
   languages:
   - javascript
@@ -9995,10 +9997,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9225
-        rv_id: 109789
+        rv_id: 834022
         rule_id: ZqU5Yn
-        version_id: GxTv61D
-        url: https://semgrep.dev/playground/r/GxTv61D/javascript.angular.security.detect-angular-open-redirect.detect-angular-open-redirect
+        version_id: 9lTJ07e
+        url: https://semgrep.dev/playground/r/9lTJ07e/javascript.angular.security.detect-angular-open-redirect.detect-angular-open-redirect
         origin: community
   languages:
   - javascript
@@ -10040,10 +10042,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9226
-        rv_id: 109790
+        rv_id: 834023
         rule_id: nJUzgX
-        version_id: RGTDky2
-        url: https://semgrep.dev/playground/r/RGTDky2/javascript.angular.security.detect-angular-resource-loading.detect-angular-resource-loading
+        version_id: yeTN1gB
+        url: https://semgrep.dev/playground/r/yeTN1gB/javascript.angular.security.detect-angular-resource-loading.detect-angular-resource-loading
         origin: community
   languages:
   - javascript
@@ -10087,10 +10089,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9228
-        rv_id: 109792
+        rv_id: 834025
         rule_id: 7KUQ4k
-        version_id: BjTXrRr
-        url: https://semgrep.dev/playground/r/BjTXrRr/javascript.angular.security.detect-angular-trust-as-css.detect-angular-trust-as-css-method
+        version_id: bZTBeoO
+        url: https://semgrep.dev/playground/r/bZTBeoO/javascript.angular.security.detect-angular-trust-as-css.detect-angular-trust-as-css-method
         origin: community
   languages:
   - javascript
@@ -10137,10 +10139,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9229
-        rv_id: 109793
+        rv_id: 834026
         rule_id: L1Uy88
-        version_id: DkT6nEY
-        url: https://semgrep.dev/playground/r/DkT6nEY/javascript.angular.security.detect-angular-trust-as-html-method.detect-angular-trust-as-html-method
+        version_id: NdTB2RY
+        url: https://semgrep.dev/playground/r/NdTB2RY/javascript.angular.security.detect-angular-trust-as-html-method.detect-angular-trust-as-html-method
         origin: community
   languages:
   - javascript
@@ -10187,10 +10189,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9230
-        rv_id: 109794
+        rv_id: 834027
         rule_id: 8GUj8k
-        version_id: WrTWQLq
-        url: https://semgrep.dev/playground/r/WrTWQLq/javascript.angular.security.detect-angular-trust-as-js-method.detect-angular-trust-as-js-method
+        version_id: kbT2lPw
+        url: https://semgrep.dev/playground/r/kbT2lPw/javascript.angular.security.detect-angular-trust-as-js-method.detect-angular-trust-as-js-method
         origin: community
   languages:
   - javascript
@@ -10237,10 +10239,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9232
-        rv_id: 109796
+        rv_id: 834029
         rule_id: QrUzeq
-        version_id: K3Tvjxg
-        url: https://semgrep.dev/playground/r/K3Tvjxg/javascript.angular.security.detect-angular-trust-as-resourceurl-method.detect-angular-trust-as-resourceurl-method
+        version_id: xyTNerN
+        url: https://semgrep.dev/playground/r/xyTNerN/javascript.angular.security.detect-angular-trust-as-resourceurl-method.detect-angular-trust-as-resourceurl-method
         origin: community
   languages:
   - javascript
@@ -10287,10 +10289,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9233
-        rv_id: 109797
+        rv_id: 834030
         rule_id: 3qUP01
-        version_id: qkT2xDL
-        url: https://semgrep.dev/playground/r/qkT2xDL/javascript.angular.security.detect-angular-trust-as-url-method.detect-angular-trust-as-url-method
+        version_id: O9TJW7v
+        url: https://semgrep.dev/playground/r/O9TJW7v/javascript.angular.security.detect-angular-trust-as-url-method.detect-angular-trust-as-url-method
         origin: community
   languages:
   - javascript
@@ -10338,10 +10340,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9235
-        rv_id: 109798
+        rv_id: 834031
         rule_id: PeUZPg
-        version_id: l4T4vE1
-        url: https://semgrep.dev/playground/r/l4T4vE1/javascript.angular.security.detect-third-party-angular-translate.detect-angular-translateprovider-translations-method
+        version_id: e1TDkK9
+        url: https://semgrep.dev/playground/r/e1TDkK9/javascript.angular.security.detect-third-party-angular-translate.detect-angular-translateprovider-translations-method
         origin: community
   languages:
   - javascript
@@ -10385,10 +10387,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13021
-        rv_id: 109799
+        rv_id: 834032
         rule_id: AbUGBR
-        version_id: YDTp2LO
-        url: https://semgrep.dev/playground/r/YDTp2LO/javascript.apollo.security.apollo-axios-ssrf.apollo-axios-ssrf
+        version_id: vdTOzQN
+        url: https://semgrep.dev/playground/r/vdTOzQN/javascript.apollo.security.apollo-axios-ssrf.apollo-axios-ssrf
         origin: community
   languages:
   - javascript
@@ -10442,10 +10444,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22550
-        rv_id: 109801
+        rv_id: 834034
         rule_id: kxUYE9
-        version_id: o5TglAW
-        url: https://semgrep.dev/playground/r/o5TglAW/javascript.audit.detect-replaceall-sanitization.detect-replaceall-sanitization
+        version_id: ZRTlPdK
+        url: https://semgrep.dev/playground/r/ZRTlPdK/javascript.audit.detect-replaceall-sanitization.detect-replaceall-sanitization
         origin: community
   languages:
   - javascript
@@ -10494,10 +10496,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9237
-        rv_id: 109814
+        rv_id: 834047
         rule_id: 5rUOg6
-        version_id: w8T9nYx
-        url: https://semgrep.dev/playground/r/w8T9nYx/javascript.browser.security.dom-based-xss.dom-based-xss
+        version_id: GxTDEXn
+        url: https://semgrep.dev/playground/r/GxTDEXn/javascript.browser.security.dom-based-xss.dom-based-xss
         origin: community
   languages:
   - javascript
@@ -10540,10 +10542,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9238
-        rv_id: 109815
+        rv_id: 834048
         rule_id: GdU7dw
-        version_id: xyTKZ6r
-        url: https://semgrep.dev/playground/r/xyTKZ6r/javascript.browser.security.eval-detected.eval-detected
+        version_id: RGTKGx8
+        url: https://semgrep.dev/playground/r/RGTKGx8/javascript.browser.security.eval-detected.eval-detected
         origin: community
   languages:
   - javascript
@@ -10582,10 +10584,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9239
-        rv_id: 109816
+        rv_id: 834049
         rule_id: ReUg41
-        version_id: O9TNO1x
-        url: https://semgrep.dev/playground/r/O9TNO1x/javascript.browser.security.insecure-document-method.insecure-document-method
+        version_id: A8T37l8
+        url: https://semgrep.dev/playground/r/A8T37l8/javascript.browser.security.insecure-document-method.insecure-document-method
         origin: community
   languages:
   - javascript
@@ -10630,10 +10632,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9241
-        rv_id: 109818
+        rv_id: 834051
         rule_id: BYUN0X
-        version_id: vdTYNlP
-        url: https://semgrep.dev/playground/r/vdTYNlP/javascript.browser.security.insufficient-postmessage-origin-validation.insufficient-postmessage-origin-validation
+        version_id: DkTG0yE
+        url: https://semgrep.dev/playground/r/DkTG0yE/javascript.browser.security.insufficient-postmessage-origin-validation.insufficient-postmessage-origin-validation
         origin: community
   languages:
   - javascript
@@ -10696,10 +10698,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9245
-        rv_id: 109824
+        rv_id: 834056
         rule_id: KxUbq4
-        version_id: LjTqQvN
-        url: https://semgrep.dev/playground/r/LjTqQvN/javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+        version_id: l4TyODR
+        url: https://semgrep.dev/playground/r/l4TyODR/javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
         origin: community
   languages:
   - javascript
@@ -10739,10 +10741,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22551
-        rv_id: 109832
+        rv_id: 834059
         rule_id: wdUKEq
-        version_id: 5PTdAbp
-        url: https://semgrep.dev/playground/r/5PTdAbp/javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage
+        version_id: 5PTyDGX
+        url: https://semgrep.dev/playground/r/5PTyDGX/javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage
         origin: community
   languages:
   - javascript
@@ -10794,10 +10796,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22553
-        rv_id: 109840
+        rv_id: 834067
         rule_id: OrUX9K
-        version_id: K3Tvj1g
-        url: https://semgrep.dev/playground/r/K3Tvj1g/javascript.express.security.audit.express-detect-notevil-usage.express-detect-notevil-usage
+        version_id: K3Trqkz
+        url: https://semgrep.dev/playground/r/K3Trqkz/javascript.express.security.audit.express-detect-notevil-usage.express-detect-notevil-usage
         origin: community
   languages:
   - javascript
@@ -10860,10 +10862,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22080
-        rv_id: 109843
+        rv_id: 834070
         rule_id: 2ZUY52
-        version_id: YDTp2dO
-        url: https://semgrep.dev/playground/r/YDTp2dO/javascript.express.security.audit.express-libxml-vm-noent.express-libxml-vm-noent
+        version_id: YDTl0eQ
+        url: https://semgrep.dev/playground/r/YDTl0eQ/javascript.express.security.audit.express-libxml-vm-noent.express-libxml-vm-noent
         origin: community
   languages:
   - javascript
@@ -10924,10 +10926,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9275
-        rv_id: 109851
+        rv_id: 834078
         rule_id: gxU12X
-        version_id: 1QTOY1R
-        url: https://semgrep.dev/playground/r/1QTOY1R/javascript.express.security.audit.possible-user-input-redirect.unknown-value-in-redirect
+        version_id: 1QTPLpy
+        url: https://semgrep.dev/playground/r/1QTPLpy/javascript.express.security.audit.possible-user-input-redirect.unknown-value-in-redirect
         origin: community
   languages:
   - javascript
@@ -10977,10 +10979,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9278
-        rv_id: 109855
+        rv_id: 834082
         rule_id: 4bUkPO
-        version_id: bZTb12y
-        url: https://semgrep.dev/playground/r/bZTb12y/javascript.express.security.audit.xss.ejs.explicit-unescape.template-explicit-unescape
+        version_id: bZTBe3l
+        url: https://semgrep.dev/playground/r/bZTBe3l/javascript.express.security.audit.xss.ejs.explicit-unescape.template-explicit-unescape
         origin: community
   languages:
   - regex
@@ -11027,10 +11029,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9279
-        rv_id: 109856
+        rv_id: 834083
         rule_id: PeUZrg
-        version_id: NdT3d77
-        url: https://semgrep.dev/playground/r/NdT3d77/javascript.express.security.audit.xss.ejs.var-in-href.var-in-href
+        version_id: NdTB2yr
+        url: https://semgrep.dev/playground/r/NdTB2yr/javascript.express.security.audit.xss.ejs.var-in-href.var-in-href
         origin: community
   languages:
   - regex
@@ -11075,10 +11077,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9280
-        rv_id: 109857
+        rv_id: 834084
         rule_id: JDUyrJ
-        version_id: kbTdx1n
-        url: https://semgrep.dev/playground/r/kbTdx1n/javascript.express.security.audit.xss.ejs.var-in-script-src.var-in-script-src
+        version_id: kbT2lGZ
+        url: https://semgrep.dev/playground/r/kbT2lGZ/javascript.express.security.audit.xss.ejs.var-in-script-src.var-in-script-src
         origin: community
   languages:
   - generic
@@ -11127,10 +11129,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9281
-        rv_id: 109858
+        rv_id: 834085
         rule_id: 5rUOD6
-        version_id: w8T9nOx
-        url: https://semgrep.dev/playground/r/w8T9nOx/javascript.express.security.audit.xss.ejs.var-in-script-tag.var-in-script-tag
+        version_id: w8TAxo4
+        url: https://semgrep.dev/playground/r/w8TAxo4/javascript.express.security.audit.xss.ejs.var-in-script-tag.var-in-script-tag
         origin: community
   languages:
   - generic
@@ -11176,10 +11178,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9282
-        rv_id: 109859
+        rv_id: 834086
         rule_id: GdU7Ew
-        version_id: xyTKZkr
-        url: https://semgrep.dev/playground/r/xyTKZkr/javascript.express.security.audit.xss.mustache.escape-function-overwrite.escape-function-overwrite
+        version_id: xyTNez1
+        url: https://semgrep.dev/playground/r/xyTNez1/javascript.express.security.audit.xss.mustache.escape-function-overwrite.escape-function-overwrite
         origin: community
   languages:
   - javascript
@@ -11225,10 +11227,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9283
-        rv_id: 109860
+        rv_id: 834087
         rule_id: ReUgG1
-        version_id: O9TNO5x
-        url: https://semgrep.dev/playground/r/O9TNO5x/javascript.express.security.audit.xss.mustache.explicit-unescape.template-explicit-unescape
+        version_id: O9TJWxA
+        url: https://semgrep.dev/playground/r/O9TJWxA/javascript.express.security.audit.xss.mustache.explicit-unescape.template-explicit-unescape
         origin: community
   languages:
   - regex
@@ -11272,10 +11274,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9286
-        rv_id: 109863
+        rv_id: 834090
         rule_id: DbUpyq
-        version_id: d6TrAJk
-        url: https://semgrep.dev/playground/r/d6TrAJk/javascript.express.security.audit.xss.pug.and-attributes.template-and-attributes
+        version_id: d6TKGx5
+        url: https://semgrep.dev/playground/r/d6TKGx5/javascript.express.security.audit.xss.pug.and-attributes.template-and-attributes
         origin: community
   languages:
   - regex
@@ -11317,10 +11319,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9287
-        rv_id: 109864
+        rv_id: 834091
         rule_id: WAUonl
-        version_id: ZRTQNoL
-        url: https://semgrep.dev/playground/r/ZRTQNoL/javascript.express.security.audit.xss.pug.explicit-unescape.template-explicit-unescape
+        version_id: ZRTlPA9
+        url: https://semgrep.dev/playground/r/ZRTlPA9/javascript.express.security.audit.xss.pug.explicit-unescape.template-explicit-unescape
         origin: community
   languages:
   - regex
@@ -11365,10 +11367,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9288
-        rv_id: 109865
+        rv_id: 834092
         rule_id: 0oU535
-        version_id: nWTxPv7
-        url: https://semgrep.dev/playground/r/nWTxPv7/javascript.express.security.audit.xss.pug.var-in-href.var-in-href
+        version_id: nWTy4LE
+        url: https://semgrep.dev/playground/r/nWTy4LE/javascript.express.security.audit.xss.pug.var-in-href.var-in-href
         origin: community
   languages:
   - regex
@@ -11411,10 +11413,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9289
-        rv_id: 109866
+        rv_id: 834093
         rule_id: KxUbL4
-        version_id: ExTjNzk
-        url: https://semgrep.dev/playground/r/ExTjNzk/javascript.express.security.audit.xss.pug.var-in-script-tag.var-in-script-tag
+        version_id: ExTrDxO
+        url: https://semgrep.dev/playground/r/ExTrDxO/javascript.express.security.audit.xss.pug.var-in-script-tag.var-in-script-tag
         origin: community
   languages:
   - regex
@@ -11458,10 +11460,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12818
-        rv_id: 109868
+        rv_id: 834095
         rule_id: ReUo60
-        version_id: LjTqQ8N
-        url: https://semgrep.dev/playground/r/LjTqQ8N/javascript.express.security.express-data-exfiltration.express-data-exfiltration
+        version_id: LjTEbgj
+        url: https://semgrep.dev/playground/r/LjTEbgj/javascript.express.security.express-data-exfiltration.express-data-exfiltration
         origin: community
   languages:
   - javascript
@@ -11536,10 +11538,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9252
-        rv_id: 109871
+        rv_id: 834098
         rule_id: pKUOjy
-        version_id: QkTW0e7
-        url: https://semgrep.dev/playground/r/QkTW0e7/javascript.express.security.express-jwt-hardcoded-secret.express-jwt-hardcoded-secret
+        version_id: QkTkrqr
+        url: https://semgrep.dev/playground/r/QkTkrqr/javascript.express.security.express-jwt-hardcoded-secret.express-jwt-hardcoded-secret
         origin: community
   languages:
   - javascript
@@ -11598,10 +11600,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9290
-        rv_id: 109884
+        rv_id: 834111
         rule_id: qNUjwb
-        version_id: K3TvjWg
-        url: https://semgrep.dev/playground/r/K3TvjWg/javascript.fbjs.security.audit.insecure-createnodesfrommarkup.insecure-createnodesfrommarkup
+        version_id: K3TrqXz
+        url: https://semgrep.dev/playground/r/K3TrqXz/javascript.fbjs.security.audit.insecure-createnodesfrommarkup.insecure-createnodesfrommarkup
         origin: community
   languages:
   - javascript
@@ -11643,10 +11645,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9291
-        rv_id: 109885
+        rv_id: 834112
         rule_id: lBU9D8
-        version_id: qkT2x8L
-        url: https://semgrep.dev/playground/r/qkT2x8L/javascript.grpc.security.grpc-nodejs-insecure-connection.grpc-nodejs-insecure-connection
+        version_id: qkTQnyj
+        url: https://semgrep.dev/playground/r/qkTQnyj/javascript.grpc.security.grpc-nodejs-insecure-connection.grpc-nodejs-insecure-connection
         origin: community
   languages:
   - javascript
@@ -11733,10 +11735,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60237
-        rv_id: 828673
+        rv_id: 834113
         rule_id: QrU96W
-        version_id: NdTB735
-        url: https://semgrep.dev/playground/r/NdTB735/javascript.intercom.security.audit.intercom-settings-user-identifier-without-user-hash.intercom-settings-user-identifier-without-user-hash
+        version_id: l4TyO0d
+        url: https://semgrep.dev/playground/r/l4TyO0d/javascript.intercom.security.audit.intercom-settings-user-identifier-without-user-hash.intercom-settings-user-identifier-without-user-hash
         origin: community
 - id: javascript.jose.security.audit.jose-exposed-data.jose-exposed-data
   message: The object is passed strictly to jose.JWT.sign(...) Make sure that sensitive
@@ -11773,10 +11775,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9295
-        rv_id: 109887
+        rv_id: 834114
         rule_id: GdU7XP
-        version_id: YDTp29O
-        url: https://semgrep.dev/playground/r/YDTp29O/javascript.jose.security.audit.jose-exposed-data.jose-exposed-data
+        version_id: YDTl07Q
+        url: https://semgrep.dev/playground/r/YDTl07Q/javascript.jose.security.audit.jose-exposed-data.jose-exposed-data
         origin: community
   languages:
   - javascript
@@ -11831,10 +11833,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9302
-        rv_id: 109894
+        rv_id: 834120
         rule_id: KxUbL3
-        version_id: DkT6nrZ
-        url: https://semgrep.dev/playground/r/DkT6nrZ/javascript.jsonwebtoken.security.audit.jwt-decode-without-verify.jwt-decode-without-verify
+        version_id: X0T5Nqx
+        url: https://semgrep.dev/playground/r/X0T5Nqx/javascript.jsonwebtoken.security.audit.jwt-decode-without-verify.jwt-decode-without-verify
         origin: community
   languages:
   - javascript
@@ -11887,10 +11889,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9303
-        rv_id: 109895
+        rv_id: 834121
         rule_id: qNUjwe
-        version_id: WrTWQ4X
-        url: https://semgrep.dev/playground/r/WrTWQ4X/javascript.jsonwebtoken.security.audit.jwt-exposed-data.jwt-exposed-data
+        version_id: jQTrX2y
+        url: https://semgrep.dev/playground/r/jQTrX2y/javascript.jsonwebtoken.security.audit.jwt-exposed-data.jwt-exposed-data
         origin: community
   languages:
   - javascript
@@ -11938,10 +11940,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22555
-        rv_id: 109918
+        rv_id: 834143
         rule_id: v8UGEw
-        version_id: e1T01kp
-        url: https://semgrep.dev/playground/r/e1T01kp/javascript.lang.security.audit.hardcoded-hmac-key.hardcoded-hmac-key
+        version_id: 3ZT3A1w
+        url: https://semgrep.dev/playground/r/3ZT3A1w/javascript.lang.security.audit.hardcoded-hmac-key.hardcoded-hmac-key
         origin: community
   languages:
   - javascript
@@ -11982,10 +11984,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13466
-        rv_id: 109919
+        rv_id: 834144
         rule_id: d8UlRq
-        version_id: vdTYNz9
-        url: https://semgrep.dev/playground/r/vdTYNz9/javascript.lang.security.audit.incomplete-sanitization.incomplete-sanitization
+        version_id: 44TQPdj
+        url: https://semgrep.dev/playground/r/44TQPdj/javascript.lang.security.audit.incomplete-sanitization.incomplete-sanitization
         origin: community
   languages:
   - javascript
@@ -12029,10 +12031,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13373
-        rv_id: 109925
+        rv_id: 834148
         rule_id: QrUpbJ
-        version_id: LjTqQbA
-        url: https://semgrep.dev/playground/r/LjTqQbA/javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop
+        version_id: GxTDERG
+        url: https://semgrep.dev/playground/r/GxTDERG/javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop
         origin: community
   languages:
   - typescript
@@ -12102,10 +12104,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9853
-        rv_id: 109926
+        rv_id: 834149
         rule_id: lBUdr5
-        version_id: 8KTQ9k5
-        url: https://semgrep.dev/playground/r/8KTQ9k5/javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
+        version_id: RGTKGlb
+        url: https://semgrep.dev/playground/r/RGTKGlb/javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
         origin: community
   languages:
   - javascript
@@ -12161,10 +12163,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9322
-        rv_id: 109931
+        rv_id: 834154
         rule_id: OrU37Y
-        version_id: PkTJ1rO
-        url: https://semgrep.dev/playground/r/PkTJ1rO/javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
+        version_id: 0bTwbdy
+        url: https://semgrep.dev/playground/r/0bTwbdy/javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
         origin: community
   languages:
   - javascript
@@ -12205,10 +12207,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9312
-        rv_id: 109943
+        rv_id: 834157
         rule_id: j2Uvj8
-        version_id: l4T4vOE
-        url: https://semgrep.dev/playground/r/l4T4vOE/javascript.lang.security.detect-buffer-noassert.detect-buffer-noassert
+        version_id: l4TyOjd
+        url: https://semgrep.dev/playground/r/l4TyOjd/javascript.lang.security.detect-buffer-noassert.detect-buffer-noassert
         origin: community
   languages:
   - javascript
@@ -12252,10 +12254,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9313
-        rv_id: 109944
+        rv_id: 834158
         rule_id: 10UKNB
-        version_id: YDTp20d
-        url: https://semgrep.dev/playground/r/YDTp20d/javascript.lang.security.detect-child-process.detect-child-process
+        version_id: YDTl0yQ
+        url: https://semgrep.dev/playground/r/YDTl0yQ/javascript.lang.security.detect-child-process.detect-child-process
         origin: community
   languages:
   - javascript
@@ -12337,10 +12339,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9314
-        rv_id: 109945
+        rv_id: 834159
         rule_id: 9AU17r
-        version_id: 6xTvJgP
-        url: https://semgrep.dev/playground/r/6xTvJgP/javascript.lang.security.detect-disable-mustache-escape.detect-disable-mustache-escape
+        version_id: JdTlrWL
+        url: https://semgrep.dev/playground/r/JdTlrWL/javascript.lang.security.detect-disable-mustache-escape.detect-disable-mustache-escape
         origin: community
   languages:
   - javascript
@@ -12379,10 +12381,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10048
-        rv_id: 109947
+        rv_id: 834161
         rule_id: AbUWeE
-        version_id: zyTK8J3
-        url: https://semgrep.dev/playground/r/zyTK8J3/javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
+        version_id: GxTDEAD
+        url: https://semgrep.dev/playground/r/GxTDEAD/javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
         origin: community
   languages:
   - regex
@@ -12422,10 +12424,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9316
-        rv_id: 109948
+        rv_id: 834162
         rule_id: r6UrvQ
-        version_id: pZT1yj3
-        url: https://semgrep.dev/playground/r/pZT1yj3/javascript.lang.security.detect-no-csrf-before-method-override.detect-no-csrf-before-method-override
+        version_id: RGTKGz2
+        url: https://semgrep.dev/playground/r/RGTKGz2/javascript.lang.security.detect-no-csrf-before-method-override.detect-no-csrf-before-method-override
         origin: community
   languages:
   - javascript
@@ -12467,10 +12469,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9318
-        rv_id: 109950
+        rv_id: 834163
         rule_id: NbUkR2
-        version_id: X0TQxN9
-        url: https://semgrep.dev/playground/r/X0TQxN9/javascript.lang.security.detect-pseudorandombytes.detect-pseudoRandomBytes
+        version_id: A8T374J
+        url: https://semgrep.dev/playground/r/A8T374J/javascript.lang.security.detect-pseudorandombytes.detect-pseudoRandomBytes
         origin: community
   languages:
   - javascript
@@ -12509,10 +12511,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9319
-        rv_id: 109953
+        rv_id: 834166
         rule_id: kxUkPP
-        version_id: 9lTdW0z
-        url: https://semgrep.dev/playground/r/9lTdW0z/javascript.lang.security.spawn-git-clone.spawn-git-clone
+        version_id: WrTdp1q
+        url: https://semgrep.dev/playground/r/WrTdp1q/javascript.lang.security.spawn-git-clone.spawn-git-clone
         origin: community
   languages:
   - javascript
@@ -12560,10 +12562,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14402
-        rv_id: 109954
+        rv_id: 834167
         rule_id: zdUYQb
-        version_id: yeTR21L
-        url: https://semgrep.dev/playground/r/yeTR21L/javascript.monaco-editor.security.audit.monaco-hover-htmlsupport.monaco-hover-htmlsupport
+        version_id: 0bTwbdo
+        url: https://semgrep.dev/playground/r/0bTwbdo/javascript.monaco-editor.security.audit.monaco-hover-htmlsupport.monaco-hover-htmlsupport
         origin: community
   languages:
   - typescript
@@ -12613,10 +12615,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9332
-        rv_id: 109955
+        rv_id: 834168
         rule_id: gxU171
-        version_id: rxTyLzP
-        url: https://semgrep.dev/playground/r/rxTyLzP/javascript.node-expat.security.audit.expat-xxe.expat-xxe
+        version_id: K3Trq0g
+        url: https://semgrep.dev/playground/r/K3Trq0g/javascript.node-expat.security.audit.expat-xxe.expat-xxe
         origin: community
   languages:
   - javascript
@@ -12708,10 +12710,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9334
-        rv_id: 109957
+        rv_id: 834170
         rule_id: 3qUPXE
-        version_id: NdT3dR3
-        url: https://semgrep.dev/playground/r/NdT3dR3/javascript.phantom.security.audit.phantom-injection.phantom-injection
+        version_id: l4TyOj1
+        url: https://semgrep.dev/playground/r/l4TyOj1/javascript.phantom.security.audit.phantom-injection.phantom-injection
         origin: community
   languages:
   - javascript
@@ -12760,10 +12762,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9335
-        rv_id: 109958
+        rv_id: 834171
         rule_id: 4bUkj1
-        version_id: kbTdxPg
-        url: https://semgrep.dev/playground/r/kbTdxPg/javascript.playwright.security.audit.playwright-addinitscript-code-injection.playwright-addinitscript-code-injection
+        version_id: YDTl0yO
+        url: https://semgrep.dev/playground/r/YDTl0yO/javascript.playwright.security.audit.playwright-addinitscript-code-injection.playwright-addinitscript-code-injection
         origin: community
   languages:
   - javascript
@@ -12807,10 +12809,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9336
-        rv_id: 109959
+        rv_id: 834172
         rule_id: PeUZ30
-        version_id: w8T9nbz
-        url: https://semgrep.dev/playground/r/w8T9nbz/javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection
+        version_id: 6xTDgY0
+        url: https://semgrep.dev/playground/r/6xTDgY0/javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection
         origin: community
   languages:
   - javascript
@@ -12854,10 +12856,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9337
-        rv_id: 109960
+        rv_id: 834173
         rule_id: JDUyxl
-        version_id: xyTKZrn
-        url: https://semgrep.dev/playground/r/xyTKZrn/javascript.playwright.security.audit.playwright-evaluate-code-injection.playwright-evaluate-code-injection
+        version_id: o5TBENW
+        url: https://semgrep.dev/playground/r/o5TBENW/javascript.playwright.security.audit.playwright-evaluate-code-injection.playwright-evaluate-code-injection
         origin: community
   languages:
   - javascript
@@ -12907,10 +12909,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9338
-        rv_id: 109961
+        rv_id: 834174
         rule_id: 5rUO1N
-        version_id: O9TNO7G
-        url: https://semgrep.dev/playground/r/O9TNO7G/javascript.playwright.security.audit.playwright-exposed-chrome-devtools.playwright-exposed-chrome-devtools
+        version_id: zyTWJ49
+        url: https://semgrep.dev/playground/r/zyTWJ49/javascript.playwright.security.audit.playwright-exposed-chrome-devtools.playwright-exposed-chrome-devtools
         origin: community
   languages:
   - javascript
@@ -12953,10 +12955,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9339
-        rv_id: 109962
+        rv_id: 834175
         rule_id: GdU7eP
-        version_id: e1T01Kp
-        url: https://semgrep.dev/playground/r/e1T01Kp/javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection
+        version_id: pZTXjWR
+        url: https://semgrep.dev/playground/r/pZTXjWR/javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection
         origin: community
   languages:
   - javascript
@@ -13002,10 +13004,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9340
-        rv_id: 109963
+        rv_id: 834176
         rule_id: ReUgLk
-        version_id: vdTYNQ9
-        url: https://semgrep.dev/playground/r/vdTYNQ9/javascript.playwright.security.audit.playwright-setcontent-injection.playwright-setcontent-injection
+        version_id: 2KT7xqN
+        url: https://semgrep.dev/playground/r/2KT7xqN/javascript.playwright.security.audit.playwright-setcontent-injection.playwright-setcontent-injection
         origin: community
   languages:
   - javascript
@@ -13051,10 +13053,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9341
-        rv_id: 109964
+        rv_id: 834177
         rule_id: AbUzdX
-        version_id: d6TrAg4
-        url: https://semgrep.dev/playground/r/d6TrAg4/javascript.puppeteer.security.audit.puppeteer-evaluate-arg-injection.puppeteer-evaluate-arg-injection
+        version_id: X0T5N9X
+        url: https://semgrep.dev/playground/r/X0T5N9X/javascript.puppeteer.security.audit.puppeteer-evaluate-arg-injection.puppeteer-evaluate-arg-injection
         origin: community
   languages:
   - javascript
@@ -13099,10 +13101,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9342
-        rv_id: 109965
+        rv_id: 834178
         rule_id: BYUNZk
-        version_id: ZRTQNdl
-        url: https://semgrep.dev/playground/r/ZRTQNdl/javascript.puppeteer.security.audit.puppeteer-evaluate-code-injection.puppeteer-evaluate-code-injection
+        version_id: jQTrXx0
+        url: https://semgrep.dev/playground/r/jQTrXx0/javascript.puppeteer.security.audit.puppeteer-evaluate-code-injection.puppeteer-evaluate-code-injection
         origin: community
   languages:
   - javascript
@@ -13152,10 +13154,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9343
-        rv_id: 109966
+        rv_id: 834179
         rule_id: DbUpbk
-        version_id: nWTxPNn
-        url: https://semgrep.dev/playground/r/nWTxPNn/javascript.puppeteer.security.audit.puppeteer-exposed-chrome-devtools.puppeteer-exposed-chrome-devtools
+        version_id: 1QTPLlR
+        url: https://semgrep.dev/playground/r/1QTPLlR/javascript.puppeteer.security.audit.puppeteer-exposed-chrome-devtools.puppeteer-exposed-chrome-devtools
         origin: community
   languages:
   - javascript
@@ -13198,10 +13200,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9344
-        rv_id: 109967
+        rv_id: 834180
         rule_id: WAUoK7
-        version_id: ExTjNWg
-        url: https://semgrep.dev/playground/r/ExTjNWg/javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection
+        version_id: 9lTJ0Bv
+        url: https://semgrep.dev/playground/r/9lTJ0Bv/javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection
         origin: community
   languages:
   - javascript
@@ -13247,10 +13249,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9345
-        rv_id: 109968
+        rv_id: 834181
         rule_id: 0oU5zg
-        version_id: 7ZTgoRo
-        url: https://semgrep.dev/playground/r/7ZTgoRo/javascript.puppeteer.security.audit.puppeteer-setcontent-injection.puppeteer-setcontent-injection
+        version_id: yeTN1j8
+        url: https://semgrep.dev/playground/r/yeTN1j8/javascript.puppeteer.security.audit.puppeteer-setcontent-injection.puppeteer-setcontent-injection
         origin: community
   languages:
   - javascript
@@ -13293,10 +13295,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9346
-        rv_id: 109970
+        rv_id: 834183
         rule_id: KxUbk3
-        version_id: 8KTQ9l5
-        url: https://semgrep.dev/playground/r/8KTQ9l5/javascript.sandbox.security.audit.sandbox-code-injection.sandbox-code-injection
+        version_id: bZTBevy
+        url: https://semgrep.dev/playground/r/bZTBevy/javascript.sandbox.security.audit.sandbox-code-injection.sandbox-code-injection
         origin: community
   languages:
   - javascript
@@ -13356,10 +13358,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9347
-        rv_id: 109971
+        rv_id: 834184
         rule_id: qNUj7e
-        version_id: gET3xXP
-        url: https://semgrep.dev/playground/r/gET3xXP/javascript.sax.security.audit.sax-xxe.sax-xxe
+        version_id: NdTB2l7
+        url: https://semgrep.dev/playground/r/NdTB2l7/javascript.sax.security.audit.sax-xxe.sax-xxe
         origin: community
   languages:
   - javascript
@@ -13406,10 +13408,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9968
-        rv_id: 109972
+        rv_id: 834185
         rule_id: NbUAYW
-        version_id: QkTW0NE
-        url: https://semgrep.dev/playground/r/QkTW0NE/javascript.sequelize.security.audit.sequelize-enforce-tls.sequelize-enforce-tls
+        version_id: kbT2lXn
+        url: https://semgrep.dev/playground/r/kbT2lXn/javascript.sequelize.security.audit.sequelize-enforce-tls.sequelize-enforce-tls
         origin: community
   languages:
   - javascript
@@ -13478,10 +13480,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9969
-        rv_id: 109975
+        rv_id: 834188
         rule_id: kxUR80
-        version_id: PkTJ1GO
-        url: https://semgrep.dev/playground/r/PkTJ1GO/javascript.sequelize.security.audit.sequelize-tls-disabled-cert-validation.sequelize-tls-disabled-cert-validation
+        version_id: O9TJWYx
+        url: https://semgrep.dev/playground/r/O9TJWYx/javascript.sequelize.security.audit.sequelize-tls-disabled-cert-validation.sequelize-tls-disabled-cert-validation
         origin: community
   languages:
   - javascript
@@ -13536,10 +13538,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9970
-        rv_id: 109976
+        rv_id: 834189
         rule_id: wdU8GB
-        version_id: JdTNpRZ
-        url: https://semgrep.dev/playground/r/JdTNpRZ/javascript.sequelize.security.audit.sequelize-weak-tls-version.sequelize-weak-tls-version
+        version_id: e1TDknO
+        url: https://semgrep.dev/playground/r/e1TDknO/javascript.sequelize.security.audit.sequelize-weak-tls-version.sequelize-weak-tls-version
         origin: community
   languages:
   - javascript
@@ -13593,10 +13595,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9349
-        rv_id: 109977
+        rv_id: 834190
         rule_id: YGURez
-        version_id: 5PTdAGB
-        url: https://semgrep.dev/playground/r/5PTdAGB/javascript.serialize-javascript.security.audit.unsafe-serialize-javascript.unsafe-serialize-javascript
+        version_id: vdTOzPP
+        url: https://semgrep.dev/playground/r/vdTOzPP/javascript.serialize-javascript.security.audit.unsafe-serialize-javascript.unsafe-serialize-javascript
         origin: community
   languages:
   - javascript
@@ -13639,10 +13641,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9350
-        rv_id: 109978
+        rv_id: 834191
         rule_id: 6JUj9k
-        version_id: GxTv6Xg
-        url: https://semgrep.dev/playground/r/GxTv6Xg/javascript.shelljs.security.shelljs-exec-injection.shelljs-exec-injection
+        version_id: d6TKGZk
+        url: https://semgrep.dev/playground/r/d6TKGZk/javascript.shelljs.security.shelljs-exec-injection.shelljs-exec-injection
         origin: community
   languages:
   - javascript
@@ -13685,10 +13687,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9351
-        rv_id: 109979
+        rv_id: 834192
         rule_id: oqUeDG
-        version_id: RGTDkxN
-        url: https://semgrep.dev/playground/r/RGTDkxN/javascript.thenify.security.audit.multiargs-code-execution.multiargs-code-execution
+        version_id: ZRTlPrL
+        url: https://semgrep.dev/playground/r/ZRTlPrL/javascript.thenify.security.audit.multiargs-code-execution.multiargs-code-execution
         origin: community
   languages:
   - javascript
@@ -13739,10 +13741,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9352
-        rv_id: 109980
+        rv_id: 834193
         rule_id: zdUk2g
-        version_id: A8T95lP
-        url: https://semgrep.dev/playground/r/A8T95lP/javascript.vm2.security.audit.vm2-code-injection.vm2-code-injection
+        version_id: nWTy4K7
+        url: https://semgrep.dev/playground/r/nWTy4K7/javascript.vm2.security.audit.vm2-code-injection.vm2-code-injection
         origin: community
   languages:
   - javascript
@@ -13819,10 +13821,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9353
-        rv_id: 109981
+        rv_id: 834194
         rule_id: pKUO3v
-        version_id: BjTXrLO
-        url: https://semgrep.dev/playground/r/BjTXrLO/javascript.vm2.security.audit.vm2-context-injection.vm2-context-injection
+        version_id: ExTrDGk
+        url: https://semgrep.dev/playground/r/ExTrDGk/javascript.vm2.security.audit.vm2-context-injection.vm2-context-injection
         origin: community
   languages:
   - javascript
@@ -14184,10 +14186,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9354
-        rv_id: 109982
+        rv_id: 834195
         rule_id: 2ZUb2o
-        version_id: DkT6nyZ
-        url: https://semgrep.dev/playground/r/DkT6nyZ/javascript.vue.security.audit.xss.templates.avoid-v-html.avoid-v-html
+        version_id: 7ZTx9AN
+        url: https://semgrep.dev/playground/r/7ZTx9AN/javascript.vue.security.audit.xss.templates.avoid-v-html.avoid-v-html
         origin: community
   languages:
   - regex
@@ -14224,10 +14226,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9355
-        rv_id: 109983
+        rv_id: 834196
         rule_id: X5U8yj
-        version_id: WrTWQnX
-        url: https://semgrep.dev/playground/r/WrTWQnX/javascript.wkhtmltoimage.security.audit.wkhtmltoimage-injection.wkhtmltoimage-injection
+        version_id: LjTEbwN
+        url: https://semgrep.dev/playground/r/LjTEbwN/javascript.wkhtmltoimage.security.audit.wkhtmltoimage-injection.wkhtmltoimage-injection
         origin: community
   languages:
   - javascript
@@ -14270,10 +14272,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9356
-        rv_id: 109984
+        rv_id: 834197
         rule_id: j2Uv58
-        version_id: 0bTLl3D
-        url: https://semgrep.dev/playground/r/0bTLl3D/javascript.wkhtmltopdf.security.audit.wkhtmltopdf-injection.wkhtmltopdf-injection
+        version_id: 8KTGkpQ
+        url: https://semgrep.dev/playground/r/8KTGkpQ/javascript.wkhtmltopdf.security.audit.wkhtmltopdf-injection.wkhtmltopdf-injection
         origin: community
   languages:
   - javascript
@@ -14322,10 +14324,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9357
-        rv_id: 109985
+        rv_id: 834198
         rule_id: 10UKpB
-        version_id: K3TvjLe
-        url: https://semgrep.dev/playground/r/K3TvjLe/javascript.xml2json.security.audit.xml2json-xxe.xml2json-xxe
+        version_id: gETy2w6
+        url: https://semgrep.dev/playground/r/gETy2w6/javascript.xml2json.security.audit.xml2json-xxe.xml2json-xxe
         origin: community
   languages:
   - javascript
@@ -14370,10 +14372,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15126
-        rv_id: 109991
+        rv_id: 834205
         rule_id: d8UegG
-        version_id: GxTv6XX
-        url: https://semgrep.dev/playground/r/GxTv6XX/kotlin.lang.security.bad-hexa-conversion.bad-hexa-conversion
+        version_id: GxTDEQD
+        url: https://semgrep.dev/playground/r/GxTDEQD/kotlin.lang.security.bad-hexa-conversion.bad-hexa-conversion
         origin: community
   message: '''Integer.toHexString()'' strips leading zeroes from each byte if read
     byte-by-byte. This mistake weakens the hash value computed since it introduces
@@ -14423,10 +14425,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9359
-        rv_id: 109992
+        rv_id: 834206
         rule_id: yyUnpo
-        version_id: RGTDkxL
-        url: https://semgrep.dev/playground/r/RGTDkxL/kotlin.lang.security.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
+        version_id: RGTKG52
+        url: https://semgrep.dev/playground/r/RGTKG52/kotlin.lang.security.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call
         origin: community
   severity: ERROR
   languages:
@@ -14461,10 +14463,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9360
-        rv_id: 109993
+        rv_id: 834207
         rule_id: r6UrKQ
-        version_id: A8T95l2
-        url: https://semgrep.dev/playground/r/A8T95l2/kotlin.lang.security.cookie-missing-httponly.cookie-missing-httponly
+        version_id: A8T37AJ
+        url: https://semgrep.dev/playground/r/A8T37AJ/kotlin.lang.security.cookie-missing-httponly.cookie-missing-httponly
         origin: community
   message: A cookie was detected without setting the 'HttpOnly' flag. The 'HttpOnly'
     flag for cookies instructs the browser to forbid client-side scripts from reading
@@ -14508,10 +14510,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9361
-        rv_id: 109994
+        rv_id: 834208
         rule_id: bwUw3j
-        version_id: BjTXrLP
-        url: https://semgrep.dev/playground/r/BjTXrLP/kotlin.lang.security.cookie-missing-secure-flag.cookie-missing-secure-flag
+        version_id: BjTe0wr
+        url: https://semgrep.dev/playground/r/BjTe0wr/kotlin.lang.security.cookie-missing-secure-flag.cookie-missing-secure-flag
         origin: community
   message: A cookie was detected without setting the 'secure' flag. The 'secure' flag
     for cookies prevents the client from transmitting the cookie over insecure channels
@@ -14561,10 +14563,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14693
-        rv_id: 109995
+        rv_id: 834209
         rule_id: ReU3Yb
-        version_id: DkT6nyD
-        url: https://semgrep.dev/playground/r/DkT6nyD/kotlin.lang.security.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
+        version_id: DkTG0DY
+        url: https://semgrep.dev/playground/r/DkTG0DY/kotlin.lang.security.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
         origin: community
   message: DefaultHttpClient is deprecated. Further, it does not support connections
     using TLS1.2, which makes using DefaultHttpClient a security hazard. Use SystemDefaultHttpClient
@@ -14600,10 +14602,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14697
-        rv_id: 109997
+        rv_id: 834211
         rule_id: WAUyAW
-        version_id: 0bTLl3v
-        url: https://semgrep.dev/playground/r/0bTLl3v/kotlin.lang.security.gcm-detection.gcm-detection
+        version_id: 0bTwbAo
+        url: https://semgrep.dev/playground/r/0bTwbAo/kotlin.lang.security.gcm-detection.gcm-detection
         origin: community
   languages:
   - kt
@@ -14652,10 +14654,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14699
-        rv_id: 109999
+        rv_id: 834213
         rule_id: KxU76z
-        version_id: qkT2xwl
-        url: https://semgrep.dev/playground/r/qkT2xwl/kotlin.lang.security.unencrypted-socket.unencrypted-socket
+        version_id: qkTQnkL
+        url: https://semgrep.dev/playground/r/qkTQnkL/kotlin.lang.security.unencrypted-socket.unencrypted-socket
         origin: community
   message: This socket is not encrypted. The traffic could be read by an attacker
     intercepting the network traffic. Use an SSLSocket created by 'SSLSocketFactory'
@@ -14701,10 +14703,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15128
-        rv_id: 110002
+        rv_id: 834216
         rule_id: nJUZNL
-        version_id: 6xTvJ9Z
-        url: https://semgrep.dev/playground/r/6xTvJ9Z/kotlin.lang.security.weak-rsa.use-of-weak-rsa-key
+        version_id: 6xTDgd0
+        url: https://semgrep.dev/playground/r/6xTDgd0/kotlin.lang.security.weak-rsa.use-of-weak-rsa-key
         origin: community
   patterns:
   - pattern-either:
@@ -14773,10 +14775,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 92978
-        rv_id: 230014
+        rv_id: 834249
         rule_id: 6JUvjv6
-        version_id: LjT7Zeo
-        url: https://semgrep.dev/playground/r/LjT7Zeo/ocaml.lang.security.unsafe.ocamllint-unsafe
+        version_id: GxTDEGD
+        url: https://semgrep.dev/playground/r/GxTDEGD/ocaml.lang.security.unsafe.ocamllint-unsafe
         origin: community
 - id: php.doctrine.security.audit.doctrine-dbal-dangerous-query.doctrine-dbal-dangerous-query
   languages:
@@ -14813,10 +14815,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13799
-        rv_id: 110029
+        rv_id: 834250
         rule_id: X5UdZj
-        version_id: QkTW0qD
-        url: https://semgrep.dev/playground/r/QkTW0qD/php.doctrine.security.audit.doctrine-dbal-dangerous-query.doctrine-dbal-dangerous-query
+        version_id: RGTKGX2
+        url: https://semgrep.dev/playground/r/RGTKGX2/php.doctrine.security.audit.doctrine-dbal-dangerous-query.doctrine-dbal-dangerous-query
         origin: community
   patterns:
   - pattern-either:
@@ -14916,10 +14918,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17328
-        rv_id: 110033
+        rv_id: 834254
         rule_id: YGUAoe
-        version_id: JdTNpx9
-        url: https://semgrep.dev/playground/r/JdTNpx9/php.lang.security.audit.openssl-decrypt-validate.openssl-decrypt-validate
+        version_id: WrTdpRq
+        url: https://semgrep.dev/playground/r/WrTdpRq/php.lang.security.audit.openssl-decrypt-validate.openssl-decrypt-validate
         origin: community
 - id: php.lang.security.backticks-use.backticks-use
   pattern: "`...`;"
@@ -14949,10 +14951,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9388
-        rv_id: 110034
+        rv_id: 834255
         rule_id: WAUow7
-        version_id: 5PTdA1D
-        url: https://semgrep.dev/playground/r/5PTdA1D/php.lang.security.backticks-use.backticks-use
+        version_id: 0bTwb4o
+        url: https://semgrep.dev/playground/r/0bTwb4o/php.lang.security.backticks-use.backticks-use
         origin: community
   languages:
   - php
@@ -14983,10 +14985,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 115928
-        rv_id: 348110
+        rv_id: 834256
         rule_id: 7KUgBAk
-        version_id: 1QTKbNw
-        url: https://semgrep.dev/playground/r/1QTKbNw/php.lang.security.base-convert-loses-precision.base-convert-loses-precision
+        version_id: K3Trqpg
+        url: https://semgrep.dev/playground/r/K3Trqpg/php.lang.security.base-convert-loses-precision.base-convert-loses-precision
         origin: community
   languages:
   - php
@@ -15053,10 +15055,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9390
-        rv_id: 110037
+        rv_id: 834259
         rule_id: KxUbX3
-        version_id: A8T95d2
-        url: https://semgrep.dev/playground/r/A8T95d2/php.lang.security.eval-use.eval-use
+        version_id: YDTl03O
+        url: https://semgrep.dev/playground/r/YDTl03O/php.lang.security.eval-use.eval-use
         origin: community
   languages:
   - php
@@ -15093,10 +15095,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9391
-        rv_id: 110038
+        rv_id: 834260
         rule_id: qNUjye
-        version_id: BjTXrZP
-        url: https://semgrep.dev/playground/r/BjTXrZP/php.lang.security.exec-use.exec-use
+        version_id: JdTlrJZ
+        url: https://semgrep.dev/playground/r/JdTlrJZ/php.lang.security.exec-use.exec-use
         origin: community
   languages:
   - php
@@ -15133,10 +15135,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9392
-        rv_id: 110039
+        rv_id: 834261
         rule_id: lBU90N
-        version_id: DkT6nbD
-        url: https://semgrep.dev/playground/r/DkT6nbD/php.lang.security.file-inclusion.file-inclusion
+        version_id: 5PTyDvB
+        url: https://semgrep.dev/playground/r/5PTyDvB/php.lang.security.file-inclusion.file-inclusion
         origin: community
   languages:
   - php
@@ -15198,10 +15200,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9393
-        rv_id: 110040
+        rv_id: 834262
         rule_id: PeUZyE
-        version_id: WrTWQKR
-        url: https://semgrep.dev/playground/r/WrTWQKR/php.lang.security.ftp-use.ftp-use
+        version_id: GxTDEGg
+        url: https://semgrep.dev/playground/r/GxTDEGg/php.lang.security.ftp-use.ftp-use
         origin: community
   languages:
   - php
@@ -15242,10 +15244,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13966
-        rv_id: 110046
+        rv_id: 834270
         rule_id: wdUjA5
-        version_id: 6xTvJoZ
-        url: https://semgrep.dev/playground/r/6xTvJoZ/php.lang.security.ldap-bind-without-password.ldap-bind-without-password
+        version_id: qkTQn06
+        url: https://semgrep.dev/playground/r/qkTQn06/php.lang.security.ldap-bind-without-password.ldap-bind-without-password
         origin: community
   languages:
   - php
@@ -15282,10 +15284,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9394
-        rv_id: 110047
+        rv_id: 834271
         rule_id: JDUyj4
-        version_id: o5Tglwy
-        url: https://semgrep.dev/playground/r/o5Tglwy/php.lang.security.mb-ereg-replace-eval.mb-ereg-replace-eval
+        version_id: l4TyOLE
+        url: https://semgrep.dev/playground/r/l4TyOLE/php.lang.security.mb-ereg-replace-eval.mb-ereg-replace-eval
         origin: community
   languages:
   - php
@@ -15320,10 +15322,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9395
-        rv_id: 110048
+        rv_id: 834272
         rule_id: 5rUOzK
-        version_id: zyTK8Zk
-        url: https://semgrep.dev/playground/r/zyTK8Zk/php.lang.security.mcrypt-use.mcrypt-use
+        version_id: YDTl03d
+        url: https://semgrep.dev/playground/r/YDTl03d/php.lang.security.mcrypt-use.mcrypt-use
         origin: community
   languages:
   - php
@@ -15361,10 +15363,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9396
-        rv_id: 110049
+        rv_id: 834273
         rule_id: GdU7RO
-        version_id: pZT1yYG
-        url: https://semgrep.dev/playground/r/pZT1yYG/php.lang.security.md5-loose-equality.md5-loose-equality
+        version_id: 6xTDgLP
+        url: https://semgrep.dev/playground/r/6xTDgLP/php.lang.security.md5-loose-equality.md5-loose-equality
         origin: community
   languages:
   - php
@@ -15405,10 +15407,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13968
-        rv_id: 110053
+        rv_id: 834276
         rule_id: OrU6JZ
-        version_id: 1QTOYvP
-        url: https://semgrep.dev/playground/r/1QTOYvP/php.lang.security.php-permissive-cors.php-permissive-cors
+        version_id: pZTXjB3
+        url: https://semgrep.dev/playground/r/pZTXjB3/php.lang.security.php-permissive-cors.php-permissive-cors
         origin: community
   languages:
   - php
@@ -15448,10 +15450,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13969
-        rv_id: 110059
+        rv_id: 834281
         rule_id: eqUzDE
-        version_id: kbTdxbD
-        url: https://semgrep.dev/playground/r/kbTdxbD/php.lang.security.unlink-use.unlink-use
+        version_id: 9lTJ0jz
+        url: https://semgrep.dev/playground/r/9lTJ0jz/php.lang.security.unlink-use.unlink-use
         origin: community
   languages:
   - php
@@ -15490,10 +15492,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13970
-        rv_id: 110060
+        rv_id: 834282
         rule_id: v8U9OJ
-        version_id: w8T9nLW
-        url: https://semgrep.dev/playground/r/w8T9nLW/php.lang.security.unserialize-use.unserialize-use
+        version_id: yeTN16L
+        url: https://semgrep.dev/playground/r/yeTN16L/php.lang.security.unserialize-use.unserialize-use
         origin: community
   languages:
   - php
@@ -15530,10 +15532,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9399
-        rv_id: 110061
+        rv_id: 834283
         rule_id: BYUNAg
-        version_id: xyTKZ50
-        url: https://semgrep.dev/playground/r/xyTKZ50/php.lang.security.weak-crypto.weak-crypto
+        version_id: rxTDz5P
+        url: https://semgrep.dev/playground/r/rxTDz5P/php.lang.security.weak-crypto.weak-crypto
         origin: community
   languages:
   - php
@@ -15588,10 +15590,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13971
-        rv_id: 110073
+        rv_id: 834295
         rule_id: d8UeKO
-        version_id: QkTW0OD
-        url: https://semgrep.dev/playground/r/QkTW0OD/php.symfony.security.audit.symfony-csrf-protection-disabled.symfony-csrf-protection-disabled
+        version_id: ExTrDng
+        url: https://semgrep.dev/playground/r/ExTrDng/php.symfony.security.audit.symfony-csrf-protection-disabled.symfony-csrf-protection-disabled
         origin: community
   languages:
   - php
@@ -15631,10 +15633,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13800
-        rv_id: 110074
+        rv_id: 834296
         rule_id: j2U3q8
-        version_id: 3ZTkQ1q
-        url: https://semgrep.dev/playground/r/3ZTkQ1q/php.symfony.security.audit.symfony-non-literal-redirect.symfony-non-literal-redirect
+        version_id: 7ZTx9Oo
+        url: https://semgrep.dev/playground/r/7ZTx9Oo/php.symfony.security.audit.symfony-non-literal-redirect.symfony-non-literal-redirect
         origin: community
   severity: WARNING
 - id: php.symfony.security.audit.symfony-permissive-cors.symfony-permissive-cors
@@ -15688,10 +15690,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13972
-        rv_id: 110075
+        rv_id: 834297
         rule_id: ZqUOlR
-        version_id: 44TRldD
-        url: https://semgrep.dev/playground/r/44TRldD/php.symfony.security.audit.symfony-permissive-cors.symfony-permissive-cors
+        version_id: LjTEb0A
+        url: https://semgrep.dev/playground/r/LjTEb0A/php.symfony.security.audit.symfony-permissive-cors.symfony-permissive-cors
         origin: community
   languages:
   - php
@@ -15735,10 +15737,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39195
-        rv_id: 110076
+        rv_id: 834298
         rule_id: DbUe2y
-        version_id: PkTJ1yN
-        url: https://semgrep.dev/playground/r/PkTJ1yN/php.wordpress-plugins.security.audit.wp-ajax-no-auth-and-auth-hooks-audit.wp-ajax-no-auth-and-auth-hooks-audit
+        version_id: 8KTGkb5
+        url: https://semgrep.dev/playground/r/8KTGkb5/php.wordpress-plugins.security.audit.wp-ajax-no-auth-and-auth-hooks-audit.wp-ajax-no-auth-and-auth-hooks-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-authorisation-checks-audit.wp-authorisation-checks-audit
   patterns:
@@ -15777,10 +15779,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39196
-        rv_id: 110077
+        rv_id: 834299
         rule_id: WAU6YK
-        version_id: JdTNpj9
-        url: https://semgrep.dev/playground/r/JdTNpj9/php.wordpress-plugins.security.audit.wp-authorisation-checks-audit.wp-authorisation-checks-audit
+        version_id: gETy2qP
+        url: https://semgrep.dev/playground/r/gETy2qP/php.wordpress-plugins.security.audit.wp-authorisation-checks-audit.wp-authorisation-checks-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-code-execution-audit.wp-code-execution-audit
   patterns:
@@ -15820,10 +15822,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39197
-        rv_id: 110078
+        rv_id: 834300
         rule_id: 0oU6pX
-        version_id: 5PTdAzD
-        url: https://semgrep.dev/playground/r/5PTdAzD/php.wordpress-plugins.security.audit.wp-code-execution-audit.wp-code-execution-audit
+        version_id: QkTkrJE
+        url: https://semgrep.dev/playground/r/QkTkrJE/php.wordpress-plugins.security.audit.wp-code-execution-audit.wp-code-execution-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-command-execution-audit.wp-command-execution-audit
   patterns:
@@ -15865,10 +15867,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39198
-        rv_id: 110079
+        rv_id: 834301
         rule_id: KxUOw0
-        version_id: GxTv6RX
-        url: https://semgrep.dev/playground/r/GxTv6RX/php.wordpress-plugins.security.audit.wp-command-execution-audit.wp-command-execution-audit
+        version_id: 3ZT3AdW
+        url: https://semgrep.dev/playground/r/3ZT3AdW/php.wordpress-plugins.security.audit.wp-command-execution-audit.wp-command-execution-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-csrf-audit.wp-csrf-audit
   pattern: check_ajax_referer(...,...,false)
@@ -15904,10 +15906,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39199
-        rv_id: 110080
+        rv_id: 834302
         rule_id: qNUKpk
-        version_id: RGTDklL
-        url: https://semgrep.dev/playground/r/RGTDklL/php.wordpress-plugins.security.audit.wp-csrf-audit.wp-csrf-audit
+        version_id: 44TQPo8
+        url: https://semgrep.dev/playground/r/44TQPo8/php.wordpress-plugins.security.audit.wp-csrf-audit.wp-csrf-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-file-download-audit.wp-file-download-audit
   patterns:
@@ -15947,10 +15949,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39200
-        rv_id: 110081
+        rv_id: 834303
         rule_id: lBUNXL
-        version_id: A8T9522
-        url: https://semgrep.dev/playground/r/A8T9522/php.wordpress-plugins.security.audit.wp-file-download-audit.wp-file-download-audit
+        version_id: PkTxrYO
+        url: https://semgrep.dev/playground/r/PkTxrYO/php.wordpress-plugins.security.audit.wp-file-download-audit.wp-file-download-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-file-inclusion-audit.wp-file-inclusion-audit
   patterns:
@@ -15999,10 +16001,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39201
-        rv_id: 110082
+        rv_id: 834304
         rule_id: YGU8Yo
-        version_id: BjTXrAP
-        url: https://semgrep.dev/playground/r/BjTXrAP/php.wordpress-plugins.security.audit.wp-file-inclusion-audit.wp-file-inclusion-audit
+        version_id: JdTlrqZ
+        url: https://semgrep.dev/playground/r/JdTlrqZ/php.wordpress-plugins.security.audit.wp-file-inclusion-audit.wp-file-inclusion-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-file-manipulation-audit.wp-file-manipulation-audit
   patterns:
@@ -16047,10 +16049,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39202
-        rv_id: 110083
+        rv_id: 834305
         rule_id: 6JU0yK
-        version_id: DkT6njD
-        url: https://semgrep.dev/playground/r/DkT6njD/php.wordpress-plugins.security.audit.wp-file-manipulation-audit.wp-file-manipulation-audit
+        version_id: 5PTyD6B
+        url: https://semgrep.dev/playground/r/5PTyD6B/php.wordpress-plugins.security.audit.wp-file-manipulation-audit.wp-file-manipulation-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-open-redirect-audit.wp-open-redirect-audit
   pattern: wp_redirect(...)
@@ -16087,10 +16089,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39203
-        rv_id: 110084
+        rv_id: 834306
         rule_id: oqU5KY
-        version_id: WrTWQwR
-        url: https://semgrep.dev/playground/r/WrTWQwR/php.wordpress-plugins.security.audit.wp-open-redirect-audit.wp-open-redirect-audit
+        version_id: GxTDE2g
+        url: https://semgrep.dev/playground/r/GxTDE2g/php.wordpress-plugins.security.audit.wp-open-redirect-audit.wp-open-redirect-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-php-object-injection-audit.wp-php-object-injection-audit
   patterns:
@@ -16130,10 +16132,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39204
-        rv_id: 110085
+        rv_id: 834307
         rule_id: zdUelq
-        version_id: 0bTLlXv
-        url: https://semgrep.dev/playground/r/0bTLlXv/php.wordpress-plugins.security.audit.wp-php-object-injection-audit.wp-php-object-injection-audit
+        version_id: RGTKGbN
+        url: https://semgrep.dev/playground/r/RGTKGbN/php.wordpress-plugins.security.audit.wp-php-object-injection-audit.wp-php-object-injection-audit
         origin: community
 - id: php.wordpress-plugins.security.audit.wp-sql-injection-audit.wp-sql-injection-audit
   patterns:
@@ -16183,10 +16185,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39205
-        rv_id: 110086
+        rv_id: 834308
         rule_id: pKUQN1
-        version_id: K3TvjXy
-        url: https://semgrep.dev/playground/r/K3TvjXy/php.wordpress-plugins.security.audit.wp-sql-injection-audit.wp-sql-injection-audit
+        version_id: A8T37RP
+        url: https://semgrep.dev/playground/r/A8T37RP/php.wordpress-plugins.security.audit.wp-sql-injection-audit.wp-sql-injection-audit
         origin: community
 - id: problem-based-packs.insecure-transport.java-stdlib.socket-request.socket-request
   message: Insecure transport rules to catch socket connections to http, telnet, and
@@ -16215,10 +16217,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9419
-        rv_id: 110107
+        rv_id: 834329
         rule_id: NbUkl9
-        version_id: 2KTzrqw
-        url: https://semgrep.dev/playground/r/2KTzrqw/problem-based-packs.insecure-transport.java-stdlib.socket-request.socket-request
+        version_id: NdTB2O3
+        url: https://semgrep.dev/playground/r/NdTB2O3/problem-based-packs.insecure-transport.java-stdlib.socket-request.socket-request
         origin: community
   languages:
   - java
@@ -16272,10 +16274,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9430
-        rv_id: 110118
+        rv_id: 834340
         rule_id: 7KUQAE
-        version_id: xyTKZoP
-        url: https://semgrep.dev/playground/r/xyTKZoP/problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server
+        version_id: 7ZTx97o
+        url: https://semgrep.dev/playground/r/7ZTx97o/problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server
         origin: community
   languages:
   - javascript
@@ -16319,10 +16321,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9436
-        rv_id: 110124
+        rv_id: 834346
         rule_id: 4bUkOY
-        version_id: nWTxPKL
-        url: https://semgrep.dev/playground/r/nWTxPKL/python.airflow.security.audit.formatted-string-bashoperator.formatted-string-bashoperator
+        version_id: 44TQP38
+        url: https://semgrep.dev/playground/r/44TQP38/python.airflow.security.audit.formatted-string-bashoperator.formatted-string-bashoperator
         origin: community
   languages:
   - python
@@ -16401,10 +16403,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9444
-        rv_id: 252915
+        rv_id: 834374
         rule_id: DbUp5g
-        version_id: l4TlPgr
-        url: https://semgrep.dev/playground/r/l4TlPgr/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
+        version_id: 6xTDgpZ
+        url: https://semgrep.dev/playground/r/6xTDgpZ/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
         origin: community
   severity: WARNING
   languages:
@@ -16455,10 +16457,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9448
-        rv_id: 251691
+        rv_id: 834378
         rule_id: qNUjZ3
-        version_id: YDTNPqv
-        url: https://semgrep.dev/playground/r/YDTNPqv/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
+        version_id: 2KT7xWK
+        url: https://semgrep.dev/playground/r/2KT7xWK/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
         origin: community
   languages:
   - python
@@ -16507,10 +16509,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9449
-        rv_id: 252918
+        rv_id: 834379
         rule_id: lBU9jn
-        version_id: o5TkxOr
-        url: https://semgrep.dev/playground/r/o5TkxOr/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+        version_id: X0T5NBd
+        url: https://semgrep.dev/playground/r/X0T5NBd/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
         origin: community
   languages:
   - python
@@ -16546,10 +16548,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31871
-        rv_id: 110158
+        rv_id: 834380
         rule_id: lBUpNZ
-        version_id: bZTb1qg
-        url: https://semgrep.dev/playground/r/bZTb1qg/python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
+        version_id: jQTrXOQ
+        url: https://semgrep.dev/playground/r/jQTrXOQ/python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
         origin: community
   patterns:
   - pattern-either:
@@ -16610,10 +16612,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9468
-        rv_id: 110181
+        rv_id: 834403
         rule_id: eqU8Wr
-        version_id: RGTDkXP
-        url: https://semgrep.dev/playground/r/RGTDkXP/python.django.security.audit.avoid-mark-safe.avoid-mark-safe
+        version_id: 44TQPvD
+        url: https://semgrep.dev/playground/r/44TQPvD/python.django.security.audit.avoid-mark-safe.avoid-mark-safe
         origin: community
   languages:
   - python
@@ -16653,10 +16655,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9470
-        rv_id: 110183
+        rv_id: 834405
         rule_id: d8Ujk6
-        version_id: BjTXr9d
-        url: https://semgrep.dev/playground/r/BjTXr9d/python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql
+        version_id: JdTlr79
+        url: https://semgrep.dev/playground/r/JdTlr79/python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql
         origin: community
   pattern: "$EXPRESSION.as_sql(...)"
   severity: WARNING
@@ -16700,10 +16702,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9477
-        rv_id: 110185
+        rv_id: 834406
         rule_id: gxU1wE
-        version_id: WrTWQRd
-        url: https://semgrep.dev/playground/r/WrTWQRd/python.django.security.audit.django-rest-framework.missing-throttle-config.missing-throttle-config
+        version_id: 5PTyDnD
+        url: https://semgrep.dev/playground/r/5PTyDnD/python.django.security.audit.django-rest-framework.missing-throttle-config.missing-throttle-config
         origin: community
   severity: WARNING
   languages:
@@ -16743,10 +16745,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9471
-        rv_id: 110186
+        rv_id: 834407
         rule_id: ZqU5z3
-        version_id: 0bTLl4p
-        url: https://semgrep.dev/playground/r/0bTLl4p/python.django.security.audit.extends-custom-expression.extends-custom-expression
+        version_id: GxTDE9X
+        url: https://semgrep.dev/playground/r/GxTDE9X/python.django.security.audit.extends-custom-expression.extends-custom-expression
         origin: community
   severity: WARNING
   pattern-either:
@@ -16898,10 +16900,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9472
-        rv_id: 110187
+        rv_id: 834408
         rule_id: nJUzBP
-        version_id: K3TvjpJ
-        url: https://semgrep.dev/playground/r/K3TvjpJ/python.django.security.audit.query-set-extra.avoid-query-set-extra
+        version_id: RGTKG1L
+        url: https://semgrep.dev/playground/r/RGTKG1L/python.django.security.audit.query-set-extra.avoid-query-set-extra
         origin: community
   languages:
   - python
@@ -16943,10 +16945,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9473
-        rv_id: 110188
+        rv_id: 834409
         rule_id: EwU2JA
-        version_id: qkT2x0x
-        url: https://semgrep.dev/playground/r/qkT2x0x/python.django.security.audit.raw-query.avoid-raw-sql
+        version_id: A8T37b2
+        url: https://semgrep.dev/playground/r/A8T37b2/python.django.security.audit.raw-query.avoid-raw-sql
         origin: community
   languages:
   - python
@@ -17020,10 +17022,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9474
-        rv_id: 110189
+        rv_id: 834410
         rule_id: 7KUQ2E
-        version_id: l4T4vL6
-        url: https://semgrep.dev/playground/r/l4T4vL6/python.django.security.audit.secure-cookies.django-secure-set-cookie
+        version_id: BjTe02P
+        url: https://semgrep.dev/playground/r/BjTe02P/python.django.security.audit.secure-cookies.django-secure-set-cookie
         origin: community
   languages:
   - python
@@ -17063,10 +17065,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9478
-        rv_id: 110190
+        rv_id: 834411
         rule_id: QrUzb2
-        version_id: YDTp23Z
-        url: https://semgrep.dev/playground/r/YDTp23Z/python.django.security.audit.templates.debug-template-tag.debug-template-tag
+        version_id: DkTG0zD
+        url: https://semgrep.dev/playground/r/DkTG0zD/python.django.security.audit.templates.debug-template-tag.debug-template-tag
         origin: community
 - id: python.django.security.audit.unvalidated-password.unvalidated-password
   patterns:
@@ -17124,10 +17126,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9475
-        rv_id: 255673
+        rv_id: 834412
         rule_id: L1UywG
-        version_id: 44TAy70
-        url: https://semgrep.dev/playground/r/44TAy70/python.django.security.audit.unvalidated-password.unvalidated-password
+        version_id: WrTdprR
+        url: https://semgrep.dev/playground/r/WrTdprR/python.django.security.audit.unvalidated-password.unvalidated-password
         origin: community
   languages:
   - python
@@ -17166,10 +17168,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9479
-        rv_id: 110192
+        rv_id: 834413
         rule_id: 3qUPve
-        version_id: 5PTdAv7
-        url: https://semgrep.dev/playground/r/5PTdAv7/python.django.security.audit.xss.class-extends-safestring.class-extends-safestring
+        version_id: 0bTwbWv
+        url: https://semgrep.dev/playground/r/0bTwbWv/python.django.security.audit.xss.class-extends-safestring.class-extends-safestring
         origin: community
   languages:
   - python
@@ -17216,10 +17218,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9480
-        rv_id: 110193
+        rv_id: 834414
         rule_id: 4bUknY
-        version_id: GxTv6GY
-        url: https://semgrep.dev/playground/r/GxTv6GY/python.django.security.audit.xss.context-autoescape-off.context-autoescape-off
+        version_id: K3TrqNy
+        url: https://semgrep.dev/playground/r/K3TrqNy/python.django.security.audit.xss.context-autoescape-off.context-autoescape-off
         origin: community
   languages:
   - python
@@ -17274,10 +17276,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9481
-        rv_id: 110194
+        rv_id: 834415
         rule_id: PeUZgE
-        version_id: RGTDkX9
-        url: https://semgrep.dev/playground/r/RGTDkX9/python.django.security.audit.xss.direct-use-of-httpresponse.direct-use-of-httpresponse
+        version_id: qkTQnll
+        url: https://semgrep.dev/playground/r/qkTQnll/python.django.security.audit.xss.direct-use-of-httpresponse.direct-use-of-httpresponse
         origin: community
   languages:
   - python
@@ -17347,10 +17349,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9482
-        rv_id: 110195
+        rv_id: 834416
         rule_id: JDUyd4
-        version_id: A8T956L
-        url: https://semgrep.dev/playground/r/A8T956L/python.django.security.audit.xss.filter-with-is-safe.filter-with-is-safe
+        version_id: l4TyDQQ
+        url: https://semgrep.dev/playground/r/l4TyDQQ/python.django.security.audit.xss.filter-with-is-safe.filter-with-is-safe
         origin: community
   languages:
   - python
@@ -17392,10 +17394,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12657
-        rv_id: 110196
+        rv_id: 834417
         rule_id: v8UjKg
-        version_id: BjTXr9G
-        url: https://semgrep.dev/playground/r/BjTXr9G/python.django.security.audit.xss.formathtml-fstring-parameter.formathtml-fstring-parameter
+        version_id: YDTlbqp
+        url: https://semgrep.dev/playground/r/YDTlbqp/python.django.security.audit.xss.formathtml-fstring-parameter.formathtml-fstring-parameter
         origin: community
   languages:
   - python
@@ -17436,10 +17438,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9483
-        rv_id: 110197
+        rv_id: 834418
         rule_id: 5rUOXK
-        version_id: DkT6nO3
-        url: https://semgrep.dev/playground/r/DkT6nO3/python.django.security.audit.xss.global-autoescape-off.global-autoescape-off
+        version_id: 6xTDXbZ
+        url: https://semgrep.dev/playground/r/6xTDXbZ/python.django.security.audit.xss.global-autoescape-off.global-autoescape-off
         origin: community
   languages:
   - python
@@ -17490,10 +17492,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9484
-        rv_id: 110198
+        rv_id: 834419
         rule_id: GdU7QO
-        version_id: WrTWQRg
-        url: https://semgrep.dev/playground/r/WrTWQRg/python.django.security.audit.xss.html-magic-method.html-magic-method
+        version_id: o5TB1Xy
+        url: https://semgrep.dev/playground/r/o5TB1Xy/python.django.security.audit.xss.html-magic-method.html-magic-method
         origin: community
   languages:
   - python
@@ -17540,10 +17542,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9485
-        rv_id: 110199
+        rv_id: 834420
         rule_id: ReUg5Y
-        version_id: 0bTLl40
-        url: https://semgrep.dev/playground/r/0bTLl40/python.django.security.audit.xss.html-safe.html-safe
+        version_id: zyTW3qk
+        url: https://semgrep.dev/playground/r/zyTW3qk/python.django.security.audit.xss.html-safe.html-safe
         origin: community
   languages:
   - python
@@ -17586,10 +17588,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9486
-        rv_id: 110200
+        rv_id: 834421
         rule_id: AbUzAZ
-        version_id: K3Tvjp9
-        url: https://semgrep.dev/playground/r/K3Tvjp9/python.django.security.audit.xss.template-autoescape-off.template-autoescape-off
+        version_id: pZTXDPG
+        url: https://semgrep.dev/playground/r/pZTXDPG/python.django.security.audit.xss.template-autoescape-off.template-autoescape-off
         origin: community
   languages:
   - regex
@@ -17651,10 +17653,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9487
-        rv_id: 110201
+        rv_id: 834422
         rule_id: BYUNwg
-        version_id: qkT2x0z
-        url: https://semgrep.dev/playground/r/qkT2x0z/python.django.security.audit.xss.template-blocktranslate-no-escape.template-blocktranslate-no-escape
+        version_id: 2KT7OlK
+        url: https://semgrep.dev/playground/r/2KT7OlK/python.django.security.audit.xss.template-blocktranslate-no-escape.template-blocktranslate-no-escape
         origin: community
 - id: python.django.security.audit.xss.template-translate-as-no-escape.template-translate-as-no-escape
   languages:
@@ -17794,10 +17796,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9489
-        rv_id: 110203
+        rv_id: 834424
         rule_id: WAUov9
-        version_id: YDTp231
-        url: https://semgrep.dev/playground/r/YDTp231/python.django.security.audit.xss.template-translate-as-no-escape.template-translate-as-no-escape
+        version_id: jQTrjkQ
+        url: https://semgrep.dev/playground/r/jQTrjkQ/python.django.security.audit.xss.template-translate-as-no-escape.template-translate-as-no-escape
         origin: community
 - id: python.django.security.audit.xss.template-var-unescaped-with-safeseq.template-var-unescaped-with-safeseq
   message: Detected a template variable where autoescaping is explicitly disabled
@@ -17831,10 +17833,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9491
-        rv_id: 110205
+        rv_id: 834425
         rule_id: KxUbdx
-        version_id: o5Tgl7v
-        url: https://semgrep.dev/playground/r/o5Tgl7v/python.django.security.audit.xss.template-var-unescaped-with-safeseq.template-var-unescaped-with-safeseq
+        version_id: 1QTPN8P
+        url: https://semgrep.dev/playground/r/1QTPN8P/python.django.security.audit.xss.template-var-unescaped-with-safeseq.template-var-unescaped-with-safeseq
         origin: community
   languages:
   - regex
@@ -17882,10 +17884,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 73471
-        rv_id: 828674
+        rv_id: 834427
         rule_id: PeUyYG
-        version_id: kbT21d9
-        url: https://semgrep.dev/playground/r/kbT21d9/python.django.security.django-no-csrf-token.django-no-csrf-token
+        version_id: yeTNgk0
+        url: https://semgrep.dev/playground/r/yeTNgk0/python.django.security.django-no-csrf-token.django-no-csrf-token
         origin: community
   paths:
     include:
@@ -17926,10 +17928,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 73472
-        rv_id: 828675
+        rv_id: 834428
         rule_id: JDUjqx
-        version_id: w8TAO9q
-        url: https://semgrep.dev/playground/r/w8TAO9q/python.django.security.django-using-request-post-after-is-valid.django-using-request-post-after-is-valid
+        version_id: rxTDvOL
+        url: https://semgrep.dev/playground/r/rxTDvOL/python.django.security.django-using-request-post-after-is-valid.django-using-request-post-after-is-valid
         origin: community
 - id: python.django.security.globals-as-template-context.globals-as-template-context
   languages:
@@ -17967,10 +17969,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11938
-        rv_id: 110207
+        rv_id: 834429
         rule_id: j2UR3n
-        version_id: pZT1yBE
-        url: https://semgrep.dev/playground/r/pZT1yBE/python.django.security.globals-as-template-context.globals-as-template-context
+        version_id: bZTBoA9
+        url: https://semgrep.dev/playground/r/bZTBoA9/python.django.security.globals-as-template-context.globals-as-template-context
         origin: community
   pattern-either:
   - pattern: django.shortcuts.render(..., globals(...), ...)
@@ -18011,10 +18013,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9499
-        rv_id: 110209
+        rv_id: 834431
         rule_id: AbUzAA
-        version_id: X0TQxv6
-        url: https://semgrep.dev/playground/r/X0TQxv6/python.django.security.injection.code.globals-misuse-code-execution.globals-misuse-code-execution
+        version_id: kbT2PKD
+        url: https://semgrep.dev/playground/r/kbT2PKD/python.django.security.injection.code.globals-misuse-code-execution.globals-misuse-code-execution
         origin: community
   languages:
   - python
@@ -18249,10 +18251,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9493
-        rv_id: 110219
+        rv_id: 834441
         rule_id: lBU97n
-        version_id: xyTKZYJ
-        url: https://semgrep.dev/playground/r/xyTKZYJ/python.django.security.injection.mass-assignment.mass-assignment
+        version_id: 7ZTxRzq
+        url: https://semgrep.dev/playground/r/7ZTxRzq/python.django.security.injection.mass-assignment.mass-assignment
         origin: community
   pattern-either:
   - pattern: "$MODEL.objects.create(**request.$W)"
@@ -18291,10 +18293,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9508
-        rv_id: 110222
+        rv_id: 834444
         rule_id: 6JUjLj
-        version_id: vdTYN21
-        url: https://semgrep.dev/playground/r/vdTYN21/python.django.security.injection.path-traversal.path-traversal-join.path-traversal-join
+        version_id: gETyXZz
+        url: https://semgrep.dev/playground/r/gETyXZz/python.django.security.injection.path-traversal.path-traversal-join.path-traversal-join
         origin: community
   patterns:
   - pattern-inside: |
@@ -18405,10 +18407,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14701
-        rv_id: 110235
+        rv_id: 834457
         rule_id: lBU8Ad
-        version_id: JdTNpqk
-        url: https://semgrep.dev/playground/r/JdTNpqk/python.django.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: 0bTw3xv
+        url: https://semgrep.dev/playground/r/0bTw3xv/python.django.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   severity: ERROR
   languages:
@@ -18471,10 +18473,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14760
-        rv_id: 762648
+        rv_id: 834458
         rule_id: 6JU1l0
-        version_id: qkTWN00
-        url: https://semgrep.dev/playground/r/qkTWN00/python.django.security.injection.tainted-url-host.tainted-url-host
+        version_id: K3TrL2y
+        url: https://semgrep.dev/playground/r/K3TrL2y/python.django.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sinks:
@@ -18554,10 +18556,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11939
-        rv_id: 110237
+        rv_id: 834459
         rule_id: 10Ued2
-        version_id: GxTv62Y
-        url: https://semgrep.dev/playground/r/GxTv62Y/python.django.security.locals-as-template-context.locals-as-template-context
+        version_id: qkTQwYl
+        url: https://semgrep.dev/playground/r/qkTQwYl/python.django.security.locals-as-template-context.locals-as-template-context
         origin: community
   pattern-either:
   - pattern: django.shortcuts.render(..., locals(...), ...)
@@ -18614,10 +18616,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9518
-        rv_id: 110241
+        rv_id: 834463
         rule_id: r6Ur5A
-        version_id: DkT6nQ3
-        url: https://semgrep.dev/playground/r/DkT6nQ3/python.docker.security.audit.docker-arbitrary-container-run.docker-arbitrary-container-run
+        version_id: 5PTyGdP
+        url: https://semgrep.dev/playground/r/5PTyGdP/python.docker.security.audit.docker-arbitrary-container-run.docker-arbitrary-container-run
         origin: community
 - id: python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_DEBUG
   message: Hardcoded variable `DEBUG` detected. Set this by using FLASK_DEBUG environment
@@ -18648,10 +18650,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9539
-        rv_id: 110255
+        rv_id: 834478
         rule_id: JDUyJR
-        version_id: 1QTOYjN
-        url: https://semgrep.dev/playground/r/1QTOYjN/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_DEBUG
+        version_id: pZTXD1A
+        url: https://semgrep.dev/playground/r/pZTXD1A/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_DEBUG
         origin: community
   languages:
   - python
@@ -18689,10 +18691,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9538
-        rv_id: 110254
+        rv_id: 834477
         rule_id: PeUZpr
-        version_id: jQTgYKX
-        url: https://semgrep.dev/playground/r/jQTgYKX/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_ENV
+        version_id: zyTW3KN
+        url: https://semgrep.dev/playground/r/zyTW3KN/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_ENV
         origin: community
   languages:
   - python
@@ -18728,10 +18730,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9537
-        rv_id: 110253
+        rv_id: 834476
         rule_id: 4bUkX0
-        version_id: X0TQxP6
-        url: https://semgrep.dev/playground/r/X0TQxP6/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_SECRET_KEY
+        version_id: o5TB1gL
+        url: https://semgrep.dev/playground/r/o5TB1gL/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_SECRET_KEY
         origin: community
   languages:
   - python
@@ -18767,10 +18769,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9536
-        rv_id: 110252
+        rv_id: 834475
         rule_id: 3qUPoy
-        version_id: 2KTzr19
-        url: https://semgrep.dev/playground/r/2KTzr19/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_TESTING
+        version_id: 6xTDXv8
+        url: https://semgrep.dev/playground/r/6xTDXv8/python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_TESTING
         origin: community
   languages:
   - python
@@ -18805,10 +18807,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9540
-        rv_id: 110257
+        rv_id: 834480
         rule_id: 5rUOv1
-        version_id: yeTR2Xr
-        url: https://semgrep.dev/playground/r/yeTR2Xr/python.flask.security.audit.render-template-string.render-template-string
+        version_id: X0T5KQJ
+        url: https://semgrep.dev/playground/r/X0T5KQJ/python.flask.security.audit.render-template-string.render-template-string
         origin: community
   message: Found a template created with string formatting. This is susceptible to
     server-side template injection and cross-site scripting attacks.
@@ -18861,10 +18863,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9541
-        rv_id: 251895
+        rv_id: 834481
         rule_id: GdU7GR
-        version_id: 5PTk5OX
-        url: https://semgrep.dev/playground/r/5PTk5OX/python.flask.security.audit.secure-set-cookie.secure-set-cookie
+        version_id: jQTrjgL
+        url: https://semgrep.dev/playground/r/jQTrjgL/python.flask.security.audit.secure-set-cookie.secure-set-cookie
         origin: community
   languages:
   - python
@@ -18901,10 +18903,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9542
-        rv_id: 252100
+        rv_id: 834482
         rule_id: ReUgXz
-        version_id: A8TkY3P
-        url: https://semgrep.dev/playground/r/A8TkY3P/python.flask.security.audit.wtf-csrf-disabled.flask-wtf-csrf-disabled
+        version_id: 1QTPNOn
+        url: https://semgrep.dev/playground/r/1QTPNOn/python.flask.security.audit.wtf-csrf-disabled.flask-wtf-csrf-disabled
         origin: community
   severity: WARNING
   languages:
@@ -19009,10 +19011,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9543
-        rv_id: 110260
+        rv_id: 834483
         rule_id: AbUz6A
-        version_id: NdT3d1x
-        url: https://semgrep.dev/playground/r/NdT3d1x/python.flask.security.audit.xss.make-response-with-unknown-content.make-response-with-unknown-content
+        version_id: 9lTJ7d8
+        url: https://semgrep.dev/playground/r/9lTJ7d8/python.flask.security.audit.xss.make-response-with-unknown-content.make-response-with-unknown-content
         origin: community
   languages:
   - python
@@ -19044,10 +19046,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9526
-        rv_id: 110261
+        rv_id: 834484
         rule_id: v8UnZJ
-        version_id: kbTdx77
-        url: https://semgrep.dev/playground/r/kbTdx77/python.flask.security.dangerous-template-string.dangerous-template-string
+        version_id: yeTNgRb
+        url: https://semgrep.dev/playground/r/yeTNgRb/python.flask.security.dangerous-template-string.dangerous-template-string
         origin: community
   languages:
   - python
@@ -19132,10 +19134,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10126
-        rv_id: 110262
+        rv_id: 834485
         rule_id: NbUAeY
-        version_id: w8T9n32
-        url: https://semgrep.dev/playground/r/w8T9n32/python.flask.security.flask-api-method-string-format.flask-api-method-string-format
+        version_id: rxTDvyR
+        url: https://semgrep.dev/playground/r/rxTDvyR/python.flask.security.flask-api-method-string-format.flask-api-method-string-format
         origin: community
 - id: python.flask.security.injection.os-system-injection.os-system-injection
   languages:
@@ -19171,10 +19173,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9544
-        rv_id: 110266
+        rv_id: 834489
         rule_id: BYUN99
-        version_id: vdTYNk1
-        url: https://semgrep.dev/playground/r/vdTYNk1/python.flask.security.injection.os-system-injection.os-system-injection
+        version_id: w8TAb9r
+        url: https://semgrep.dev/playground/r/w8TAb9r/python.flask.security.injection.os-system-injection.os-system-injection
         origin: community
   pattern-either:
   - patterns:
@@ -19253,10 +19255,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9545
-        rv_id: 110267
+        rv_id: 834490
         rule_id: DbUpOQ
-        version_id: d6TrARQ
-        url: https://semgrep.dev/playground/r/d6TrARQ/python.flask.security.injection.path-traversal-open.path-traversal-open
+        version_id: xyTNrKP
+        url: https://semgrep.dev/playground/r/xyTNrKP/python.flask.security.injection.path-traversal-open.path-traversal-open
         origin: community
   pattern-either:
   - patterns:
@@ -19363,10 +19365,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9527
-        rv_id: 110275
+        rv_id: 834498
         rule_id: d8UjBO
-        version_id: QkTW0yZ
-        url: https://semgrep.dev/playground/r/QkTW0yZ/python.flask.security.insecure-deserialization.insecure-deserialization
+        version_id: 7ZTxRgA
+        url: https://semgrep.dev/playground/r/7ZTxRgA/python.flask.security.insecure-deserialization.insecure-deserialization
         origin: community
   message: Detected the use of an insecure deserialization library in a Flask route.
     These libraries are prone to code execution vulnerabilities. Ensure user data
@@ -19455,10 +19457,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9528
-        rv_id: 110276
+        rv_id: 834499
         rule_id: ZqU5LR
-        version_id: 3ZTkQJQ
-        url: https://semgrep.dev/playground/r/3ZTkQJQ/python.flask.security.open-redirect.open-redirect
+        version_id: LjTEeqw
+        url: https://semgrep.dev/playground/r/LjTEeqw/python.flask.security.open-redirect.open-redirect
         origin: community
   languages:
   - python
@@ -19496,10 +19498,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9529
-        rv_id: 110277
+        rv_id: 834500
         rule_id: nJUz6A
-        version_id: 44TRl36
-        url: https://semgrep.dev/playground/r/44TRl36/python.flask.security.secure-static-file-serve.avoid_send_file_without_path_sanitization
+        version_id: 8KTGlQd
+        url: https://semgrep.dev/playground/r/8KTGlQd/python.flask.security.secure-static-file-serve.avoid_send_file_without_path_sanitization
         origin: community
   languages:
   - python
@@ -19539,10 +19541,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9530
-        rv_id: 110278
+        rv_id: 834501
         rule_id: EwU293
-        version_id: PkTJ1LR
-        url: https://semgrep.dev/playground/r/PkTJ1LR/python.flask.security.unescaped-template-extension.unescaped-template-extension
+        version_id: gETyX3q
+        url: https://semgrep.dev/playground/r/gETyX3q/python.flask.security.unescaped-template-extension.unescaped-template-extension
         origin: community
   patterns:
   - pattern-not: flask.render_template("=~/.+\.html$/", ...)
@@ -19604,10 +19606,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9531
-        rv_id: 110279
+        rv_id: 834502
         rule_id: 7KUQLl
-        version_id: JdTNpgk
-        url: https://semgrep.dev/playground/r/JdTNpgk/python.flask.security.unsanitized-input.response-contains-unsanitized-input
+        version_id: QkTkNWy
+        url: https://semgrep.dev/playground/r/QkTkNWy/python.flask.security.unsanitized-input.response-contains-unsanitized-input
         origin: community
   languages:
   - python
@@ -19661,10 +19663,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9549
-        rv_id: 110280
+        rv_id: 834503
         rule_id: qNUjN2
-        version_id: 5PTdA57
-        url: https://semgrep.dev/playground/r/5PTdA57/python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+        version_id: 3ZT3wk9
+        url: https://semgrep.dev/playground/r/3ZT3wk9/python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
         origin: community
   languages:
   - python
@@ -19714,10 +19716,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9550
-        rv_id: 763840
+        rv_id: 834504
         rule_id: lBU95l
-        version_id: nWTGeDW
-        url: https://semgrep.dev/playground/r/nWTGeDW/python.flask.security.xss.audit.explicit-unescape-with-markup.explicit-unescape-with-markup
+        version_id: 44TQq7y
+        url: https://semgrep.dev/playground/r/44TQq7y/python.flask.security.xss.audit.explicit-unescape-with-markup.explicit-unescape-with-markup
         origin: community
   languages:
   - python
@@ -19766,10 +19768,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9551
-        rv_id: 110282
+        rv_id: 834505
         rule_id: YGURo6
-        version_id: RGTDkv9
-        url: https://semgrep.dev/playground/r/RGTDkv9/python.flask.security.xss.audit.template-autoescape-off.template-autoescape-off
+        version_id: PkTxGDJ
+        url: https://semgrep.dev/playground/r/PkTxGDJ/python.flask.security.xss.audit.template-autoescape-off.template-autoescape-off
         origin: community
   languages:
   - regex
@@ -19808,10 +19810,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9560
-        rv_id: 110288
+        rv_id: 834511
         rule_id: 9AU1zW
-        version_id: K3Tvjy9
-        url: https://semgrep.dev/playground/r/K3Tvjy9/python.jwt.security.audit.jwt-exposed-data.jwt-python-exposed-data
+        version_id: BjTeLxd
+        url: https://semgrep.dev/playground/r/BjTeLxd/python.jwt.security.audit.jwt-exposed-data.jwt-python-exposed-data
         origin: community
   languages:
   - python
@@ -19849,10 +19851,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9556
-        rv_id: 110289
+        rv_id: 834512
         rule_id: 2ZUb1L
-        version_id: qkT2xqz
-        url: https://semgrep.dev/playground/r/qkT2xqz/python.jwt.security.jwt-exposed-credentials.jwt-python-exposed-credentials
+        version_id: DkTGyqx
+        url: https://semgrep.dev/playground/r/DkTGyqx/python.jwt.security.jwt-exposed-credentials.jwt-python-exposed-credentials
         origin: community
   message: Password is exposed through JWT token payload. This is not encrypted and
     the password could be compromised. Do not store passwords in JWT tokens.
@@ -19918,10 +19920,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9559
-        rv_id: 110292
+        rv_id: 834515
         rule_id: 10UKjo
-        version_id: JdTNpgE
-        url: https://semgrep.dev/playground/r/JdTNpgE/python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
+        version_id: K3TrLnJ
+        url: https://semgrep.dev/playground/r/K3TrLnJ/python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
         origin: community
   fix: 'True
 
@@ -19963,10 +19965,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9630
-        rv_id: 110362
+        rv_id: 834585
         rule_id: nJUzeK
-        version_id: kbTdLKO
-        url: https://semgrep.dev/playground/r/kbTdLKO/python.lang.security.audit.conn_recv.multiprocessing-recv
+        version_id: yeTNgBr
+        url: https://semgrep.dev/playground/r/yeTNgBr/python.lang.security.audit.conn_recv.multiprocessing-recv
         origin: community
   pattern-either:
   - pattern: multiprocessing.connection.Connection.recv(...)
@@ -20014,10 +20016,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11940
-        rv_id: 110363
+        rv_id: 834586
         rule_id: 9AUkR3
-        version_id: w8T9D1K
-        url: https://semgrep.dev/playground/r/w8T9D1K/python.lang.security.audit.dangerous-annotations-usage.dangerous-annotations-usage
+        version_id: rxTDvo3
+        url: https://semgrep.dev/playground/r/rxTDvo3/python.lang.security.audit.dangerous-annotations-usage.dangerous-annotations-usage
         origin: community
   languages:
   - python
@@ -20081,10 +20083,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9634
-        rv_id: 110385
+        rv_id: 834607
         rule_id: 8GUj22
-        version_id: BjTXpW3
-        url: https://semgrep.dev/playground/r/BjTXpW3/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        version_id: JdTlRyk
+        url: https://semgrep.dev/playground/r/JdTlRyk/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         origin: community
   languages:
   - python
@@ -20128,10 +20130,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9635
-        rv_id: 110386
+        rv_id: 834608
         rule_id: gxU149
-        version_id: DkT6Yd0
-        url: https://semgrep.dev/playground/r/DkT6Yd0/python.lang.security.audit.eval-detected.eval-detected
+        version_id: 5PTyGO7
+        url: https://semgrep.dev/playground/r/5PTyGO7/python.lang.security.audit.eval-detected.eval-detected
         origin: community
   languages:
   - python
@@ -20174,10 +20176,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9636
-        rv_id: 110387
+        rv_id: 834609
         rule_id: QrUzKv
-        version_id: WrTW3zn
-        url: https://semgrep.dev/playground/r/WrTW3zn/python.lang.security.audit.exec-detected.exec-detected
+        version_id: GxTDX7Y
+        url: https://semgrep.dev/playground/r/GxTDX7Y/python.lang.security.audit.exec-detected.exec-detected
         origin: community
   languages:
   - python
@@ -20211,10 +20213,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9637
-        rv_id: 110388
+        rv_id: 834610
         rule_id: 3qUP9k
-        version_id: 0bTLexz
-        url: https://semgrep.dev/playground/r/0bTLexz/python.lang.security.audit.formatted-sql-query.formatted-sql-query
+        version_id: RGTKxg9
+        url: https://semgrep.dev/playground/r/RGTKxg9/python.lang.security.audit.formatted-sql-query.formatted-sql-query
         origin: community
   severity: WARNING
   languages:
@@ -20265,10 +20267,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9638
-        rv_id: 110389
+        rv_id: 834611
         rule_id: 4bUkv7
-        version_id: K3TvG2X
-        url: https://semgrep.dev/playground/r/K3TvG2X/python.lang.security.audit.ftplib.ftplib
+        version_id: A8T3lzL
+        url: https://semgrep.dev/playground/r/A8T3lzL/python.lang.security.audit.ftplib.ftplib
         origin: community
   severity: WARNING
   languages:
@@ -20311,10 +20313,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9639
-        rv_id: 110390
+        rv_id: 834612
         rule_id: PeUZAW
-        version_id: qkT2BYZ
-        url: https://semgrep.dev/playground/r/qkT2BYZ/python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument
+        version_id: BjTeLNG
+        url: https://semgrep.dev/playground/r/BjTeLNG/python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument
         origin: community
 - id: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
   message: The HTTPSConnection API has changed frequently with minor releases of Python.
@@ -20346,10 +20348,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9640
-        rv_id: 110391
+        rv_id: 834613
         rule_id: JDUy7y
-        version_id: l4T46Q7
-        url: https://semgrep.dev/playground/r/l4T46Q7/python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
+        version_id: DkTGyp3
+        url: https://semgrep.dev/playground/r/DkTGyp3/python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
         origin: community
   severity: WARNING
   languages:
@@ -20389,10 +20391,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9650
-        rv_id: 110393
+        rv_id: 834615
         rule_id: qNUjlR
-        version_id: JdTNv1q
-        url: https://semgrep.dev/playground/r/JdTNv1q/python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
+        version_id: 0bTw350
+        url: https://semgrep.dev/playground/r/0bTw350/python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
         origin: community
   severity: WARNING
   languages:
@@ -20457,10 +20459,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9651
-        rv_id: 110394
+        rv_id: 834616
         rule_id: lBU9BZ
-        version_id: 5PTdeJ5
-        url: https://semgrep.dev/playground/r/5PTdeJ5/python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
+        version_id: K3TrLb9
+        url: https://semgrep.dev/playground/r/K3TrLb9/python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
         origin: community
   languages:
   - python
@@ -20525,10 +20527,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9652
-        rv_id: 110395
+        rv_id: 834617
         rule_id: YGURXw
-        version_id: GxTv8L9
-        url: https://semgrep.dev/playground/r/GxTv8L9/python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
+        version_id: qkTQwjz
+        url: https://semgrep.dev/playground/r/qkTQwjz/python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
         origin: community
 - id: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
   fix-regex:
@@ -20567,10 +20569,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9653
-        rv_id: 110396
+        rv_id: 834618
         rule_id: 6JUjpG
-        version_id: RGTDRDO
-        url: https://semgrep.dev/playground/r/RGTDRDO/python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+        version_id: l4TyD9A
+        url: https://semgrep.dev/playground/r/l4TyD9A/python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
         origin: community
   languages:
   - python
@@ -20632,10 +20634,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9654
-        rv_id: 110397
+        rv_id: 834619
         rule_id: oqUeYJ
-        version_id: A8T9X99
-        url: https://semgrep.dev/playground/r/A8T9X99/python.lang.security.audit.insecure-transport.ssl.no-set-ciphers.no-set-ciphers
+        version_id: YDTlbR1
+        url: https://semgrep.dev/playground/r/YDTlbR1/python.lang.security.audit.insecure-transport.ssl.no-set-ciphers.no-set-ciphers
         origin: community
   languages:
   - python
@@ -20669,10 +20671,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9655
-        rv_id: 110398
+        rv_id: 834620
         rule_id: zdUkPQ
-        version_id: BjTXpXx
-        url: https://semgrep.dev/playground/r/BjTXpXx/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open-ftp.insecure-openerdirector-open-ftp
+        version_id: 6xTDXjr
+        url: https://semgrep.dev/playground/r/6xTDXjr/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open-ftp.insecure-openerdirector-open-ftp
         origin: community
   severity: WARNING
   languages:
@@ -20734,10 +20736,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9656
-        rv_id: 110399
+        rv_id: 834621
         rule_id: pKUO9Q
-        version_id: DkT6Y69
-        url: https://semgrep.dev/playground/r/DkT6Y69/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open.insecure-openerdirector-open
+        version_id: o5TB1ev
+        url: https://semgrep.dev/playground/r/o5TB1ev/python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open.insecure-openerdirector-open
         origin: community
   severity: WARNING
   languages:
@@ -20806,10 +20808,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9657
-        rv_id: 110400
+        rv_id: 834622
         rule_id: 2ZUbWA
-        version_id: WrTW3Wo
-        url: https://semgrep.dev/playground/r/WrTW3Wo/python.lang.security.audit.insecure-transport.urllib.insecure-request-object-ftp.insecure-request-object-ftp
+        version_id: zyTW3ko
+        url: https://semgrep.dev/playground/r/zyTW3ko/python.lang.security.audit.insecure-transport.urllib.insecure-request-object-ftp.insecure-request-object-ftp
         origin: community
   severity: WARNING
   languages:
@@ -20851,10 +20853,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9658
-        rv_id: 110401
+        rv_id: 834623
         rule_id: X5U8Bp
-        version_id: 0bTLeLE
-        url: https://semgrep.dev/playground/r/0bTLeLE/python.lang.security.audit.insecure-transport.urllib.insecure-request-object.insecure-request-object
+        version_id: pZTXDOE
+        url: https://semgrep.dev/playground/r/pZTXDOE/python.lang.security.audit.insecure-transport.urllib.insecure-request-object.insecure-request-object
         origin: community
   severity: WARNING
   languages:
@@ -20901,10 +20903,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9659
-        rv_id: 110402
+        rv_id: 834624
         rule_id: j2UvOG
-        version_id: K3TvGvY
-        url: https://semgrep.dev/playground/r/K3TvGvY/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen-ftp.insecure-urlopen-ftp
+        version_id: 2KT7Ob9
+        url: https://semgrep.dev/playground/r/2KT7Ob9/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen-ftp.insecure-urlopen-ftp
         origin: community
   severity: WARNING
   languages:
@@ -20946,10 +20948,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9660
-        rv_id: 110403
+        rv_id: 834625
         rule_id: 10UKgW
-        version_id: qkT2B2X
-        url: https://semgrep.dev/playground/r/qkT2B2X/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
+        version_id: X0T5K86
+        url: https://semgrep.dev/playground/r/X0T5K86/python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
         origin: community
   severity: WARNING
   languages:
@@ -20995,10 +20997,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9661
-        rv_id: 110404
+        rv_id: 834626
         rule_id: 9AU1DY
-        version_id: l4T464W
-        url: https://semgrep.dev/playground/r/l4T464W/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open-ftp.insecure-urlopener-open-ftp
+        version_id: jQTrjvX
+        url: https://semgrep.dev/playground/r/jQTrjvX/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open-ftp.insecure-urlopener-open-ftp
         origin: community
   severity: WARNING
   languages:
@@ -21060,10 +21062,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9662
-        rv_id: 110405
+        rv_id: 834627
         rule_id: yyUnwW
-        version_id: YDTpnpl
-        url: https://semgrep.dev/playground/r/YDTpnpl/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open.insecure-urlopener-open
+        version_id: 1QTPNKN
+        url: https://semgrep.dev/playground/r/1QTPNKN/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open.insecure-urlopener-open
         origin: community
   severity: WARNING
   languages:
@@ -21130,10 +21132,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9663
-        rv_id: 110406
+        rv_id: 834628
         rule_id: r6UrPp
-        version_id: 6xTvQvy
-        url: https://semgrep.dev/playground/r/6xTvQvy/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve-ftp.insecure-urlopener-retrieve-ftp
+        version_id: 9lTJ71b
+        url: https://semgrep.dev/playground/r/9lTJ71b/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve-ftp.insecure-urlopener-retrieve-ftp
         origin: community
   severity: WARNING
   languages:
@@ -21195,10 +21197,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9664
-        rv_id: 110407
+        rv_id: 834629
         rule_id: bwUw0n
-        version_id: o5Tg9gZ
-        url: https://semgrep.dev/playground/r/o5Tg9gZ/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve.insecure-urlopener-retrieve
+        version_id: yeTNgnr
+        url: https://semgrep.dev/playground/r/yeTNgnr/python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve.insecure-urlopener-retrieve
         origin: community
   severity: WARNING
   languages:
@@ -21265,10 +21267,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9665
-        rv_id: 110408
+        rv_id: 834630
         rule_id: NbUknL
-        version_id: zyTKDK8
-        url: https://semgrep.dev/playground/r/zyTKDK8/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve-ftp.insecure-urlretrieve-ftp
+        version_id: rxTDvr3
+        url: https://semgrep.dev/playground/r/rxTDvr3/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve-ftp.insecure-urlretrieve-ftp
         origin: community
   severity: WARNING
   languages:
@@ -21310,10 +21312,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9666
-        rv_id: 110409
+        rv_id: 834631
         rule_id: kxUk4N
-        version_id: pZT1L1L
-        url: https://semgrep.dev/playground/r/pZT1L1L/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve.insecure-urlretrieve
+        version_id: bZTBowq
+        url: https://semgrep.dev/playground/r/bZTBowq/python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve.insecure-urlretrieve
         origin: community
   severity: WARNING
   languages:
@@ -21364,10 +21366,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9667
-        rv_id: 110410
+        rv_id: 834632
         rule_id: wdUJQY
-        version_id: 2KTz3zv
-        url: https://semgrep.dev/playground/r/2KTz3zv/python.lang.security.audit.logging.listeneval.listen-eval
+        version_id: NdTBRkx
+        url: https://semgrep.dev/playground/r/NdTBRkx/python.lang.security.audit.logging.listeneval.listen-eval
         origin: community
   severity: WARNING
   pattern: logging.config.listen(...)
@@ -21406,10 +21408,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9642
-        rv_id: 110412
+        rv_id: 834634
         rule_id: GdU79Z
-        version_id: jQTgyg1
-        url: https://semgrep.dev/playground/r/jQTgyg1/python.lang.security.audit.mako-templates-detected.mako-templates-detected
+        version_id: w8TAbJ2
+        url: https://semgrep.dev/playground/r/w8TAbJ2/python.lang.security.audit.mako-templates-detected.mako-templates-detected
         origin: community
   languages:
   - python
@@ -21446,10 +21448,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9643
-        rv_id: 110413
+        rv_id: 834635
         rule_id: ReUg13
-        version_id: 1QTO7O3
-        url: https://semgrep.dev/playground/r/1QTO7O3/python.lang.security.audit.marshal.marshal-usage
+        version_id: xyTNrnJ
+        url: https://semgrep.dev/playground/r/xyTNrnJ/python.lang.security.audit.marshal.marshal-usage
         origin: community
   pattern-either:
   - pattern: marshal.dump(...)
@@ -21484,10 +21486,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9671
-        rv_id: 110417
+        rv_id: 834639
         rule_id: v8UnWQ
-        version_id: bZTb9bx
-        url: https://semgrep.dev/playground/r/bZTb9bx/python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
+        version_id: d6TKgzQ
+        url: https://semgrep.dev/playground/r/d6TKgzQ/python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
         origin: community
   languages:
   - python
@@ -21529,10 +21531,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12068
-        rv_id: 110418
+        rv_id: 834640
         rule_id: AbUGN5
-        version_id: NdT3o3E
-        url: https://semgrep.dev/playground/r/NdT3o3E/python.lang.security.audit.non-literal-import.non-literal-import
+        version_id: ZRTldq5
+        url: https://semgrep.dev/playground/r/ZRTldq5/python.lang.security.audit.non-literal-import.non-literal-import
         origin: community
   languages:
   - python
@@ -21573,10 +21575,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9644
-        rv_id: 110420
+        rv_id: 834642
         rule_id: AbUzbe
-        version_id: w8T9D9g
-        url: https://semgrep.dev/playground/r/w8T9D9g/python.lang.security.audit.paramiko-implicit-trust-host-key.paramiko-implicit-trust-host-key
+        version_id: ExTrW4Q
+        url: https://semgrep.dev/playground/r/ExTrW4Q/python.lang.security.audit.paramiko-implicit-trust-host-key.paramiko-implicit-trust-host-key
         origin: community
   languages:
   - python
@@ -21619,10 +21621,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9672
-        rv_id: 110419
+        rv_id: 834641
         rule_id: d8Uj9x
-        version_id: kbTdLdQ
-        url: https://semgrep.dev/playground/r/kbTdLdQ/python.lang.security.audit.paramiko.paramiko-exec-command.paramiko-exec-command
+        version_id: nWTyNYY
+        url: https://semgrep.dev/playground/r/nWTyNYY/python.lang.security.audit.paramiko.paramiko-exec-command.paramiko-exec-command
         origin: community
   severity: ERROR
   languages:
@@ -21664,10 +21666,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15185
-        rv_id: 110421
+        rv_id: 834643
         rule_id: nJUZRY
-        version_id: xyTKpKy
-        url: https://semgrep.dev/playground/r/xyTKpKy/python.lang.security.audit.python-reverse-shell.python-reverse-shell
+        version_id: 7ZTxRev
+        url: https://semgrep.dev/playground/r/7ZTxRev/python.lang.security.audit.python-reverse-shell.python-reverse-shell
         origin: community
   languages:
   - python
@@ -21707,10 +21709,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10309
-        rv_id: 110423
+        rv_id: 834645
         rule_id: DbUWRY
-        version_id: e1T030o
-        url: https://semgrep.dev/playground/r/e1T030o/python.lang.security.audit.sqli.aiopg-sqli.aiopg-sqli
+        version_id: 8KTGlEG
+        url: https://semgrep.dev/playground/r/8KTGlEG/python.lang.security.audit.sqli.aiopg-sqli.aiopg-sqli
         origin: community
   patterns:
   - pattern-either:
@@ -21823,10 +21825,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10310
-        rv_id: 110424
+        rv_id: 834646
         rule_id: WAUZqq
-        version_id: vdTY8YE
-        url: https://semgrep.dev/playground/r/vdTY8YE/python.lang.security.audit.sqli.asyncpg-sqli.asyncpg-sqli
+        version_id: gETyXWk
+        url: https://semgrep.dev/playground/r/gETyXWk/python.lang.security.audit.sqli.asyncpg-sqli.asyncpg-sqli
         origin: community
   patterns:
   - pattern-either:
@@ -21927,10 +21929,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10311
-        rv_id: 110425
+        rv_id: 834647
         rule_id: 0oUEKo
-        version_id: d6Trvr1
-        url: https://semgrep.dev/playground/r/d6Trvr1/python.lang.security.audit.sqli.pg8000-sqli.pg8000-sqli
+        version_id: QkTkN6Z
+        url: https://semgrep.dev/playground/r/QkTkN6Z/python.lang.security.audit.sqli.pg8000-sqli.pg8000-sqli
         origin: community
   patterns:
   - pattern-either:
@@ -22026,10 +22028,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10312
-        rv_id: 110426
+        rv_id: 834648
         rule_id: KxU4Kg
-        version_id: ZRTQpQ0
-        url: https://semgrep.dev/playground/r/ZRTQpQ0/python.lang.security.audit.sqli.psycopg-sqli.psycopg-sqli
+        version_id: 3ZT3wBQ
+        url: https://semgrep.dev/playground/r/3ZT3wBQ/python.lang.security.audit.sqli.psycopg-sqli.psycopg-sqli
         origin: community
   patterns:
   - pattern-either:
@@ -22085,6 +22087,58 @@ rules:
       metavariable: "$METHOD"
       regex: "^(execute|executemany|mogrify)$"
   severity: WARNING
+- id: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+  patterns:
+  - pattern: subprocess.$FUNC(..., shell=$TRUE, ...)
+  - metavariable-pattern:
+      metavariable: "$TRUE"
+      pattern: "True \n"
+  - pattern-not: subprocess.$FUNC("...", shell=True, ...)
+  - focus-metavariable: "$TRUE"
+  message: Found 'subprocess' function '$FUNC' with 'shell=True'. This is dangerous
+    because this call will spawn the command using a shell process. Doing so propagates
+    current shell settings and variables, which makes it much easier for a malicious
+    actor to execute commands. Use 'shell=False' instead.
+  fix: 'False
+
+    '
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    references:
+    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
+    - https://docs.python.org/3/library/subprocess.html
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: HIGH
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Command Injection
+    source: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+    shortlink: https://sg.run/J92w
+    semgrep.dev:
+      rule:
+        r_id: 9646
+        rv_id: 834650
+        rule_id: DbUpz2
+        version_id: PkTxGkR
+        url: https://semgrep.dev/playground/r/PkTxGkR/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+        origin: community
+  languages:
+  - python
+  severity: ERROR
 - id: python.lang.security.audit.system-wildcard-detected.system-wildcard-detected
   patterns:
   - pattern-either:
@@ -22123,10 +22177,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9647
-        rv_id: 110429
+        rv_id: 834651
         rule_id: WAUorE
-        version_id: 7ZTgng4
-        url: https://semgrep.dev/playground/r/7ZTgng4/python.lang.security.audit.system-wildcard-detected.system-wildcard-detected
+        version_id: JdTlRPk
+        url: https://semgrep.dev/playground/r/JdTlRPk/python.lang.security.audit.system-wildcard-detected.system-wildcard-detected
         origin: community
   languages:
   - python
@@ -22160,10 +22214,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9648
-        rv_id: 110430
+        rv_id: 834652
         rule_id: 0oU5Wl
-        version_id: LjTqAqb
-        url: https://semgrep.dev/playground/r/LjTqAqb/python.lang.security.audit.telnetlib.telnetlib
+        version_id: 5PTyG47
+        url: https://semgrep.dev/playground/r/5PTyG47/python.lang.security.audit.telnetlib.telnetlib
         origin: community
   severity: WARNING
   languages:
@@ -22204,10 +22258,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9649
-        rv_id: 110431
+        rv_id: 834653
         rule_id: KxUbNG
-        version_id: 8KTQyQl
-        url: https://semgrep.dev/playground/r/8KTQyQl/python.lang.security.audit.weak-ssl-version.weak-ssl-version
+        version_id: GxTDX0Y
+        url: https://semgrep.dev/playground/r/GxTDX0Y/python.lang.security.audit.weak-ssl-version.weak-ssl-version
         origin: community
   languages:
   - python
@@ -22280,10 +22334,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10065
-        rv_id: 110433
+        rv_id: 834655
         rule_id: 9AUOZP
-        version_id: QkTWwWO
-        url: https://semgrep.dev/playground/r/QkTWwWO/python.lang.security.dangerous-globals-use.dangerous-globals-use
+        version_id: A8T3lWL
+        url: https://semgrep.dev/playground/r/A8T3lWL/python.lang.security.dangerous-globals-use.dangerous-globals-use
         origin: community
   severity: WARNING
   languages:
@@ -22323,10 +22377,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12069
-        rv_id: 110440
+        rv_id: 834662
         rule_id: BYU7Kp
-        version_id: RGTDReO
-        url: https://semgrep.dev/playground/r/RGTDReO/python.lang.security.deserialization.avoid-jsonpickle.avoid-jsonpickle
+        version_id: l4TyDdA
+        url: https://semgrep.dev/playground/r/l4TyDdA/python.lang.security.deserialization.avoid-jsonpickle.avoid-jsonpickle
         origin: community
   message: Avoid using `jsonpickle`, which is known to lead to code execution vulnerabilities.
     When unpickling, the serialized data could be manipulated to run arbitrary code.
@@ -22362,10 +22416,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9673
-        rv_id: 110441
+        rv_id: 834663
         rule_id: ZqU5jZ
-        version_id: A8T9Xk9
-        url: https://semgrep.dev/playground/r/A8T9Xk9/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
+        version_id: YDTlbr1
+        url: https://semgrep.dev/playground/r/YDTlbr1/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
         origin: community
   languages:
   - python
@@ -22422,10 +22476,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9674
-        rv_id: 110442
+        rv_id: 834664
         rule_id: nJUzqK
-        version_id: BjTXpxx
-        url: https://semgrep.dev/playground/r/BjTXpxx/python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
+        version_id: JdTlRPE
+        url: https://semgrep.dev/playground/r/JdTlRPE/python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
         origin: community
   languages:
   - python
@@ -22463,10 +22517,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9676
-        rv_id: 110444
+        rv_id: 834666
         rule_id: 7KUQNL
-        version_id: WrTW3Oo
-        url: https://semgrep.dev/playground/r/WrTW3Oo/python.lang.security.deserialization.pickle.avoid-cPickle
+        version_id: GxTDX0N
+        url: https://semgrep.dev/playground/r/GxTDX0N/python.lang.security.deserialization.pickle.avoid-cPickle
         origin: community
   languages:
   - python
@@ -22505,10 +22559,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9677
-        rv_id: 110445
+        rv_id: 834667
         rule_id: L1Uy60
-        version_id: 0bTLeyE
-        url: https://semgrep.dev/playground/r/0bTLeyE/python.lang.security.deserialization.pickle.avoid-dill
+        version_id: RGTKxPy
+        url: https://semgrep.dev/playground/r/RGTKxPy/python.lang.security.deserialization.pickle.avoid-dill
         origin: community
   languages:
   - python
@@ -22547,10 +22601,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9675
-        rv_id: 110443
+        rv_id: 834665
         rule_id: EwU2BJ
-        version_id: DkT6Yq9
-        url: https://semgrep.dev/playground/r/DkT6Yq9/python.lang.security.deserialization.pickle.avoid-pickle
+        version_id: 5PTyG4j
+        url: https://semgrep.dev/playground/r/5PTyG4j/python.lang.security.deserialization.pickle.avoid-pickle
         origin: community
   languages:
   - python
@@ -22592,10 +22646,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9678
-        rv_id: 110446
+        rv_id: 834668
         rule_id: 8GUje2
-        version_id: K3TvGnY
-        url: https://semgrep.dev/playground/r/K3TvGnY/python.lang.security.deserialization.pickle.avoid-shelve
+        version_id: A8T3lWw
+        url: https://semgrep.dev/playground/r/A8T3lWw/python.lang.security.deserialization.pickle.avoid-shelve
         origin: community
   languages:
   - python
@@ -22641,10 +22695,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9625
-        rv_id: 110449
+        rv_id: 834671
         rule_id: OrU30g
-        version_id: YDTpnNl
-        url: https://semgrep.dev/playground/r/YDTpnNl/python.lang.security.insecure-hash-function.insecure-hash-function
+        version_id: WrTdnZn
+        url: https://semgrep.dev/playground/r/WrTdnZn/python.lang.security.insecure-hash-function.insecure-hash-function
         origin: community
   languages:
   - python
@@ -22687,10 +22741,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9627
-        rv_id: 110451
+        rv_id: 834672
         rule_id: v8UnkQ
-        version_id: o5Tg9kZ
-        url: https://semgrep.dev/playground/r/o5Tg9kZ/python.lang.security.unverified-ssl-context.unverified-ssl-context
+        version_id: 0bTw3Ez
+        url: https://semgrep.dev/playground/r/0bTw3Ez/python.lang.security.unverified-ssl-context.unverified-ssl-context
         origin: community
   severity: ERROR
   languages:
@@ -22724,10 +22778,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9628
-        rv_id: 110453
+        rv_id: 834674
         rule_id: d8UjRx
-        version_id: pZT1LkL
-        url: https://semgrep.dev/playground/r/pZT1LkL/python.lang.security.use-defused-xml.use-defused-xml
+        version_id: qkTQwoZ
+        url: https://semgrep.dev/playground/r/qkTQwoZ/python.lang.security.use-defused-xml.use-defused-xml
         origin: community
   message: The Python documentation recommends using `defusedxml` instead of `xml`
     because the native Python `xml` library is vulnerable to XML External Entity (XXE)
@@ -22771,10 +22825,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9629
-        rv_id: 110454
+        rv_id: 834675
         rule_id: ZqU5EZ
-        version_id: 2KTz3Gv
-        url: https://semgrep.dev/playground/r/2KTz3Gv/python.lang.security.use-defused-xmlrpc.use-defused-xmlrpc
+        version_id: l4TyDd7
+        url: https://semgrep.dev/playground/r/l4TyDd7/python.lang.security.use-defused-xmlrpc.use-defused-xmlrpc
         origin: community
   severity: ERROR
   languages:
@@ -22806,10 +22860,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9694
-        rv_id: 110490
+        rv_id: 834711
         rule_id: qNUoYR
-        version_id: K3TvGzY
-        url: https://semgrep.dev/playground/r/K3TvGzY/python.requests.security.disabled-cert-validation.disabled-cert-validation
+        version_id: RGTKxoy
+        url: https://semgrep.dev/playground/r/RGTKxoy/python.requests.security.disabled-cert-validation.disabled-cert-validation
         origin: community
   languages:
   - python
@@ -22860,10 +22914,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9695
-        rv_id: 110491
+        rv_id: 875836
         rule_id: lBUdQZ
-        version_id: qkT2B1X
-        url: https://semgrep.dev/playground/r/qkT2B1X/python.requests.security.no-auth-over-http.no-auth-over-http
+        version_id: 9lTAWq3
+        url: https://semgrep.dev/playground/r/9lTAWq3/python.requests.security.no-auth-over-http.no-auth-over-http
         origin: community
   languages:
   - python
@@ -22908,10 +22962,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9697
-        rv_id: 110492
+        rv_id: 834713
         rule_id: JDUP1G
-        version_id: l4T46rW
-        url: https://semgrep.dev/playground/r/l4T46rW/python.sh.security.string-concat.string-concat
+        version_id: BjTeL73
+        url: https://semgrep.dev/playground/r/BjTeL73/python.sh.security.string-concat.string-concat
         origin: community
   pattern-either:
   - pattern: sh.$BIN($X + $Y)
@@ -22979,10 +23033,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15824
-        rv_id: 253874
+        rv_id: 834718
         rule_id: r6U2wE
-        version_id: 2KTGW4q
-        url: https://semgrep.dev/playground/r/2KTGW4q/python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        version_id: qkTQwbZ
+        url: https://semgrep.dev/playground/r/qkTQwbZ/python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
         origin: community
   languages:
   - python
@@ -23023,10 +23077,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10563
-        rv_id: 110498
+        rv_id: 834719
         rule_id: oqUz5y
-        version_id: A8T9Xrg
-        url: https://semgrep.dev/playground/r/A8T9Xrg/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        version_id: l4TyDz7
+        url: https://semgrep.dev/playground/r/l4TyDz7/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
         origin: community
   severity: ERROR
   languages:
@@ -23086,10 +23140,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9706
-        rv_id: 110506
+        rv_id: 834728
         rule_id: KxU426
-        version_id: YDTpn6x
-        url: https://semgrep.dev/playground/r/YDTpn6x/ruby.jwt.security.audit.jwt-decode-without-verify.ruby-jwt-decode-without-verify
+        version_id: 1QTPNdK
+        url: https://semgrep.dev/playground/r/1QTPNdK/ruby.jwt.security.audit.jwt-decode-without-verify.ruby-jwt-decode-without-verify
         origin: community
   languages:
   - ruby
@@ -23129,10 +23183,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9707
-        rv_id: 110507
+        rv_id: 834729
         rule_id: qNUoYd
-        version_id: 6xTvQ54
-        url: https://semgrep.dev/playground/r/6xTvQ54/ruby.jwt.security.audit.jwt-exposed-data.ruby-jwt-exposed-data
+        version_id: 9lTJ7RO
+        url: https://semgrep.dev/playground/r/9lTJ7RO/ruby.jwt.security.audit.jwt-exposed-data.ruby-jwt-exposed-data
         origin: community
   languages:
   - ruby
@@ -23176,10 +23230,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9703
-        rv_id: 110508
+        rv_id: 834730
         rule_id: DbUWdB
-        version_id: o5Tg9yQ
-        url: https://semgrep.dev/playground/r/o5Tg9yQ/ruby.jwt.security.jwt-exposed-credentials.ruby-jwt-exposed-credentials
+        version_id: yeTNgPy
+        url: https://semgrep.dev/playground/r/yeTNgPy/ruby.jwt.security.jwt-exposed-credentials.ruby-jwt-exposed-credentials
         origin: community
   message: Password is exposed through JWT token payload. This is not encrypted and
     the password could be compromised. Do not store passwords in JWT tokens.
@@ -23223,10 +23277,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9704
-        rv_id: 729097
+        rv_id: 834731
         rule_id: WAUZz5
-        version_id: ExTq53v
-        url: https://semgrep.dev/playground/r/ExTq53v/ruby.jwt.security.jwt-hardcode.ruby-jwt-hardcoded-secret
+        version_id: rxTDvww
+        url: https://semgrep.dev/playground/r/rxTDvww/ruby.jwt.security.jwt-hardcode.ruby-jwt-hardcoded-secret
         origin: community
   patterns:
   - pattern-inside: |
@@ -23292,10 +23346,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9705
-        rv_id: 110510
+        rv_id: 834732
         rule_id: 0oUExR
-        version_id: pZT1L64
-        url: https://semgrep.dev/playground/r/pZT1L64/ruby.jwt.security.jwt-none-alg.ruby-jwt-none-alg
+        version_id: bZTBo8z
+        url: https://semgrep.dev/playground/r/bZTBo8z/ruby.jwt.security.jwt-none-alg.ruby-jwt-none-alg
         origin: community
   languages:
   - ruby
@@ -23336,10 +23390,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9709
-        rv_id: 110514
+        rv_id: 834736
         rule_id: YGUrq5
-        version_id: 1QTO7b6
-        url: https://semgrep.dev/playground/r/1QTO7b6/ruby.lang.security.cookie-serialization.cookie-serialization
+        version_id: xyTNrxZ
+        url: https://semgrep.dev/playground/r/xyTNrxZ/ruby.lang.security.cookie-serialization.cookie-serialization
         origin: community
   languages:
   - ruby
@@ -23384,10 +23438,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9710
-        rv_id: 110515
+        rv_id: 834737
         rule_id: 6JUqbn
-        version_id: 9lTd5op
-        url: https://semgrep.dev/playground/r/9lTd5op/ruby.lang.security.create-with.create-with
+        version_id: O9TJ76d
+        url: https://semgrep.dev/playground/r/O9TJ76d/ruby.lang.security.create-with.create-with
         origin: community
   languages:
   - ruby
@@ -23430,10 +23484,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9806
-        rv_id: 110517
+        rv_id: 834739
         rule_id: 0oUEyd
-        version_id: rxTy4o7
-        url: https://semgrep.dev/playground/r/rxTy4o7/ruby.lang.security.dangerous-open.dangerous-open
+        version_id: vdTOQ9X
+        url: https://semgrep.dev/playground/r/vdTOQ9X/ruby.lang.security.dangerous-open.dangerous-open
         origin: community
   severity: WARNING
   languages:
@@ -23476,10 +23530,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9807
-        rv_id: 110518
+        rv_id: 834740
         rule_id: KxU4nd
-        version_id: bZTb9Ke
-        url: https://semgrep.dev/playground/r/bZTb9Ke/ruby.lang.security.dangerous-open3-pipeline.dangerous-open3-pipeline
+        version_id: d6TKge8
+        url: https://semgrep.dev/playground/r/d6TKge8/ruby.lang.security.dangerous-open3-pipeline.dangerous-open3-pipeline
         origin: community
   severity: WARNING
   languages:
@@ -23520,10 +23574,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9827
-        rv_id: 110519
+        rv_id: 834741
         rule_id: OrUGn8
-        version_id: NdT3o9R
-        url: https://semgrep.dev/playground/r/NdT3o9R/ruby.lang.security.dangerous-subshell.dangerous-subshell
+        version_id: ZRTldOx
+        url: https://semgrep.dev/playground/r/ZRTldOx/ruby.lang.security.dangerous-subshell.dangerous-subshell
         origin: community
   severity: WARNING
   languages:
@@ -23558,10 +23612,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9808
-        rv_id: 110520
+        rv_id: 834742
         rule_id: qNUo50
-        version_id: kbTdLjG
-        url: https://semgrep.dev/playground/r/kbTdLjG/ruby.lang.security.dangerous-syscall.dangerous-syscall
+        version_id: nWTyNZk
+        url: https://semgrep.dev/playground/r/nWTyNZk/ruby.lang.security.dangerous-syscall.dangerous-syscall
         origin: community
   severity: WARNING
   languages:
@@ -23598,10 +23652,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9712
-        rv_id: 110522
+        rv_id: 834744
         rule_id: zdUyqE
-        version_id: xyTKpAo
-        url: https://semgrep.dev/playground/r/xyTKpAo/ruby.lang.security.file-disclosure.file-disclosure
+        version_id: 7ZTxRvY
+        url: https://semgrep.dev/playground/r/7ZTxRvY/ruby.lang.security.file-disclosure.file-disclosure
         origin: community
   languages:
   - ruby
@@ -23645,10 +23699,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9713
-        rv_id: 110523
+        rv_id: 834745
         rule_id: pKUGP7
-        version_id: O9TNdne
-        url: https://semgrep.dev/playground/r/O9TNdne/ruby.lang.security.filter-skipping.filter-skipping
+        version_id: LjTEe5x
+        url: https://semgrep.dev/playground/r/LjTEe5x/ruby.lang.security.filter-skipping.filter-skipping
         origin: community
   languages:
   - ruby
@@ -23692,10 +23746,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9715
-        rv_id: 110525
+        rv_id: 834747
         rule_id: X5UZWK
-        version_id: vdTY8p2
-        url: https://semgrep.dev/playground/r/vdTY8p2/ruby.lang.security.hardcoded-http-auth-in-controller.hardcoded-http-auth-in-controller
+        version_id: gETyXgv
+        url: https://semgrep.dev/playground/r/gETyXgv/ruby.lang.security.hardcoded-http-auth-in-controller.hardcoded-http-auth-in-controller
         origin: community
   languages:
   - ruby
@@ -23737,10 +23791,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9718
-        rv_id: 110530
+        rv_id: 834750
         rule_id: 9AUOQB
-        version_id: 7ZTgnQD
-        url: https://semgrep.dev/playground/r/7ZTgnQD/ruby.lang.security.json-entity-escape.json-entity-escape
+        version_id: 44TQq1w
+        url: https://semgrep.dev/playground/r/44TQq1w/ruby.lang.security.json-entity-escape.json-entity-escape
         origin: community
   languages:
   - ruby
@@ -23776,10 +23830,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9719
-        rv_id: 110531
+        rv_id: 834751
         rule_id: yyUvkJ
-        version_id: LjTqAy2
-        url: https://semgrep.dev/playground/r/LjTqAy2/ruby.lang.security.mass-assignment-protection-disabled.mass-assignment-protection-disabled
+        version_id: PkTxGol
+        url: https://semgrep.dev/playground/r/PkTxGol/ruby.lang.security.mass-assignment-protection-disabled.mass-assignment-protection-disabled
         origin: community
   severity: WARNING
   languages:
@@ -23830,10 +23884,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9720
-        rv_id: 110533
+        rv_id: 834753
         rule_id: r6UkO5
-        version_id: gET3O1W
-        url: https://semgrep.dev/playground/r/gET3O1W/ruby.lang.security.missing-csrf-protection.missing-csrf-protection
+        version_id: 5PTyGLj
+        url: https://semgrep.dev/playground/r/5PTyGLj/ruby.lang.security.missing-csrf-protection.missing-csrf-protection
         origin: community
   languages:
   - ruby
@@ -23867,10 +23921,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9721
-        rv_id: 110534
+        rv_id: 834754
         rule_id: bwUOAG
-        version_id: QkTWwzp
-        url: https://semgrep.dev/playground/r/QkTWwzp/ruby.lang.security.model-attr-accessible.model-attr-accessible
+        version_id: GxTDXrN
+        url: https://semgrep.dev/playground/r/GxTDXrN/ruby.lang.security.model-attr-accessible.model-attr-accessible
         origin: community
   languages:
   - ruby
@@ -23944,10 +23998,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9722
-        rv_id: 110535
+        rv_id: 834755
         rule_id: NbUADO
-        version_id: 3ZTkrPj
-        url: https://semgrep.dev/playground/r/3ZTkrPj/ruby.lang.security.model-attributes-attr-accessible.model-attributes-attr-accessible
+        version_id: RGTKx3y
+        url: https://semgrep.dev/playground/r/RGTKx3y/ruby.lang.security.model-attributes-attr-accessible.model-attributes-attr-accessible
         origin: community
   languages:
   - ruby
@@ -23982,10 +24036,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9727
-        rv_id: 110540
+        rv_id: 834757
         rule_id: eqUv0L
-        version_id: GxTv876
-        url: https://semgrep.dev/playground/r/GxTv876/ruby.lang.security.no-send.bad-send
+        version_id: BjTeLd3
+        url: https://semgrep.dev/playground/r/BjTeLd3/ruby.lang.security.no-send.bad-send
         origin: community
   languages:
   - ruby
@@ -24046,10 +24100,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9730
-        rv_id: 110543
+        rv_id: 834759
         rule_id: ZqUqQg
-        version_id: BjTXpNb
-        url: https://semgrep.dev/playground/r/BjTXpNb/ruby.lang.security.unprotected-mass-assign.mass-assignment-vuln
+        version_id: WrTdnyn
+        url: https://semgrep.dev/playground/r/WrTdnyn/ruby.lang.security.unprotected-mass-assign.mass-assignment-vuln
         origin: community
   languages:
   - ruby
@@ -24080,10 +24134,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16546
-        rv_id: 110554
+        rv_id: 834769
         rule_id: 8GUAo4
-        version_id: pZT1LO4
-        url: https://semgrep.dev/playground/r/pZT1LO4/ruby.rails.security.audit.detailed-exceptions.detailed-exceptions
+        version_id: A8T3le9
+        url: https://semgrep.dev/playground/r/A8T3le9/ruby.rails.security.audit.detailed-exceptions.detailed-exceptions
         origin: community
   message: Found that the setting for providing detailed exception reports in Rails
     is set to true. This can lead to information exposure, where sensitive system
@@ -24145,10 +24199,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16201
-        rv_id: 110568
+        rv_id: 834770
         rule_id: QrUnEk
-        version_id: e1T0386
-        url: https://semgrep.dev/playground/r/e1T0386/ruby.rails.security.audit.rails-skip-forgery-protection.rails-skip-forgery-protection
+        version_id: BjTeLzx
+        url: https://semgrep.dev/playground/r/BjTeLzx/ruby.rails.security.audit.rails-skip-forgery-protection.rails-skip-forgery-protection
         origin: community
 - id: ruby.rails.security.audit.xss.avoid-content-tag.avoid-content-tag
   metadata:
@@ -24180,10 +24234,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9734
-        rv_id: 110570
+        rv_id: 834772
         rule_id: L1U4qz
-        version_id: d6TrvjR
-        url: https://semgrep.dev/playground/r/d6TrvjR/ruby.rails.security.audit.xss.avoid-content-tag.avoid-content-tag
+        version_id: WrTdnNo
+        url: https://semgrep.dev/playground/r/WrTdnNo/ruby.rails.security.audit.xss.avoid-content-tag.avoid-content-tag
         origin: community
   message: "'content_tag()' bypasses HTML escaping for some portion of the content.
     If external data can reach here, this exposes your application to cross-site scripting
@@ -24220,10 +24274,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13589
-        rv_id: 110571
+        rv_id: 834773
         rule_id: qNUXYy
-        version_id: ZRTQp5j
-        url: https://semgrep.dev/playground/r/ZRTQp5j/ruby.rails.security.audit.xss.avoid-default-routes.avoid-default-routes
+        version_id: 0bTw3rE
+        url: https://semgrep.dev/playground/r/0bTw3rE/ruby.rails.security.audit.xss.avoid-default-routes.avoid-default-routes
         origin: community
   message: Default routes are enabled in this routes file. This means any public method
     on a controller can be called as an action. It is very easy to accidentally expose
@@ -24269,10 +24323,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9735
-        rv_id: 110572
+        rv_id: 834774
         rule_id: 8GUEQK
-        version_id: nWTxoYW
-        url: https://semgrep.dev/playground/r/nWTxoYW/ruby.rails.security.audit.xss.avoid-html-safe.avoid-html-safe
+        version_id: K3TrL5Y
+        url: https://semgrep.dev/playground/r/K3TrL5Y/ruby.rails.security.audit.xss.avoid-html-safe.avoid-html-safe
         origin: community
   message: "'html_safe()' does not make the supplied string safe. 'html_safe()' bypasses
     HTML escaping. If external data can reach here, this exposes your application
@@ -24313,10 +24367,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9736
-        rv_id: 110574
+        rv_id: 834776
         rule_id: gxUW3x
-        version_id: 7ZTgneD
-        url: https://semgrep.dev/playground/r/7ZTgneD/ruby.rails.security.audit.xss.avoid-raw.avoid-raw
+        version_id: l4TyDWW
+        url: https://semgrep.dev/playground/r/l4TyDWW/ruby.rails.security.audit.xss.avoid-raw.avoid-raw
         origin: community
   message: "'raw()' bypasses HTML escaping. If external data can reach here, this
     exposes your application to cross-site scripting (XSS) attacks. If you must do
@@ -24355,10 +24409,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9737
-        rv_id: 110577
+        rv_id: 834779
         rule_id: QrU6Ww
-        version_id: gET3OWW
-        url: https://semgrep.dev/playground/r/gET3OWW/ruby.rails.security.audit.xss.avoid-render-inline.avoid-render-inline
+        version_id: o5TB12Z
+        url: https://semgrep.dev/playground/r/o5TB12Z/ruby.rails.security.audit.xss.avoid-render-inline.avoid-render-inline
         origin: community
   message: "'render inline: ...' renders an entire ERB template inline and is dangerous.
     If external data can reach here, this exposes your application to server-side
@@ -24397,10 +24451,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9738
-        rv_id: 110578
+        rv_id: 834780
         rule_id: 3qUBk4
-        version_id: QkTWw6p
-        url: https://semgrep.dev/playground/r/QkTWw6p/ruby.rails.security.audit.xss.avoid-render-text.avoid-render-text
+        version_id: zyTW3n8
+        url: https://semgrep.dev/playground/r/zyTW3n8/ruby.rails.security.audit.xss.avoid-render-text.avoid-render-text
         origin: community
   message: "'render text: ...' actually sets the content-type to 'text/html'. If external
     data can reach here, this exposes your application to cross-site scripting (XSS)
@@ -24441,10 +24495,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9739
-        rv_id: 110579
+        rv_id: 834781
         rule_id: 4bUzR9
-        version_id: 3ZTkrBj
-        url: https://semgrep.dev/playground/r/3ZTkrBj/ruby.rails.security.audit.xss.manual-template-creation.manual-template-creation
+        version_id: pZTXDzL
+        url: https://semgrep.dev/playground/r/pZTXDzL/ruby.rails.security.audit.xss.manual-template-creation.manual-template-creation
         origin: community
   message: Detected manual creation of an ERB template. Manual creation of templates
     may expose your application to server-side template injection (SSTI) or cross-site
@@ -24488,10 +24542,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9740
-        rv_id: 110580
+        rv_id: 834782
         rule_id: PeUkJe
-        version_id: 44TR6zg
-        url: https://semgrep.dev/playground/r/44TR6zg/ruby.rails.security.audit.xss.templates.alias-for-html-safe.alias-for-html-safe
+        version_id: 2KT7OLv
+        url: https://semgrep.dev/playground/r/2KT7OLv/ruby.rails.security.audit.xss.templates.alias-for-html-safe.alias-for-html-safe
         origin: community
   languages:
   - generic
@@ -24536,10 +24590,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9741
-        rv_id: 110581
+        rv_id: 834783
         rule_id: JDUPNG
-        version_id: PkTJdkx
-        url: https://semgrep.dev/playground/r/PkTJdkx/ruby.rails.security.audit.xss.templates.avoid-content-tag.avoid-content-tag
+        version_id: X0T5Kg4
+        url: https://semgrep.dev/playground/r/X0T5Kg4/ruby.rails.security.audit.xss.templates.avoid-content-tag.avoid-content-tag
         origin: community
   languages:
   - generic
@@ -24584,10 +24638,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9742
-        rv_id: 110582
+        rv_id: 834784
         rule_id: 5rU4dE
-        version_id: JdTNvPo
-        url: https://semgrep.dev/playground/r/JdTNvPo/ruby.rails.security.audit.xss.templates.avoid-html-safe.avoid-html-safe
+        version_id: jQTrjQ1
+        url: https://semgrep.dev/playground/r/jQTrjQ1/ruby.rails.security.audit.xss.templates.avoid-html-safe.avoid-html-safe
         origin: community
   languages:
   - generic
@@ -24632,10 +24686,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9743
-        rv_id: 110583
+        rv_id: 834785
         rule_id: GdU0vJ
-        version_id: 5PTde49
-        url: https://semgrep.dev/playground/r/5PTde49/ruby.rails.security.audit.xss.templates.avoid-raw.avoid-raw
+        version_id: 1QTPN53
+        url: https://semgrep.dev/playground/r/1QTPN53/ruby.rails.security.audit.xss.templates.avoid-raw.avoid-raw
         origin: community
   languages:
   - generic
@@ -24678,10 +24732,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9745
-        rv_id: 110585
+        rv_id: 834787
         rule_id: AbUW9y
-        version_id: RGTDRPR
-        url: https://semgrep.dev/playground/r/RGTDRPR/ruby.rails.security.audit.xss.templates.unquoted-attribute.unquoted-attribute
+        version_id: yeTNgA5
+        url: https://semgrep.dev/playground/r/yeTNgA5/ruby.rails.security.audit.xss.templates.unquoted-attribute.unquoted-attribute
         origin: community
   languages:
   - generic
@@ -24733,10 +24787,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9746
-        rv_id: 110586
+        rv_id: 834788
         rule_id: BYUBXo
-        version_id: A8T9XWg
-        url: https://semgrep.dev/playground/r/A8T9XWg/ruby.rails.security.audit.xss.templates.var-in-href.var-in-href
+        version_id: rxTDv28
+        url: https://semgrep.dev/playground/r/rxTDv28/ruby.rails.security.audit.xss.templates.var-in-href.var-in-href
         origin: community
   languages:
   - generic
@@ -24783,10 +24837,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9747
-        rv_id: 110587
+        rv_id: 834789
         rule_id: DbUW6B
-        version_id: BjTXpBb
-        url: https://semgrep.dev/playground/r/BjTXpBb/ruby.rails.security.audit.xss.templates.var-in-script-tag.var-in-script-tag
+        version_id: bZTBozx
+        url: https://semgrep.dev/playground/r/bZTBozx/ruby.rails.security.audit.xss.templates.var-in-script-tag.var-in-script-tag
         origin: community
   languages:
   - generic
@@ -24845,10 +24899,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20153
-        rv_id: 110591
+        rv_id: 834793
         rule_id: KxUw3v
-        version_id: K3TvG4Q
-        url: https://semgrep.dev/playground/r/K3TvG4Q/ruby.rails.security.brakeman.check-cookie-store-session-security-attributes.check-cookie-store-session-security-attributes
+        version_id: xyTNrGy
+        url: https://semgrep.dev/playground/r/xyTNrGy/ruby.rails.security.brakeman.check-cookie-store-session-security-attributes.check-cookie-store-session-security-attributes
         origin: community
 - id: ruby.rails.security.brakeman.check-permit-attributes-high.check-permit-attributes-high
   patterns:
@@ -24887,10 +24941,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20044
-        rv_id: 110594
+        rv_id: 834796
         rule_id: 5rUNql
-        version_id: YDTpnrx
-        url: https://semgrep.dev/playground/r/YDTpnrx/ruby.rails.security.brakeman.check-permit-attributes-high.check-permit-attributes-high
+        version_id: vdTOQ4E
+        url: https://semgrep.dev/playground/r/vdTOQ4E/ruby.rails.security.brakeman.check-permit-attributes-high.check-permit-attributes-high
         origin: community
 - id: ruby.rails.security.brakeman.check-permit-attributes-medium.check-permit-attributes-medium
   patterns:
@@ -24929,10 +24983,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20045
-        rv_id: 110595
+        rv_id: 834797
         rule_id: GdUoq5
-        version_id: JdTNvPO
-        url: https://semgrep.dev/playground/r/JdTNvPO/ruby.rails.security.brakeman.check-permit-attributes-medium.check-permit-attributes-medium
+        version_id: d6TKg41
+        url: https://semgrep.dev/playground/r/d6TKg41/ruby.rails.security.brakeman.check-permit-attributes-medium.check-permit-attributes-medium
         origin: community
 - id: ruby.rails.security.brakeman.check-rails-secret-yaml.check-rails-secret-yaml
   paths:
@@ -24984,10 +25038,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20154
-        rv_id: 110596
+        rv_id: 834798
         rule_id: qNUpJ5
-        version_id: 5PTde4l
-        url: https://semgrep.dev/playground/r/5PTde4l/ruby.rails.security.brakeman.check-rails-secret-yaml.check-rails-secret-yaml
+        version_id: ZRTldG0
+        url: https://semgrep.dev/playground/r/ZRTldG0/ruby.rails.security.brakeman.check-rails-secret-yaml.check-rails-secret-yaml
         origin: community
 - id: rust.lang.security.args-os.args-os
   message: 'args_os should not be used for security operations. From the docs: "The
@@ -25014,10 +25068,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40104
-        rv_id: 110613
+        rv_id: 834814
         rule_id: DbUeEe
-        version_id: X0TQ2ZP
-        url: https://semgrep.dev/playground/r/X0TQ2ZP/rust.lang.security.args-os.args-os
+        version_id: BjTeLex
+        url: https://semgrep.dev/playground/r/BjTeLex/rust.lang.security.args-os.args-os
         origin: community
   languages:
   - rust
@@ -25047,10 +25101,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40105
-        rv_id: 110614
+        rv_id: 834815
         rule_id: WAU6Lk
-        version_id: jQTgyqZ
-        url: https://semgrep.dev/playground/r/jQTgyqZ/rust.lang.security.args.args
+        version_id: DkTGyG9
+        url: https://semgrep.dev/playground/r/DkTGyG9/rust.lang.security.args.args
         origin: community
   languages:
   - rust
@@ -25080,10 +25134,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40106
-        rv_id: 110615
+        rv_id: 834816
         rule_id: 0oU6nZ
-        version_id: 1QTO7Zg
-        url: https://semgrep.dev/playground/r/1QTO7Zg/rust.lang.security.current-exe.current-exe
+        version_id: WrTdndo
+        url: https://semgrep.dev/playground/r/WrTdndo/rust.lang.security.current-exe.current-exe
         origin: community
   languages:
   - rust
@@ -25118,10 +25172,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40107
-        rv_id: 110616
+        rv_id: 834817
         rule_id: KxUOxA
-        version_id: 9lTd5kQ
-        url: https://semgrep.dev/playground/r/9lTd5kQ/rust.lang.security.insecure-hashes.insecure-hashes
+        version_id: 0bTw3wE
+        url: https://semgrep.dev/playground/r/0bTw3wE/rust.lang.security.insecure-hashes.insecure-hashes
         origin: community
   languages:
   - rust
@@ -25176,10 +25230,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40109
-        rv_id: 110618
+        rv_id: 834819
         rule_id: lBUNEw
-        version_id: rxTy490
-        url: https://semgrep.dev/playground/r/rxTy490/rust.lang.security.reqwest-set-sensitive.reqwest-set-sensitive
+        version_id: qkTQwQX
+        url: https://semgrep.dev/playground/r/qkTQwQX/rust.lang.security.reqwest-set-sensitive.reqwest-set-sensitive
         origin: community
   languages:
   - rust
@@ -25211,10 +25265,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40112
-        rv_id: 110621
+        rv_id: 834822
         rule_id: oqU5AO
-        version_id: kbTdL8R
-        url: https://semgrep.dev/playground/r/kbTdL8R/rust.lang.security.temp-dir.temp-dir
+        version_id: 6xTDXDy
+        url: https://semgrep.dev/playground/r/6xTDXDy/rust.lang.security.temp-dir.temp-dir
         origin: community
   languages:
   - rust
@@ -25241,10 +25295,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40113
-        rv_id: 110622
+        rv_id: 834823
         rule_id: zdUezd
-        version_id: w8T9DGG
-        url: https://semgrep.dev/playground/r/w8T9DGG/rust.lang.security.unsafe-usage.unsafe-usage
+        version_id: o5TB1BZ
+        url: https://semgrep.dev/playground/r/o5TB1BZ/rust.lang.security.unsafe-usage.unsafe-usage
         origin: community
   languages:
   - rust
@@ -25297,10 +25351,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18282
-        rv_id: 110625
+        rv_id: 834826
         rule_id: JDUle4
-        version_id: e1T03pD
-        url: https://semgrep.dev/playground/r/e1T03pD/scala.lang.security.audit.dangerous-seq-run.dangerous-seq-run
+        version_id: 2KT7O7v
+        url: https://semgrep.dev/playground/r/2KT7O7v/scala.lang.security.audit.dangerous-seq-run.dangerous-seq-run
         origin: community
 - id: scala.lang.security.audit.dangerous-shell-run.dangerous-shell-run
   patterns:
@@ -25353,10 +25407,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18283
-        rv_id: 110626
+        rv_id: 834827
         rule_id: 5rUy3K
-        version_id: vdTY8jv
-        url: https://semgrep.dev/playground/r/vdTY8jv/scala.lang.security.audit.dangerous-shell-run.dangerous-shell-run
+        version_id: X0T5K54
+        url: https://semgrep.dev/playground/r/X0T5K54/scala.lang.security.audit.dangerous-shell-run.dangerous-shell-run
         origin: community
 - id: scala.lang.security.audit.dispatch-ssrf.dispatch-ssrf
   patterns:
@@ -25406,10 +25460,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18485
-        rv_id: 762651
+        rv_id: 834828
         rule_id: 5rUyl4
-        version_id: JdT6qJ7
-        url: https://semgrep.dev/playground/r/JdT6qJ7/scala.lang.security.audit.dispatch-ssrf.dispatch-ssrf
+        version_id: jQTrjr1
+        url: https://semgrep.dev/playground/r/jQTrjr1/scala.lang.security.audit.dispatch-ssrf.dispatch-ssrf
         origin: community
   languages:
   - scala
@@ -25441,10 +25495,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15190
-        rv_id: 110629
+        rv_id: 834830
         rule_id: gxUgDk
-        version_id: nWTxoro
-        url: https://semgrep.dev/playground/r/nWTxoro/scala.lang.security.audit.insecure-random.insecure-random
+        version_id: 9lTJ7J6
+        url: https://semgrep.dev/playground/r/9lTJ7J6/scala.lang.security.audit.insecure-random.insecure-random
         origin: community
   message: Flags the use of a predictable random value from `scala.util.Random`. This
     can lead to vulnerabilities when used in security contexts, such as in a CSRF
@@ -25506,10 +25560,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18486
-        rv_id: 762652
+        rv_id: 834831
         rule_id: GdUDOZ
-        version_id: 5PTp66J
-        url: https://semgrep.dev/playground/r/5PTp66J/scala.lang.security.audit.io-source-ssrf.io-source-ssrf
+        version_id: yeTNgN5
+        url: https://semgrep.dev/playground/r/yeTNgN5/scala.lang.security.audit.io-source-ssrf.io-source-ssrf
         origin: community
   languages:
   - scala
@@ -25544,10 +25598,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15191
-        rv_id: 110631
+        rv_id: 834832
         rule_id: QrUdOZ
-        version_id: 7ZTgnpB
-        url: https://semgrep.dev/playground/r/7ZTgnpB/scala.lang.security.audit.path-traversal-fromfile.path-traversal-fromfile
+        version_id: rxTDvD8
+        url: https://semgrep.dev/playground/r/rxTDvD8/scala.lang.security.audit.path-traversal-fromfile.path-traversal-fromfile
         origin: community
   message: Flags cases of possible path traversal. If an unfiltered parameter is passed
     into 'fromFile', file from an arbitrary filesystem location could be read. This
@@ -25610,10 +25664,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15192
-        rv_id: 110632
+        rv_id: 834833
         rule_id: 3qUj1Q
-        version_id: LjTqArR
-        url: https://semgrep.dev/playground/r/LjTqArR/scala.lang.security.audit.rsa-padding-set.rsa-padding-set
+        version_id: bZTBoBx
+        url: https://semgrep.dev/playground/r/bZTBoBx/scala.lang.security.audit.rsa-padding-set.rsa-padding-set
         origin: community
   message: Usage of RSA without OAEP (Optimal Asymmetric Encryption Padding) may weaken
     encryption. This could lead to sensitive data exposure. Instead, use RSA with
@@ -25704,10 +25758,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19042
-        rv_id: 110633
+        rv_id: 834834
         rule_id: KxUrkq
-        version_id: 8KTQyxg
-        url: https://semgrep.dev/playground/r/8KTQyxg/scala.lang.security.audit.sax-dtd-enabled.sax-dtd-enabled
+        version_id: NdTBRBE
+        url: https://semgrep.dev/playground/r/NdTBRBE/scala.lang.security.audit.sax-dtd-enabled.sax-dtd-enabled
         origin: community
 - id: scala.lang.security.audit.scala-dangerous-process-run.scala-dangerous-process-run
   patterns:
@@ -25775,10 +25829,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17329
-        rv_id: 110634
+        rv_id: 834835
         rule_id: 6JUEeo
-        version_id: gET3OY0
-        url: https://semgrep.dev/playground/r/gET3OY0/scala.lang.security.audit.scala-dangerous-process-run.scala-dangerous-process-run
+        version_id: kbT2P2Q
+        url: https://semgrep.dev/playground/r/kbT2P2Q/scala.lang.security.audit.scala-dangerous-process-run.scala-dangerous-process-run
         origin: community
 - id: scala.lang.security.audit.scalac-debug.scalac-debug
   patterns:
@@ -25817,10 +25871,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18686
-        rv_id: 110635
+        rv_id: 834836
         rule_id: JDUlE0
-        version_id: QkTWwpg
-        url: https://semgrep.dev/playground/r/QkTWwpg/scala.lang.security.audit.scalac-debug.scalac-debug
+        version_id: w8TAbAg
+        url: https://semgrep.dev/playground/r/w8TAbAg/scala.lang.security.audit.scalac-debug.scalac-debug
         origin: community
 - id: scala.lang.security.audit.scalaj-http-ssrf.scalaj-http-ssrf
   patterns:
@@ -25870,10 +25924,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18431
-        rv_id: 762653
+        rv_id: 834837
         rule_id: AbU3xA
-        version_id: GxTz22v
-        url: https://semgrep.dev/playground/r/GxTz22v/scala.lang.security.audit.scalaj-http-ssrf.scalaj-http-ssrf
+        version_id: xyTNrNy
+        url: https://semgrep.dev/playground/r/xyTNrNy/scala.lang.security.audit.scalaj-http-ssrf.scalaj-http-ssrf
         origin: community
   languages:
   - scala
@@ -25922,10 +25976,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19043
-        rv_id: 110639
+        rv_id: 834840
         rule_id: qNUQ7w
-        version_id: JdTNvQO
-        url: https://semgrep.dev/playground/r/JdTNvQO/scala.lang.security.audit.xmlinputfactory-dtd-enabled.xmlinputfactory-dtd-enabled
+        version_id: vdTOQOE
+        url: https://semgrep.dev/playground/r/vdTOQOE/scala.lang.security.audit.xmlinputfactory-dtd-enabled.xmlinputfactory-dtd-enabled
         origin: community
 - id: scala.play.security.webservice-ssrf.webservice-ssrf
   patterns:
@@ -25984,10 +26038,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18369
-        rv_id: 751092
+        rv_id: 834847
         rule_id: PeUxEE
-        version_id: YDTAbP2
-        url: https://semgrep.dev/playground/r/YDTAbP2/scala.play.security.webservice-ssrf.webservice-ssrf
+        version_id: 8KTGlGl
+        url: https://semgrep.dev/playground/r/8KTGlGl/scala.play.security.webservice-ssrf.webservice-ssrf
         origin: community
   languages:
   - scala
@@ -26025,10 +26079,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15079
-        rv_id: 110647
+        rv_id: 834848
         rule_id: OrU6W1
-        version_id: 0bTLeJn
-        url: https://semgrep.dev/playground/r/0bTLeJn/scala.scala-jwt.security.jwt-hardcode.scala-jwt-hardcoded-secret
+        version_id: gETyXy7
+        url: https://semgrep.dev/playground/r/gETyXy7/scala.scala-jwt.security.jwt-hardcode.scala-jwt-hardcoded-secret
         origin: community
   pattern-either:
   - pattern: 'com.auth0.jwt.algorithms.Algorithm.HMAC256("...");
@@ -26130,10 +26184,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17501
-        rv_id: 110648
+        rv_id: 834849
         rule_id: wdUA97
-        version_id: K3TvGY1
-        url: https://semgrep.dev/playground/r/K3TvGY1/scala.slick.security.scala-slick-overridesql-literal.scala-slick-overrideSql-literal
+        version_id: QkTkNkO
+        url: https://semgrep.dev/playground/r/QkTkNkO/scala.slick.security.scala-slick-overridesql-literal.scala-slick-overrideSql-literal
         origin: community
 - id: scala.slick.security.scala-slick-sql-non-literal.scala-slick-sql-non-literal
   patterns:
@@ -26177,10 +26231,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17502
-        rv_id: 110649
+        rv_id: 834850
         rule_id: x8UNKe
-        version_id: qkT2Bb8
-        url: https://semgrep.dev/playground/r/qkT2Bb8/scala.slick.security.scala-slick-sql-non-literal.scala-slick-sql-non-literal
+        version_id: 3ZT3w3N
+        url: https://semgrep.dev/playground/r/3ZT3w3N/scala.slick.security.scala-slick-sql-non-literal.scala-slick-sql-non-literal
         origin: community
 - id: solidity.security.no-bidi-characters.no-bidi-characters
   message: The code must not contain any of Unicode Direction Control Characters
@@ -26204,10 +26258,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67659
-        rv_id: 110687
+        rv_id: 834889
         rule_id: 5rUD6Z
-        version_id: A8T9XQO
-        url: https://semgrep.dev/playground/r/A8T9XQO/solidity.security.no-bidi-characters.no-bidi-characters
+        version_id: rxTDvj7
+        url: https://semgrep.dev/playground/r/rxTDvj7/solidity.security.no-bidi-characters.no-bidi-characters
         origin: community
   patterns:
   - pattern-either:
@@ -26253,10 +26307,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66514
-        rv_id: 110702
+        rv_id: 834904
         rule_id: lBUOZk
-        version_id: DkT6Y18
-        url: https://semgrep.dev/playground/r/DkT6Y18/swift.webview.webview-js-window.swift-webview-config-allows-js-open-windows
+        version_id: 8KTGlKj
+        url: https://semgrep.dev/playground/r/8KTGlKj/swift.webview.webview-js-window.swift-webview-config-allows-js-open-windows
         origin: community
   languages:
   - swift
@@ -26350,10 +26404,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17341
-        rv_id: 110726
+        rv_id: 834928
         rule_id: NbUXOA
-        version_id: e1T03rw
-        url: https://semgrep.dev/playground/r/e1T03rw/terraform.aws.security.aws-athena-workgroup-unencrypted.aws-athena-workgroup-unencrypted
+        version_id: X0T5KL1
+        url: https://semgrep.dev/playground/r/X0T5KL1/terraform.aws.security.aws-athena-workgroup-unencrypted.aws-athena-workgroup-unencrypted
         origin: community
 - id: terraform.aws.security.aws-backup-vault-unencrypted.aws-backup-vault-unencrypted
   patterns:
@@ -26394,10 +26448,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15122
-        rv_id: 110727
+        rv_id: 834929
         rule_id: x8UxrP
-        version_id: vdTY84K
-        url: https://semgrep.dev/playground/r/vdTY84K/terraform.aws.security.aws-backup-vault-unencrypted.aws-backup-vault-unencrypted
+        version_id: jQTrjzW
+        url: https://semgrep.dev/playground/r/jQTrjzW/terraform.aws.security.aws-backup-vault-unencrypted.aws-backup-vault-unencrypted
         origin: community
 - id: terraform.aws.security.aws-cloudtrail-encrypted-with-cmk.aws-cloudtrail-encrypted-with-cmk
   patterns:
@@ -26437,10 +26491,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17343
-        rv_id: 110729
+        rv_id: 834931
         rule_id: wdUl2j
-        version_id: ZRTQpG1
-        url: https://semgrep.dev/playground/r/ZRTQpG1/terraform.aws.security.aws-cloudtrail-encrypted-with-cmk.aws-cloudtrail-encrypted-with-cmk
+        version_id: 9lTJ7yp
+        url: https://semgrep.dev/playground/r/9lTJ7yp/terraform.aws.security.aws-cloudtrail-encrypted-with-cmk.aws-cloudtrail-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -26489,10 +26543,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17345
-        rv_id: 110731
+        rv_id: 834933
         rule_id: OrUl0J
-        version_id: ExTjAqL
-        url: https://semgrep.dev/playground/r/ExTjAqL/terraform.aws.security.aws-cloudwatch-log-group-unencrypted.aws-cloudwatch-log-group-unencrypted
+        version_id: rxTDv67
+        url: https://semgrep.dev/playground/r/rxTDv67/terraform.aws.security.aws-cloudwatch-log-group-unencrypted.aws-cloudwatch-log-group-unencrypted
         origin: community
 - id: terraform.aws.security.aws-codebuild-project-artifacts-unencrypted.aws-codebuild-project-artifacts-unencrypted
   patterns:
@@ -26553,10 +26607,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17346
-        rv_id: 110733
+        rv_id: 834935
         rule_id: eqUrdZ
-        version_id: LjTqAPO
-        url: https://semgrep.dev/playground/r/LjTqAPO/terraform.aws.security.aws-codebuild-project-artifacts-unencrypted.aws-codebuild-project-artifacts-unencrypted
+        version_id: NdTBRqR
+        url: https://semgrep.dev/playground/r/NdTBRqR/terraform.aws.security.aws-codebuild-project-artifacts-unencrypted.aws-codebuild-project-artifacts-unencrypted
         origin: community
 - id: terraform.aws.security.aws-config-aggregator-not-all-regions.aws-config-aggregator-not-all-regions
   pattern-either:
@@ -26610,10 +26664,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 47275
-        rv_id: 110735
+        rv_id: 834937
         rule_id: DbUo7v
-        version_id: gET3OJK
-        url: https://semgrep.dev/playground/r/gET3OJK/terraform.aws.security.aws-config-aggregator-not-all-regions.aws-config-aggregator-not-all-regions
+        version_id: w8TAbKL
+        url: https://semgrep.dev/playground/r/w8TAbKL/terraform.aws.security.aws-config-aggregator-not-all-regions.aws-config-aggregator-not-all-regions
         origin: community
 - id: terraform.aws.security.aws-docdb-encrypted-with-cmk.aws-docdb-encrypted-with-cmk
   patterns:
@@ -26653,10 +26707,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17349
-        rv_id: 110737
+        rv_id: 834939
         rule_id: ZqUGEp
-        version_id: 3ZTkr60
-        url: https://semgrep.dev/playground/r/3ZTkr60/terraform.aws.security.aws-docdb-encrypted-with-cmk.aws-docdb-encrypted-with-cmk
+        version_id: O9TJ7Xe
+        url: https://semgrep.dev/playground/r/O9TJ7Xe/terraform.aws.security.aws-docdb-encrypted-with-cmk.aws-docdb-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -26704,10 +26758,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48630
-        rv_id: 110738
+        rv_id: 834940
         rule_id: AbU1WN
-        version_id: 44TR6gP
-        url: https://semgrep.dev/playground/r/44TR6gP/terraform.aws.security.aws-documentdb-auditing-disabled.aws-documentdb-auditing-disabled
+        version_id: e1TDK96
+        url: https://semgrep.dev/playground/r/e1TDK96/terraform.aws.security.aws-documentdb-auditing-disabled.aws-documentdb-auditing-disabled
         origin: community
 - id: terraform.aws.security.aws-ebs-volume-encrypted-with-cmk.aws-ebs-volume-encrypted-with-cmk
   patterns:
@@ -26750,10 +26804,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17353
-        rv_id: 110744
+        rv_id: 834946
         rule_id: L1UPY9
-        version_id: A8T9Xe6
-        url: https://semgrep.dev/playground/r/A8T9Xe6/terraform.aws.security.aws-ebs-volume-encrypted-with-cmk.aws-ebs-volume-encrypted-with-cmk
+        version_id: 7ZTxRoD
+        url: https://semgrep.dev/playground/r/7ZTxRoD/terraform.aws.security.aws-ebs-volume-encrypted-with-cmk.aws-ebs-volume-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -26803,10 +26857,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 50759
-        rv_id: 110745
+        rv_id: 834947
         rule_id: YGUKl1
-        version_id: BjTXpzE
-        url: https://semgrep.dev/playground/r/BjTXpzE/terraform.aws.security.aws-ebs-volume-unencrypted.aws-ebs-volume-unencrypted
+        version_id: LjTEeQ2
+        url: https://semgrep.dev/playground/r/LjTEeQ2/terraform.aws.security.aws-ebs-volume-unencrypted.aws-ebs-volume-unencrypted
         origin: community
 - id: terraform.aws.security.aws-ec2-launch-template-metadata-service-v1-enabled.aws-ec2-launch-template-metadata-service-v1-enabled
   patterns:
@@ -26866,10 +26920,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 50762
-        rv_id: 110749
+        rv_id: 834951
         rule_id: zdU0Wo
-        version_id: K3TvGrv
-        url: https://semgrep.dev/playground/r/K3TvGrv/terraform.aws.security.aws-ec2-launch-template-metadata-service-v1-enabled.aws-ec2-launch-template-metadata-service-v1-enabled
+        version_id: 3ZT3wQj
+        url: https://semgrep.dev/playground/r/3ZT3wQj/terraform.aws.security.aws-ec2-launch-template-metadata-service-v1-enabled.aws-ec2-launch-template-metadata-service-v1-enabled
         origin: community
 - id: terraform.aws.security.aws-ecr-mutable-image-tags.aws-ecr-mutable-image-tags
   patterns:
@@ -26915,10 +26969,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48635
-        rv_id: 110753
+        rv_id: 834955
         rule_id: KxUB4o
-        version_id: 6xTvQDq
-        url: https://semgrep.dev/playground/r/6xTvQDq/terraform.aws.security.aws-ecr-mutable-image-tags.aws-ecr-mutable-image-tags
+        version_id: 5PTyGA9
+        url: https://semgrep.dev/playground/r/5PTyGA9/terraform.aws.security.aws-ecr-mutable-image-tags.aws-ecr-mutable-image-tags
         origin: community
 - id: terraform.aws.security.aws-efs-filesystem-encrypted-with-cmk.aws-efs-filesystem-encrypted-with-cmk
   patterns:
@@ -26961,10 +27015,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17355
-        rv_id: 110755
+        rv_id: 834957
         rule_id: gxUJ4n
-        version_id: zyTKDWY
-        url: https://semgrep.dev/playground/r/zyTKDWY/terraform.aws.security.aws-efs-filesystem-encrypted-with-cmk.aws-efs-filesystem-encrypted-with-cmk
+        version_id: RGTKxkR
+        url: https://semgrep.dev/playground/r/RGTKxkR/terraform.aws.security.aws-efs-filesystem-encrypted-with-cmk.aws-efs-filesystem-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27009,10 +27063,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17359
-        rv_id: 110760
+        rv_id: 834961
         rule_id: PeU0L7
-        version_id: 1QTO7PY
-        url: https://semgrep.dev/playground/r/1QTO7PY/terraform.aws.security.aws-emr-encrypted-with-cmk.aws-emr-encrypted-with-cmk
+        version_id: WrTdnQG
+        url: https://semgrep.dev/playground/r/WrTdnQG/terraform.aws.security.aws-emr-encrypted-with-cmk.aws-emr-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27057,10 +27111,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17360
-        rv_id: 110761
+        rv_id: 834962
         rule_id: JDU6gw
-        version_id: 9lTd5J5
-        url: https://semgrep.dev/playground/r/9lTd5J5/terraform.aws.security.aws-fsx-lustre-files-ystem.aws-fsx-lustre-filesystem-encrypted-with-cmk
+        version_id: 0bTw3lq
+        url: https://semgrep.dev/playground/r/0bTw3lq/terraform.aws.security.aws-fsx-lustre-files-ystem.aws-fsx-lustre-filesystem-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27104,10 +27158,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17361
-        rv_id: 110762
+        rv_id: 834963
         rule_id: 5rUp50
-        version_id: yeTRZNx
-        url: https://semgrep.dev/playground/r/yeTRZNx/terraform.aws.security.aws-fsx-lustre-filesystem-encrypted-with-cmk.aws-fsx-lustre-filesystem-encrypted-with-cmk
+        version_id: K3TrLjQ
+        url: https://semgrep.dev/playground/r/K3TrLjQ/terraform.aws.security.aws-fsx-lustre-filesystem-encrypted-with-cmk.aws-fsx-lustre-filesystem-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27150,10 +27204,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17362
-        rv_id: 110763
+        rv_id: 834964
         rule_id: GdUzwK
-        version_id: rxTy4D1
-        url: https://semgrep.dev/playground/r/rxTy4D1/terraform.aws.security.aws-fsx-ontapfs-encrypted-with-cmk.aws-fsx-ontapfs-encrypted-with-cmk
+        version_id: qkTQwxK
+        url: https://semgrep.dev/playground/r/qkTQwxK/terraform.aws.security.aws-fsx-ontapfs-encrypted-with-cmk.aws-fsx-ontapfs-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27196,10 +27250,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17363
-        rv_id: 110764
+        rv_id: 834965
         rule_id: ReUqv6
-        version_id: bZTb9BE
-        url: https://semgrep.dev/playground/r/bZTb9BE/terraform.aws.security.aws-fsx-windows-encrypted-with-cmk.aws-fsx-windows-encrypted-with-cmk
+        version_id: l4TyDve
+        url: https://semgrep.dev/playground/r/l4TyDve/terraform.aws.security.aws-fsx-windows-encrypted-with-cmk.aws-fsx-windows-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27242,10 +27296,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17367
-        rv_id: 110768
+        rv_id: 834969
         rule_id: WAUNxL
-        version_id: xyTKpN3
-        url: https://semgrep.dev/playground/r/xyTKpN3/terraform.aws.security.aws-imagebuilder-component-encrypted-with-cmk.aws-imagebuilder-component-encrypted-with-cmk
+        version_id: GxTDX65
+        url: https://semgrep.dev/playground/r/GxTDX65/terraform.aws.security.aws-imagebuilder-component-encrypted-with-cmk.aws-imagebuilder-component-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27288,10 +27342,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17369
-        rv_id: 110771
+        rv_id: 834972
         rule_id: KxU5yW
-        version_id: vdTY8OK
-        url: https://semgrep.dev/playground/r/vdTY8OK/terraform.aws.security.aws-kinesis-stream-encrypted-with-cmk.aws-kinesis-stream-encrypted-with-cmk
+        version_id: BjTeLrl
+        url: https://semgrep.dev/playground/r/BjTeLrl/terraform.aws.security.aws-kinesis-stream-encrypted-with-cmk.aws-kinesis-stream-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27342,10 +27396,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 52199
-        rv_id: 110772
+        rv_id: 834973
         rule_id: 8GU72N
-        version_id: d6TrvKN
-        url: https://semgrep.dev/playground/r/d6TrvKN/terraform.aws.security.aws-kinesis-stream-unencrypted.aws-kinesis-stream-unencrypted
+        version_id: DkTGynJ
+        url: https://semgrep.dev/playground/r/DkTGynJ/terraform.aws.security.aws-kinesis-stream-unencrypted.aws-kinesis-stream-unencrypted
         origin: community
 - id: terraform.aws.security.aws-kinesis-video-stream-encrypted-with-cmk.aws-kinesis-video-stream-encrypted-with-cmk
   patterns:
@@ -27385,10 +27439,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17370
-        rv_id: 110773
+        rv_id: 834974
         rule_id: qNUWqn
-        version_id: ZRTQpl1
-        url: https://semgrep.dev/playground/r/ZRTQpl1/terraform.aws.security.aws-kinesis-video-stream-encrypted-with-cmk.aws-kinesis-video-stream-encrypted-with-cmk
+        version_id: WrTdnQB
+        url: https://semgrep.dev/playground/r/WrTdnQB/terraform.aws.security.aws-kinesis-video-stream-encrypted-with-cmk.aws-kinesis-video-stream-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27453,10 +27507,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17374
-        rv_id: 110777
+        rv_id: 834978
         rule_id: 5rUp5w
-        version_id: LjTqAEO
-        url: https://semgrep.dev/playground/r/LjTqAEO/terraform.aws.security.aws-lambda-environment-unencrypted.aws-lambda-environment-unencrypted
+        version_id: l4TyDvO
+        url: https://semgrep.dev/playground/r/l4TyDvO/terraform.aws.security.aws-lambda-environment-unencrypted.aws-lambda-environment-unencrypted
         origin: community
 - id: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
   patterns:
@@ -27507,10 +27561,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 54773
-        rv_id: 110779
+        rv_id: 834980
         rule_id: eqUl1O
-        version_id: gET3OyK
-        url: https://semgrep.dev/playground/r/gET3OyK/terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+        version_id: 6xTDXJ9
+        url: https://semgrep.dev/playground/r/6xTDXJ9/terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
         origin: community
 - patterns:
   - pattern-either:
@@ -27561,10 +27615,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 70982
-        rv_id: 828676
+        rv_id: 834985
         rule_id: EwUxO1
-        version_id: xyTNkKb
-        url: https://semgrep.dev/playground/r/xyTNkKb/terraform.aws.security.aws-provisioner-exec.aws-provisioner-exec
+        version_id: X0T5KxP
+        url: https://semgrep.dev/playground/r/X0T5KxP/terraform.aws.security.aws-provisioner-exec.aws-provisioner-exec
         origin: community
 - id: terraform.aws.security.aws-redshift-cluster-encrypted-with-cmk.aws-redshift-cluster-encrypted-with-cmk
   patterns:
@@ -27605,10 +27659,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17376
-        rv_id: 110786
+        rv_id: 834987
         rule_id: ReUqvX
-        version_id: GxTv8DA
-        url: https://semgrep.dev/playground/r/GxTv8DA/terraform.aws.security.aws-redshift-cluster-encrypted-with-cmk.aws-redshift-cluster-encrypted-with-cmk
+        version_id: 1QTPNYg
+        url: https://semgrep.dev/playground/r/1QTPNYg/terraform.aws.security.aws-redshift-cluster-encrypted-with-cmk.aws-redshift-cluster-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27651,10 +27705,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17377
-        rv_id: 110787
+        rv_id: 834988
         rule_id: AbUeYR
-        version_id: RGTDRK5
-        url: https://semgrep.dev/playground/r/RGTDRK5/terraform.aws.security.aws-s3-bucket-object-encrypted-with-cmk.aws-s3-bucket-object-encrypted-with-cmk
+        version_id: 9lTJ75Q
+        url: https://semgrep.dev/playground/r/9lTJ75Q/terraform.aws.security.aws-s3-bucket-object-encrypted-with-cmk.aws-s3-bucket-object-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27697,10 +27751,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17378
-        rv_id: 110788
+        rv_id: 834989
         rule_id: BYUzYY
-        version_id: A8T9X36
-        url: https://semgrep.dev/playground/r/A8T9X36/terraform.aws.security.aws-s3-object-copy-encrypted-with-cmk.aws-s3-object-copy-encrypted-with-cmk
+        version_id: yeTNgZR
+        url: https://semgrep.dev/playground/r/yeTNgZR/terraform.aws.security.aws-s3-object-copy-encrypted-with-cmk.aws-s3-object-copy-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27743,10 +27797,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17379
-        rv_id: 110789
+        rv_id: 834990
         rule_id: DbUx8z
-        version_id: BjTXpeE
-        url: https://semgrep.dev/playground/r/BjTXpeE/terraform.aws.security.aws-sagemaker-domain-encrypted-with-cmk.aws-sagemaker-domain-encrypted-with-cmk
+        version_id: rxTDv40
+        url: https://semgrep.dev/playground/r/rxTDv40/terraform.aws.security.aws-sagemaker-domain-encrypted-with-cmk.aws-sagemaker-domain-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27796,10 +27850,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17380
-        rv_id: 110790
+        rv_id: 834991
         rule_id: WAUNrz
-        version_id: DkT6YG8
-        url: https://semgrep.dev/playground/r/DkT6YG8/terraform.aws.security.aws-secretsmanager-secret-unencrypted.aws-secretsmanager-secret-unencrypted
+        version_id: bZTBo9K
+        url: https://semgrep.dev/playground/r/bZTBo9K/terraform.aws.security.aws-secretsmanager-secret-unencrypted.aws-secretsmanager-secret-unencrypted
         origin: community
 - id: terraform.aws.security.aws-ssm-document-logging-issues.aws-ssm-document-logging-issues
   patterns:
@@ -27852,10 +27906,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17381
-        rv_id: 110795
+        rv_id: 834996
         rule_id: 0oUrWL
-        version_id: l4T46Xr
-        url: https://semgrep.dev/playground/r/l4T46Xr/terraform.aws.security.aws-ssm-document-logging-issues.aws-ssm-document-logging-issues
+        version_id: O9TJ7dl
+        url: https://semgrep.dev/playground/r/O9TJ7dl/terraform.aws.security.aws-ssm-document-logging-issues.aws-ssm-document-logging-issues
         origin: community
 - id: terraform.aws.security.aws-subnet-has-public-ip-address.aws-subnet-has-public-ip-address
   patterns:
@@ -27909,10 +27963,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 50764
-        rv_id: 110796
+        rv_id: 834997
         rule_id: 2ZUo79
-        version_id: YDTpnYR
-        url: https://semgrep.dev/playground/r/YDTpnYR/terraform.aws.security.aws-subnet-has-public-ip-address.aws-subnet-has-public-ip-address
+        version_id: e1TDK3D
+        url: https://semgrep.dev/playground/r/e1TDK3D/terraform.aws.security.aws-subnet-has-public-ip-address.aws-subnet-has-public-ip-address
         origin: community
 - id: terraform.aws.security.aws-timestream-database-encrypted-with-cmk.aws-timestream-database-encrypted-with-cmk
   patterns:
@@ -27952,10 +28006,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17382
-        rv_id: 110797
+        rv_id: 834998
         rule_id: KxU5Nn
-        version_id: JdTNvoP
-        url: https://semgrep.dev/playground/r/JdTNvoP/terraform.aws.security.aws-timestream-database-encrypted-with-cmk.aws-timestream-database-encrypted-with-cmk
+        version_id: vdTOQ8v
+        url: https://semgrep.dev/playground/r/vdTOQ8v/terraform.aws.security.aws-timestream-database-encrypted-with-cmk.aws-timestream-database-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -27999,10 +28053,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17383
-        rv_id: 110798
+        rv_id: 834999
         rule_id: qNUWl1
-        version_id: 5PTdeN8
-        url: https://semgrep.dev/playground/r/5PTdeN8/terraform.aws.security.aws-transfer-server-is-public.aws-transfer-server-is-public
+        version_id: d6TKgvP
+        url: https://semgrep.dev/playground/r/d6TKgvP/terraform.aws.security.aws-transfer-server-is-public.aws-transfer-server-is-public
         origin: community
   languages:
   - hcl
@@ -28050,10 +28104,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17384
-        rv_id: 110799
+        rv_id: 835000
         rule_id: lBUWB9
-        version_id: GxTv8or
-        url: https://semgrep.dev/playground/r/GxTv8or/terraform.aws.security.aws-workspaces-root-volume-unencrypted.aws-workspaces-root-volume-unencrypted
+        version_id: ZRTldpN
+        url: https://semgrep.dev/playground/r/ZRTldpN/terraform.aws.security.aws-workspaces-root-volume-unencrypted.aws-workspaces-root-volume-unencrypted
         origin: community
 - id: terraform.aws.security.aws-workspaces-user-volume-unencrypted.aws-workspaces-user-volume-unencrypted
   patterns:
@@ -28097,10 +28151,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17385
-        rv_id: 110800
+        rv_id: 835001
         rule_id: YGUAXr
-        version_id: RGTDR2q
-        url: https://semgrep.dev/playground/r/RGTDR2q/terraform.aws.security.aws-workspaces-user-volume-unencrypted.aws-workspaces-user-volume-unencrypted
+        version_id: nWTyNoo
+        url: https://semgrep.dev/playground/r/nWTyNoo/terraform.aws.security.aws-workspaces-user-volume-unencrypted.aws-workspaces-user-volume-unencrypted
         origin: community
 - id: terraform.aws.security.missing-athena-workgroup-encryption.missing-athena-workgroup-encryption
   patterns:
@@ -28143,10 +28197,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15828
-        rv_id: 110802
+        rv_id: 835003
         rule_id: wdUljO
-        version_id: BjTXpKK
-        url: https://semgrep.dev/playground/r/BjTXpKK/terraform.aws.security.missing-athena-workgroup-encryption.missing-athena-workgroup-encryption
+        version_id: 7ZTxRnB
+        url: https://semgrep.dev/playground/r/7ZTxRnB/terraform.aws.security.missing-athena-workgroup-encryption.missing-athena-workgroup-encryption
         origin: community
 - id: terraform.aws.security.unrestricted-github-oidc-policy.unrestricted-github-oidc-policy
   metadata:
@@ -28175,10 +28229,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 70983
-        rv_id: 110803
+        rv_id: 835004
         rule_id: 7KU3dr
-        version_id: DkT6Y2N
-        url: https://semgrep.dev/playground/r/DkT6Y2N/terraform.aws.security.unrestricted-github-oidc-policy.unrestricted-github-oidc-policy
+        version_id: LjTEeAR
+        url: https://semgrep.dev/playground/r/LjTEeAR/terraform.aws.security.unrestricted-github-oidc-policy.unrestricted-github-oidc-policy
         origin: community
   message: "`$POLICY` is missing a `condition` block which scopes users of this policy
     to specific GitHub repositories. Without this, `$POLICY` is open to all users
@@ -28267,10 +28321,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15101
-        rv_id: 110864
+        rv_id: 835065
         rule_id: WAUynd
-        version_id: rxTy46E
-        url: https://semgrep.dev/playground/r/rxTy46E/terraform.azure.security.appservice.appservice-account-identity-registered.appservice-account-identity-registered
+        version_id: qkTQwR8
+        url: https://semgrep.dev/playground/r/qkTQwR8/terraform.azure.security.appservice.appservice-account-identity-registered.appservice-account-identity-registered
         origin: community
   languages:
   - hcl
@@ -28315,10 +28369,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23969
-        rv_id: 110879
+        rv_id: 835080
         rule_id: v8UNL7
-        version_id: 8KTQyKe
-        url: https://semgrep.dev/playground/r/8KTQyKe/terraform.azure.security.appservice.azure-appservice-min-tls-version.azure-appservice-min-tls-version
+        version_id: YDTlbER
+        url: https://semgrep.dev/playground/r/YDTlbER/terraform.azure.security.appservice.azure-appservice-min-tls-version.azure-appservice-min-tls-version
         origin: community
   languages:
   - hcl
@@ -28381,10 +28435,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15107
-        rv_id: 110926
+        rv_id: 835127
         rule_id: 6JU1X8
-        version_id: xyTKppv
-        url: https://semgrep.dev/playground/r/xyTKppv/terraform.azure.security.functionapp.functionapp-authentication-enabled.functionapp-authentication-enabled
+        version_id: zyTW3BY
+        url: https://semgrep.dev/playground/r/zyTW3BY/terraform.azure.security.functionapp.functionapp-authentication-enabled.functionapp-authentication-enabled
         origin: community
   languages:
   - hcl
@@ -28444,10 +28498,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15108
-        rv_id: 110927
+        rv_id: 835128
         rule_id: oqU41L
-        version_id: O9TNddn
-        url: https://semgrep.dev/playground/r/O9TNddn/terraform.azure.security.functionapp.functionapp-enable-http2.functionapp-enable-http2
+        version_id: pZTXD2z
+        url: https://semgrep.dev/playground/r/pZTXD2z/terraform.azure.security.functionapp.functionapp-enable-http2.functionapp-enable-http2
         origin: community
   languages:
   - hcl
@@ -28509,10 +28563,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15136
-        rv_id: 110932
+        rv_id: 835133
         rule_id: 4bU1jy
-        version_id: nWTxooG
-        url: https://semgrep.dev/playground/r/nWTxooG/terraform.azure.security.keyvault.keyvault-specify-network-acl.keyvault-specify-network-acl
+        version_id: 9lTJ735
+        url: https://semgrep.dev/playground/r/9lTJ735/terraform.azure.security.keyvault.keyvault-specify-network-acl.keyvault-specify-network-acl
         origin: community
   languages:
   - hcl
@@ -28583,10 +28637,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15153
-        rv_id: 110933
+        rv_id: 835134
         rule_id: GdUreY
-        version_id: ExTjAAr
-        url: https://semgrep.dev/playground/r/ExTjAAr/terraform.azure.security.storage.storage-allow-microsoft-service-bypass.storage-allow-microsoft-service-bypass
+        version_id: yeTNgqx
+        url: https://semgrep.dev/playground/r/yeTNgqx/terraform.azure.security.storage.storage-allow-microsoft-service-bypass.storage-allow-microsoft-service-bypass
         origin: community
   languages:
   - hcl
@@ -28634,10 +28688,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15109
-        rv_id: 110934
+        rv_id: 835135
         rule_id: zdUY3N
-        version_id: 7ZTgnnb
-        url: https://semgrep.dev/playground/r/7ZTgnnb/terraform.azure.security.storage.storage-default-action-deny.storage-default-action-deny
+        version_id: rxTDvn1
+        url: https://semgrep.dev/playground/r/rxTDvn1/terraform.azure.security.storage.storage-default-action-deny.storage-default-action-deny
         origin: community
   languages:
   - hcl
@@ -28699,10 +28753,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15154
-        rv_id: 110936
+        rv_id: 835137
         rule_id: ReU3L9
-        version_id: 8KTQyy9
-        url: https://semgrep.dev/playground/r/8KTQyy9/terraform.azure.security.storage.storage-queue-services-logging.storage-queue-services-logging
+        version_id: NdTBR6G
+        url: https://semgrep.dev/playground/r/NdTBR6G/terraform.azure.security.storage.storage-queue-services-logging.storage-queue-services-logging
         origin: community
   languages:
   - hcl
@@ -28752,10 +28806,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9749
-        rv_id: 111050
+        rv_id: 835250
         rule_id: 0oUELR
-        version_id: WrTW381
-        url: https://semgrep.dev/playground/r/WrTW381/terraform.lang.security.ecr-image-scan-on-push.ecr-image-scan-on-push
+        version_id: LjTEeBY
+        url: https://semgrep.dev/playground/r/LjTEeBY/terraform.lang.security.ecr-image-scan-on-push.ecr-image-scan-on-push
         origin: community
 - id: terraform.lang.security.eks-insufficient-control-plane-logging.eks-insufficient-control-plane-logging
   patterns:
@@ -28810,10 +28864,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15829
-        rv_id: 111051
+        rv_id: 835251
         rule_id: x8UGx7
-        version_id: 0bTLeoA
-        url: https://semgrep.dev/playground/r/0bTLeoA/terraform.lang.security.eks-insufficient-control-plane-logging.eks-insufficient-control-plane-logging
+        version_id: 8KTGlne
+        url: https://semgrep.dev/playground/r/8KTGlne/terraform.lang.security.eks-insufficient-control-plane-logging.eks-insufficient-control-plane-logging
         origin: community
 - id: terraform.lang.security.eks-public-endpoint-enabled.eks-public-endpoint-enabled
   patterns:
@@ -28863,10 +28917,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9750
-        rv_id: 111052
+        rv_id: 835252
         rule_id: KxU4v6
-        version_id: K3TvGop
-        url: https://semgrep.dev/playground/r/K3TvGop/terraform.lang.security.eks-public-endpoint-enabled.eks-public-endpoint-enabled
+        version_id: gETyXnZ
+        url: https://semgrep.dev/playground/r/gETyXnZ/terraform.lang.security.eks-public-endpoint-enabled.eks-public-endpoint-enabled
         origin: community
 - id: terraform.lang.security.elastic-search-encryption-at-rest.elastic-search-encryption-at-rest
   patterns:
@@ -28915,10 +28969,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9751
-        rv_id: 111053
+        rv_id: 835253
         rule_id: qNUo2d
-        version_id: qkT2BON
-        url: https://semgrep.dev/playground/r/qkT2BON/terraform.lang.security.elastic-search-encryption-at-rest.elastic-search-encryption-at-rest
+        version_id: QkTkNgW
+        url: https://semgrep.dev/playground/r/QkTkNgW/terraform.lang.security.elastic-search-encryption-at-rest.elastic-search-encryption-at-rest
         origin: community
 - id: terraform.lang.security.iam.no-iam-admin-privileges.no-iam-admin-privileges
   pattern-either:
@@ -29025,10 +29079,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13560
-        rv_id: 111054
+        rv_id: 835254
         rule_id: NbUNDX
-        version_id: l4T46ZP
-        url: https://semgrep.dev/playground/r/l4T46ZP/terraform.lang.security.iam.no-iam-admin-privileges.no-iam-admin-privileges
+        version_id: 3ZT3wel
+        url: https://semgrep.dev/playground/r/3ZT3wel/terraform.lang.security.iam.no-iam-admin-privileges.no-iam-admin-privileges
         origin: community
   languages:
   - hcl
@@ -29259,10 +29313,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13561
-        rv_id: 378646
+        rv_id: 835255
         rule_id: kxUwK2
-        version_id: qkTjezP
-        url: https://semgrep.dev/playground/r/qkTjezP/terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
+        version_id: 44TQqGA
+        url: https://semgrep.dev/playground/r/44TQqGA/terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
         origin: community
   languages:
   - hcl
@@ -29401,10 +29455,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13562
-        rv_id: 378647
+        rv_id: 835256
         rule_id: wdUj1k
-        version_id: l4T92wK
-        url: https://semgrep.dev/playground/r/l4T92wK/terraform.lang.security.iam.no-iam-data-exfiltration.no-iam-data-exfiltration
+        version_id: PkTxGOZ
+        url: https://semgrep.dev/playground/r/PkTxGOZ/terraform.lang.security.iam.no-iam-data-exfiltration.no-iam-data-exfiltration
         origin: community
   languages:
   - hcl
@@ -29542,10 +29596,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13563
-        rv_id: 378648
+        rv_id: 835257
         rule_id: x8UxLq
-        version_id: YDTROjB
-        url: https://semgrep.dev/playground/r/YDTROjB/terraform.lang.security.iam.no-iam-priv-esc-funcs.no-iam-priv-esc-funcs
+        version_id: JdTlReP
+        url: https://semgrep.dev/playground/r/JdTlReP/terraform.lang.security.iam.no-iam-priv-esc-funcs.no-iam-priv-esc-funcs
         origin: community
   languages:
   - hcl
@@ -29672,10 +29726,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13564
-        rv_id: 378649
+        rv_id: 835258
         rule_id: OrU6jO
-        version_id: JdTyeAb
-        url: https://semgrep.dev/playground/r/JdTyeAb/terraform.lang.security.iam.no-iam-priv-esc-other-users.no-iam-priv-esc-other-users
+        version_id: 5PTyG38
+        url: https://semgrep.dev/playground/r/5PTyG38/terraform.lang.security.iam.no-iam-priv-esc-other-users.no-iam-priv-esc-other-users
         origin: community
   languages:
   - hcl
@@ -29836,10 +29890,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13565
-        rv_id: 378650
+        rv_id: 835259
         rule_id: eqUzR3
-        version_id: 5PTO30W
-        url: https://semgrep.dev/playground/r/5PTO30W/terraform.lang.security.iam.no-iam-priv-esc-roles.no-iam-priv-esc-roles
+        version_id: GxTDXJr
+        url: https://semgrep.dev/playground/r/GxTDXJr/terraform.lang.security.iam.no-iam-priv-esc-roles.no-iam-priv-esc-roles
         origin: community
   languages:
   - hcl
@@ -30997,10 +31051,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13566
-        rv_id: 378651
+        rv_id: 835260
         rule_id: v8U9r0
-        version_id: GxT7J51
-        url: https://semgrep.dev/playground/r/GxT7J51/terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
+        version_id: RGTKxrq
+        url: https://semgrep.dev/playground/r/RGTKxrq/terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
         origin: community
   languages:
   - hcl
@@ -31104,10 +31158,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13567
-        rv_id: 378652
+        rv_id: 835261
         rule_id: d8Uew3
-        version_id: RGTgrYj
-        url: https://semgrep.dev/playground/r/RGTgrYj/terraform.lang.security.iam.no-iam-star-actions.no-iam-star-actions
+        version_id: A8T3lL3
+        url: https://semgrep.dev/playground/r/A8T3lL3/terraform.lang.security.iam.no-iam-star-actions.no-iam-star-actions
         origin: community
   languages:
   - hcl
@@ -31149,10 +31203,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15831
-        rv_id: 111063
+        rv_id: 835263
         rule_id: eqUrzK
-        version_id: 1QTO7Ed
-        url: https://semgrep.dev/playground/r/1QTO7Ed/terraform.lang.security.rds-public-access.rds-public-access
+        version_id: DkTGyvN
+        url: https://semgrep.dev/playground/r/DkTGyvN/terraform.lang.security.rds-public-access.rds-public-access
         origin: community
 - id: terraform.lang.security.s3-cors-all-origins.all-origins-allowed
   patterns:
@@ -31186,10 +31240,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9752
-        rv_id: 111064
+        rv_id: 835264
         rule_id: lBUd4g
-        version_id: 9lTd53Z
-        url: https://semgrep.dev/playground/r/9lTd53Z/terraform.lang.security.s3-cors-all-origins.all-origins-allowed
+        version_id: WrTdnjQ
+        url: https://semgrep.dev/playground/r/WrTdnjQ/terraform.lang.security.s3-cors-all-origins.all-origins-allowed
         origin: community
 - id: terraform.lang.security.s3-public-read-bucket.s3-public-read-bucket
   patterns:
@@ -31232,10 +31286,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9753
-        rv_id: 111065
+        rv_id: 835265
         rule_id: YGUrp5
-        version_id: yeTRZqN
-        url: https://semgrep.dev/playground/r/yeTRZqN/terraform.lang.security.s3-public-read-bucket.s3-public-read-bucket
+        version_id: 0bTw39e
+        url: https://semgrep.dev/playground/r/0bTw39e/terraform.lang.security.s3-public-read-bucket.s3-public-read-bucket
         origin: community
 - id: typescript.lang.security.audit.cors-regex-wildcard.cors-regex-wildcard
   message: 'Unescaped ''.'' character in CORS domain regex $CORS: $PATTERN'
@@ -31262,10 +31316,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11929
-        rv_id: 111076
+        rv_id: 835276
         rule_id: qNUbXo
-        version_id: ZRTQpDy
-        url: https://semgrep.dev/playground/r/ZRTQpDy/typescript.lang.security.audit.cors-regex-wildcard.cors-regex-wildcard
+        version_id: DkTGyvo
+        url: https://semgrep.dev/playground/r/DkTGyvo/typescript.lang.security.audit.cors-regex-wildcard.cors-regex-wildcard
         origin: community
   languages:
   - ts
@@ -31312,10 +31366,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9757
-        rv_id: 111077
+        rv_id: 835277
         rule_id: pKUG17
-        version_id: nWTxoQd
-        url: https://semgrep.dev/playground/r/nWTxoQd/typescript.nestjs.security.audit.nestjs-header-cors-any.nestjs-header-cors-any
+        version_id: WrTdnj2
+        url: https://semgrep.dev/playground/r/WrTdnj2/typescript.nestjs.security.audit.nestjs-header-cors-any.nestjs-header-cors-any
         origin: community
   languages:
   - typescript
@@ -31366,10 +31420,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9758
-        rv_id: 111078
+        rv_id: 835278
         rule_id: 2ZU4zx
-        version_id: ExTjAeb
-        url: https://semgrep.dev/playground/r/ExTjAeb/typescript.nestjs.security.audit.nestjs-header-xss-disabled.nestjs-header-xss-disabled
+        version_id: 0bTw39Y
+        url: https://semgrep.dev/playground/r/0bTw39Y/typescript.nestjs.security.audit.nestjs-header-xss-disabled.nestjs-header-xss-disabled
         origin: community
   languages:
   - typescript
@@ -31408,10 +31462,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9759
-        rv_id: 111079
+        rv_id: 835279
         rule_id: X5UZQK
-        version_id: 7ZTgnKJ
-        url: https://semgrep.dev/playground/r/7ZTgnKJ/typescript.nestjs.security.audit.nestjs-open-redirect.nestjs-open-redirect
+        version_id: K3TrLQD
+        url: https://semgrep.dev/playground/r/K3TrLQD/typescript.nestjs.security.audit.nestjs-open-redirect.nestjs-open-redirect
         origin: community
   languages:
   - typescript
@@ -31455,10 +31509,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9773
-        rv_id: 111095
+        rv_id: 835292
         rule_id: d8Uzqz
-        version_id: 0bTLeGA
-        url: https://semgrep.dev/playground/r/0bTLeGA/typescript.react.security.audit.react-jwt-decoded-property.react-jwt-decoded-property
+        version_id: yeTNg56
+        url: https://semgrep.dev/playground/r/yeTNg56/typescript.react.security.audit.react-jwt-decoded-property.react-jwt-decoded-property
         origin: community
   languages:
   - typescript
@@ -31498,10 +31552,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9774
-        rv_id: 111096
+        rv_id: 835293
         rule_id: ZqUq6g
-        version_id: K3TvGgp
-        url: https://semgrep.dev/playground/r/K3TvGgp/typescript.react.security.audit.react-jwt-in-localstorage.react-jwt-in-localstorage
+        version_id: rxTDvGx
+        url: https://semgrep.dev/playground/r/rxTDvGx/typescript.react.security.audit.react-jwt-in-localstorage.react-jwt-in-localstorage
         origin: community
   languages:
   - typescript
@@ -31551,10 +31605,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9767
-        rv_id: 111107
+        rv_id: 835297
         rule_id: kxURd4
-        version_id: WrTW3Gy
-        url: https://semgrep.dev/playground/r/WrTW3Gy/typescript.react.security.react-markdown-insecure-html.react-markdown-insecure-html
+        version_id: w8TAb09
+        url: https://semgrep.dev/playground/r/w8TAb09/typescript.react.security.react-markdown-insecure-html.react-markdown-insecure-html
         origin: community
   languages:
   - typescript
@@ -31657,10 +31711,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10131
-        rv_id: 111109
+        rv_id: 835300
         rule_id: eqUvZ9
-        version_id: K3TvG8r
-        url: https://semgrep.dev/playground/r/K3TvG8r/yaml.docker-compose.security.exposing-docker-socket-volume.exposing-docker-socket-volume
+        version_id: e1TDKA8
+        url: https://semgrep.dev/playground/r/e1TDKA8/yaml.docker-compose.security.exposing-docker-socket-volume.exposing-docker-socket-volume
         origin: community
   languages:
   - yaml
@@ -31706,10 +31760,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10055
-        rv_id: 111112
+        rv_id: 835303
         rule_id: lBUdW3
-        version_id: YDTpnk2
-        url: https://semgrep.dev/playground/r/YDTpnk2/yaml.docker-compose.security.seccomp-confinement-disabled.seccomp-confinement-disabled
+        version_id: ZRTldyO
+        url: https://semgrep.dev/playground/r/ZRTldyO/yaml.docker-compose.security.seccomp-confinement-disabled.seccomp-confinement-disabled
         origin: community
   languages:
   - yaml
@@ -31756,10 +31810,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10056
-        rv_id: 111113
+        rv_id: 835304
         rule_id: YGUrAG
-        version_id: 6xTvQGQ
-        url: https://semgrep.dev/playground/r/6xTvQGQ/yaml.docker-compose.security.selinux-separation-disabled.selinux-separation-disabled
+        version_id: nWTyNwG
+        url: https://semgrep.dev/playground/r/nWTyNwG/yaml.docker-compose.security.selinux-separation-disabled.selinux-separation-disabled
         origin: community
   languages:
   - yaml
@@ -31814,10 +31868,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10132
-        rv_id: 111114
+        rv_id: 835305
         rule_id: v8U5vN
-        version_id: o5Tg9ob
-        url: https://semgrep.dev/playground/r/o5Tg9ob/yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service
+        version_id: ExTrWYr
+        url: https://semgrep.dev/playground/r/ExTrWYr/yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service
         origin: community
   languages:
   - yaml
@@ -31859,10 +31913,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14967
-        rv_id: 111116
+        rv_id: 835308
         rule_id: X5Udrd
-        version_id: pZT1Le2
-        url: https://semgrep.dev/playground/r/pZT1Le2/yaml.github-actions.security.curl-eval.curl-eval
+        version_id: 8KTGlL9
+        url: https://semgrep.dev/playground/r/8KTGlL9/yaml.github-actions.security.curl-eval.curl-eval
         origin: community
   patterns:
   - pattern-inside: 'steps: [...]'
@@ -31918,10 +31972,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13365
-        rv_id: 111118
+        rv_id: 835310
         rule_id: d8Ulkd
-        version_id: X0TQ2kn
-        url: https://semgrep.dev/playground/r/X0TQ2kn/yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout
+        version_id: QkTkNQG
+        url: https://semgrep.dev/playground/r/QkTkNQG/yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout
         origin: community
   patterns:
   - pattern-either:
@@ -31989,10 +32043,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13024
-        rv_id: 111128
+        rv_id: 835320
         rule_id: WAUP0z
-        version_id: xyTKp0E
-        url: https://semgrep.dev/playground/r/xyTKp0E/yaml.kubernetes.security.env.flask-debugging-enabled.flask-debugging-enabled
+        version_id: DkTGyeo
+        url: https://semgrep.dev/playground/r/DkTGyeo/yaml.kubernetes.security.env.flask-debugging-enabled.flask-debugging-enabled
         origin: community
   patterns:
   - pattern-inside: 'env: [...]
@@ -32036,10 +32090,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10236
-        rv_id: 111130
+        rv_id: 835322
         rule_id: nJUYPE
-        version_id: e1T03bQ
-        url: https://semgrep.dev/playground/r/e1T03bQ/yaml.kubernetes.security.hostipc-pod.hostipc-pod
+        version_id: 0bTw36Y
+        url: https://semgrep.dev/playground/r/0bTw36Y/yaml.kubernetes.security.hostipc-pod.hostipc-pod
         origin: community
   languages:
   - yaml
@@ -32077,10 +32131,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10237
-        rv_id: 111131
+        rv_id: 835323
         rule_id: EwU4NO
-        version_id: vdTY8ol
-        url: https://semgrep.dev/playground/r/vdTY8ol/yaml.kubernetes.security.hostnetwork-pod.hostnetwork-pod
+        version_id: K3TrLOD
+        url: https://semgrep.dev/playground/r/K3TrLOD/yaml.kubernetes.security.hostnetwork-pod.hostnetwork-pod
         origin: community
   languages:
   - yaml
@@ -32119,10 +32173,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10238
-        rv_id: 111132
+        rv_id: 835324
         rule_id: 7KUeo0
-        version_id: d6Trv7J
-        url: https://semgrep.dev/playground/r/d6Trv7J/yaml.kubernetes.security.hostpid-pod.hostpid-pod
+        version_id: qkTQwKE
+        url: https://semgrep.dev/playground/r/qkTQwKE/yaml.kubernetes.security.hostpid-pod.hostpid-pod
         origin: community
   languages:
   - yaml
@@ -32191,10 +32245,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26096
-        rv_id: 111137
+        rv_id: 835330
         rule_id: L1UAxy
-        version_id: LjTqA93
-        url: https://semgrep.dev/playground/r/LjTqA93/yaml.kubernetes.security.run-as-non-root-unsafe-value.run-as-non-root-unsafe-value
+        version_id: pZTXDQj
+        url: https://semgrep.dev/playground/r/pZTXDQj/yaml.kubernetes.security.run-as-non-root-unsafe-value.run-as-non-root-unsafe-value
         origin: community
   languages:
   - yaml
@@ -32273,10 +32327,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10134
-        rv_id: 111138
+        rv_id: 835331
         rule_id: ZqUqeK
-        version_id: 8KTQyg1
-        url: https://semgrep.dev/playground/r/8KTQyg1/yaml.kubernetes.security.run-as-non-root.run-as-non-root
+        version_id: 2KT7O6O
+        url: https://semgrep.dev/playground/r/2KT7O6O/yaml.kubernetes.security.run-as-non-root.run-as-non-root
         origin: community
   languages:
   - yaml
@@ -32332,10 +32386,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10135
-        rv_id: 111143
+        rv_id: 835336
         rule_id: nJUYn9
-        version_id: PkTJd2A
-        url: https://semgrep.dev/playground/r/PkTJd2A/yaml.kubernetes.security.writable-filesystem-container.writable-filesystem-container
+        version_id: yeTNgd6
+        url: https://semgrep.dev/playground/r/yeTNgd6/yaml.kubernetes.security.writable-filesystem-container.writable-filesystem-container
         origin: community
   languages:
   - yaml

--- a/assets/semgrep_rules/generated/nonfree/others.yaml
+++ b/assets/semgrep_rules/generated/nonfree/others.yaml
@@ -29,10 +29,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20149
-        rv_id: 109335
+        rv_id: 833560
         rule_id: BYUKJE
-        version_id: K3TvjOd
-        url: https://semgrep.dev/playground/r/K3TvjOd/generic.dockerfile.missing-zypper-no-confirm-switch.missing-zypper-no-confirm-switch
+        version_id: WrTdp55
+        url: https://semgrep.dev/playground/r/WrTdp55/generic.dockerfile.missing-zypper-no-confirm-switch.missing-zypper-no-confirm-switch
         origin: community
   paths:
     include:
@@ -59,10 +59,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14114
-        rv_id: 109969
+        rv_id: 834182
         rule_id: eqUz1k
-        version_id: LjTqQeA
-        url: https://semgrep.dev/playground/r/LjTqQeA/javascript.react.correctness.hooks.set-state-no-op.calling-set-state-on-current-state
+        version_id: rxTDz3d
+        url: https://semgrep.dev/playground/r/rxTDz3d/javascript.react.correctness.hooks.set-state-no-op.calling-set-state-on-current-state
         origin: community
 - id: ocaml.lang.compatibility.deprecated.deprecated-pervasives
   pattern: Pervasives.$X
@@ -80,10 +80,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9378
-        rv_id: 110016
+        rv_id: 834230
         rule_id: 3qUP1E
-        version_id: w8T9noW
-        url: https://semgrep.dev/playground/r/w8T9noW/ocaml.lang.compatibility.deprecated.deprecated-pervasives
+        version_id: w8TAxZx
+        url: https://semgrep.dev/playground/r/w8TAxZx/ocaml.lang.compatibility.deprecated.deprecated-pervasives
         origin: community
 - id: ocaml.lang.portability.crlf-support.broken-input-line
   pattern: 'input_line
@@ -107,10 +107,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12777
-        rv_id: 110025
+        rv_id: 834239
         rule_id: DbUKZX
-        version_id: 7ZTgo3q
-        url: https://semgrep.dev/playground/r/7ZTgo3q/ocaml.lang.portability.crlf-support.broken-input-line
+        version_id: 7ZTx92N
+        url: https://semgrep.dev/playground/r/7ZTx92N/ocaml.lang.portability.crlf-support.broken-input-line
         origin: community
 - id: ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
   pattern: open_in
@@ -132,10 +132,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12778
-        rv_id: 110026
+        rv_id: 834240
         rule_id: WAUPAJ
-        version_id: LjTqQgo
-        url: https://semgrep.dev/playground/r/LjTqQgo/ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
+        version_id: LjTEb1N
+        url: https://semgrep.dev/playground/r/LjTEb1N/ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
         origin: community
 - id: ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
   pattern: open_out
@@ -157,10 +157,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12779
-        rv_id: 110027
+        rv_id: 834241
         rule_id: 0oUJY9
-        version_id: 8KTQ9rJ
-        url: https://semgrep.dev/playground/r/8KTQ9rJ/ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
+        version_id: 8KTGkdQ
+        url: https://semgrep.dev/playground/r/8KTGkdQ/ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
         origin: community
 - id: ocaml.lang.portability.slash-tmp.not-portable-tmp-string
   pattern: '"=~/\/tmp/"
@@ -180,10 +180,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12786
-        rv_id: 110028
+        rv_id: 834242
         rule_id: zdU100
-        version_id: gET3x7z
-        url: https://semgrep.dev/playground/r/gET3x7z/ocaml.lang.portability.slash-tmp.not-portable-tmp-string
+        version_id: gETy2b6
+        url: https://semgrep.dev/playground/r/gETy2b6/ocaml.lang.portability.slash-tmp.not-portable-tmp-string
         origin: community
 - id: python.flask.caching.query-string.flask-cache-query-string
   patterns:
@@ -235,10 +235,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9521
-        rv_id: 110244
+        rv_id: 834467
         rule_id: kxUko3
-        version_id: K3Tvjl9
-        url: https://semgrep.dev/playground/r/K3Tvjl9/python.flask.caching.query-string.flask-cache-query-string
+        version_id: BjTeLXd
+        url: https://semgrep.dev/playground/r/BjTeLXd/python.flask.caching.query-string.flask-cache-query-string
         origin: community
 - id: python.lang.compatibility.python36.python36-compatibility-Popen1
   pattern: subprocess.Popen(errors=$X, ...)
@@ -256,10 +256,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9573
-        rv_id: 110307
+        rv_id: 834530
         rule_id: nJUz7A
-        version_id: zyTK8RP
-        url: https://semgrep.dev/playground/r/zyTK8RP/python.lang.compatibility.python36.python36-compatibility-Popen1
+        version_id: bZTBoRg
+        url: https://semgrep.dev/playground/r/bZTBoRg/python.lang.compatibility.python36.python36-compatibility-Popen1
         origin: community
 - id: python.lang.compatibility.python36.python36-compatibility-Popen2
   pattern: subprocess.Popen(encoding=$X, ...)
@@ -277,10 +277,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9574
-        rv_id: 110308
+        rv_id: 834531
         rule_id: EwU2n3
-        version_id: pZT1y9P
-        url: https://semgrep.dev/playground/r/pZT1y9P/python.lang.compatibility.python36.python36-compatibility-Popen2
+        version_id: NdTBRgK
+        url: https://semgrep.dev/playground/r/NdTBRgK/python.lang.compatibility.python36.python36-compatibility-Popen2
         origin: community
 - id: python.lang.compatibility.python36.python36-compatibility-ssl
   pattern: ssl.get_ciphers()
@@ -298,10 +298,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9572
-        rv_id: 110306
+        rv_id: 834529
         rule_id: ZqU5wR
-        version_id: o5Tglxx
-        url: https://semgrep.dev/playground/r/o5Tglxx/python.lang.compatibility.python36.python36-compatibility-ssl
+        version_id: rxTDv0R
+        url: https://semgrep.dev/playground/r/rxTDv0R/python.lang.compatibility.python36.python36-compatibility-ssl
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-httpconn
   pattern: http.client.HTTPConnection(blocksize=$X,...)
@@ -321,10 +321,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9577
-        rv_id: 110311
+        rv_id: 834534
         rule_id: 8GUjbX
-        version_id: jQTgYO6
-        url: https://semgrep.dev/playground/r/jQTgYO6/python.lang.compatibility.python37.python37-compatibility-httpconn
+        version_id: xyTNrvP
+        url: https://semgrep.dev/playground/r/xyTNrvP/python.lang.compatibility.python37.python37-compatibility-httpconn
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-httpsconn
   pattern: http.client.HTTPSConnection(blocksize=$X,...)
@@ -344,10 +344,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9578
-        rv_id: 110312
+        rv_id: 834535
         rule_id: gxU1qd
-        version_id: 1QTOYgK
-        url: https://semgrep.dev/playground/r/1QTOYgK/python.lang.compatibility.python37.python37-compatibility-httpsconn
+        version_id: O9TJ7k1
+        url: https://semgrep.dev/playground/r/O9TJ7k1/python.lang.compatibility.python37.python37-compatibility-httpsconn
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-importlib
   pattern: importlib.source_hash()
@@ -367,10 +367,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9575
-        rv_id: 110309
+        rv_id: 834532
         rule_id: 7KUQOl
-        version_id: 2KTzrWz
-        url: https://semgrep.dev/playground/r/2KTzrWz/python.lang.compatibility.python37.python37-compatibility-importlib
+        version_id: kbT2PgE
+        url: https://semgrep.dev/playground/r/kbT2PgE/python.lang.compatibility.python37.python37-compatibility-importlib
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-importlib2
   pattern: import importlib.resources
@@ -390,10 +390,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9576
-        rv_id: 110310
+        rv_id: 834533
         rule_id: L1Uy0n
-        version_id: X0TQxBO
-        url: https://semgrep.dev/playground/r/X0TQxBO/python.lang.compatibility.python37.python37-compatibility-importlib2
+        version_id: w8TAb6r
+        url: https://semgrep.dev/playground/r/w8TAb6r/python.lang.compatibility.python37.python37-compatibility-importlib2
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-importlib3
   pattern: import importlib.abc.ResourceReader
@@ -413,10 +413,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9579
-        rv_id: 110313
+        rv_id: 834536
         rule_id: QrUzJ9
-        version_id: 9lTdWDO
-        url: https://semgrep.dev/playground/r/9lTdWDO/python.lang.compatibility.python37.python37-compatibility-importlib3
+        version_id: e1TDKgJ
+        url: https://semgrep.dev/playground/r/e1TDKgJ/python.lang.compatibility.python37.python37-compatibility-importlib3
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-ipv4network1
   pattern: ipaddress.IPv4Network.subnet_of($X)
@@ -435,10 +435,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9583
-        rv_id: 110317
+        rv_id: 834540
         rule_id: JDUyqR
-        version_id: NdT3dnB
-        url: https://semgrep.dev/playground/r/NdT3dnB/python.lang.compatibility.python37.python37-compatibility-ipv4network1
+        version_id: nWTyNOL
+        url: https://semgrep.dev/playground/r/nWTyNOL/python.lang.compatibility.python37.python37-compatibility-ipv4network1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-ipv4network2
   pattern: ipaddress.IPv4Network.supernet_of($X)
@@ -457,10 +457,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9584
-        rv_id: 110318
+        rv_id: 834541
         rule_id: 5rUO61
-        version_id: kbTdx4O
-        url: https://semgrep.dev/playground/r/kbTdx4O/python.lang.compatibility.python37.python37-compatibility-ipv4network2
+        version_id: ExTrWRw
+        url: https://semgrep.dev/playground/r/ExTrWRw/python.lang.compatibility.python37.python37-compatibility-ipv4network2
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-ipv6network1
   pattern: ipaddress.IPv6Network.subnet_of($X)
@@ -479,10 +479,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9581
-        rv_id: 110315
+        rv_id: 834538
         rule_id: 4bUko0
-        version_id: rxTyLPw
-        url: https://semgrep.dev/playground/r/rxTyLPw/python.lang.compatibility.python37.python37-compatibility-ipv6network1
+        version_id: d6TKgqG
+        url: https://semgrep.dev/playground/r/d6TKgqG/python.lang.compatibility.python37.python37-compatibility-ipv6network1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-ipv6network2
   pattern: ipaddress.IPv6Network.supernet_of($X)
@@ -501,10 +501,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9582
-        rv_id: 110316
+        rv_id: 834539
         rule_id: PeUZYr
-        version_id: bZTb10z
-        url: https://semgrep.dev/playground/r/bZTb10z/python.lang.compatibility.python37.python37-compatibility-ipv6network2
+        version_id: ZRTld6d
+        url: https://semgrep.dev/playground/r/ZRTld6d/python.lang.compatibility.python37.python37-compatibility-ipv6network2
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-locale1
   pattern: locale.format_string(monetary=$X, ...)
@@ -524,10 +524,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9585
-        rv_id: 110319
+        rv_id: 834542
         rule_id: GdU72R
-        version_id: w8T9nQK
-        url: https://semgrep.dev/playground/r/w8T9nQK/python.lang.compatibility.python37.python37-compatibility-locale1
+        version_id: 7ZTxRDA
+        url: https://semgrep.dev/playground/r/7ZTxRDA/python.lang.compatibility.python37.python37-compatibility-locale1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-math1
   pattern: math.remainder($X, $Y)
@@ -546,10 +546,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9586
-        rv_id: 110320
+        rv_id: 834543
         rule_id: ReUgbz
-        version_id: xyTKZJZ
-        url: https://semgrep.dev/playground/r/xyTKZJZ/python.lang.compatibility.python37.python37-compatibility-math1
+        version_id: LjTEe7w
+        url: https://semgrep.dev/playground/r/LjTEe7w/python.lang.compatibility.python37.python37-compatibility-math1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-multiprocess1
   pattern: multiprocessing.Process.close()
@@ -568,10 +568,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9587
-        rv_id: 110321
+        rv_id: 834544
         rule_id: AbUzRA
-        version_id: O9TNOod
-        url: https://semgrep.dev/playground/r/O9TNOod/python.lang.compatibility.python37.python37-compatibility-multiprocess1
+        version_id: 8KTGl4d
+        url: https://semgrep.dev/playground/r/8KTGl4d/python.lang.compatibility.python37.python37-compatibility-multiprocess1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-multiprocess2
   pattern: multiprocessing.Process.kill()
@@ -590,10 +590,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9588
-        rv_id: 110322
+        rv_id: 834545
         rule_id: BYUNE9
-        version_id: e1T017y
-        url: https://semgrep.dev/playground/r/e1T017y/python.lang.compatibility.python37.python37-compatibility-multiprocess2
+        version_id: gETyX6q
+        url: https://semgrep.dev/playground/r/gETyX6q/python.lang.compatibility.python37.python37-compatibility-multiprocess2
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-os1
   pattern: os.preadv(...)
@@ -612,10 +612,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9589
-        rv_id: 110323
+        rv_id: 834546
         rule_id: DbUpQQ
-        version_id: vdTYNWX
-        url: https://semgrep.dev/playground/r/vdTYNWX/python.lang.compatibility.python37.python37-compatibility-os1
+        version_id: QkTkN8y
+        url: https://semgrep.dev/playground/r/QkTkN8y/python.lang.compatibility.python37.python37-compatibility-os1
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-os2-ok2
   patterns:
@@ -638,10 +638,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9591
-        rv_id: 110324
+        rv_id: 834547
         rule_id: 0oU5vW
-        version_id: d6TrA98
-        url: https://semgrep.dev/playground/r/d6TrA98/python.lang.compatibility.python37.python37-compatibility-os2-ok2
+        version_id: 3ZT3wl9
+        url: https://semgrep.dev/playground/r/3ZT3wl9/python.lang.compatibility.python37.python37-compatibility-os2-ok2
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-pdb
   pattern: pdb.set_trace(header=$X, ...)
@@ -661,10 +661,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9592
-        rv_id: 110325
+        rv_id: 834548
         rule_id: KxUby2
-        version_id: ZRTQNjx
-        url: https://semgrep.dev/playground/r/ZRTQNjx/python.lang.compatibility.python37.python37-compatibility-pdb
+        version_id: 44TQqAy
+        url: https://semgrep.dev/playground/r/44TQqAy/python.lang.compatibility.python37.python37-compatibility-pdb
         origin: community
 - id: python.lang.compatibility.python37.python37-compatibility-textiowrapper
   pattern: TextIOWrapper.reconfigure(...)
@@ -684,10 +684,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9580
-        rv_id: 110314
+        rv_id: 834537
         rule_id: 3qUPdy
-        version_id: yeTR2wy
-        url: https://semgrep.dev/playground/r/yeTR2wy/python.lang.compatibility.python37.python37-compatibility-textiowrapper
+        version_id: vdTOQ17
+        url: https://semgrep.dev/playground/r/vdTOQ17/python.lang.compatibility.python37.python37-compatibility-textiowrapper
         origin: community
 - id: python.sqlalchemy.performance.performance-improvements.batch-import
   pattern: |
@@ -708,10 +708,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9701
-        rv_id: 110496
+        rv_id: 834717
         rule_id: AbUWjy
-        version_id: GxTv8x6
-        url: https://semgrep.dev/playground/r/GxTv8x6/python.sqlalchemy.performance.performance-improvements.batch-import
+        version_id: K3TrLYX
+        url: https://semgrep.dev/playground/r/K3TrLYX/python.sqlalchemy.performance.performance-improvements.batch-import
         origin: community
 - id: python.sqlalchemy.performance.performance-improvements.len-all-count
   pattern: len($X.all())
@@ -730,10 +730,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9700
-        rv_id: 110495
+        rv_id: 834716
         rule_id: ReUPOw
-        version_id: 5PTdeP9
-        url: https://semgrep.dev/playground/r/5PTdeP9/python.sqlalchemy.performance.performance-improvements.len-all-count
+        version_id: 0bTw3Jz
+        url: https://semgrep.dev/playground/r/0bTw3Jz/python.sqlalchemy.performance.performance-improvements.len-all-count
         origin: community
 - id: terraform.azure.security.keyvault.keyvault-content-type-for-secret.keyvault-content-type-for-secret
   message: Key vault Secret should have a content type set
@@ -763,10 +763,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15132
-        rv_id: 110928
+        rv_id: 835129
         rule_id: 8GUzld
-        version_id: e1T0338
-        url: https://semgrep.dev/playground/r/e1T0338/terraform.azure.security.keyvault.keyvault-content-type-for-secret.keyvault-content-type-for-secret
+        version_id: 2KT7OR7
+        url: https://semgrep.dev/playground/r/2KT7OR7/terraform.azure.security.keyvault.keyvault-content-type-for-secret.keyvault-content-type-for-secret
         origin: community
   languages:
   - hcl
@@ -809,10 +809,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9760
-        rv_id: 111080
+        rv_id: 835280
         rule_id: j2Uqg5
-        version_id: LjTqARd
-        url: https://semgrep.dev/playground/r/LjTqARd/typescript.react.best-practice.define-styled-components-on-module-level.define-styled-components-on-module-level
+        version_id: qkTQweE
+        url: https://semgrep.dev/playground/r/qkTQweE/typescript.react.best-practice.define-styled-components-on-module-level.define-styled-components-on-module-level
         origin: community
   languages:
   - typescript
@@ -840,10 +840,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9761
-        rv_id: 111081
+        rv_id: 835281
         rule_id: 10UZOv
-        version_id: 8KTQy3O
-        url: https://semgrep.dev/playground/r/8KTQy3O/typescript.react.best-practice.react-find-dom.react-find-dom
+        version_id: l4TyD2b
+        url: https://semgrep.dev/playground/r/l4TyD2b/typescript.react.best-practice.react-find-dom.react-find-dom
         origin: community
   languages:
   - typescript
@@ -873,10 +873,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9762
-        rv_id: 111082
+        rv_id: 835282
         rule_id: 9AUOdB
-        version_id: gET3Oro
-        url: https://semgrep.dev/playground/r/gET3Oro/typescript.react.best-practice.react-legacy-component.react-legacy-component
+        version_id: YDTlbOW
+        url: https://semgrep.dev/playground/r/YDTlbOW/typescript.react.best-practice.react-legacy-component.react-legacy-component
         origin: community
 - id: typescript.react.best-practice.react-props-in-state.react-props-in-state
   pattern-either:
@@ -938,10 +938,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9763
-        rv_id: 111083
+        rv_id: 835283
         rule_id: yyUvRJ
-        version_id: QkTWwEY
-        url: https://semgrep.dev/playground/r/QkTWwEY/typescript.react.best-practice.react-props-in-state.react-props-in-state
+        version_id: 6xTDXzB
+        url: https://semgrep.dev/playground/r/6xTDXzB/typescript.react.best-practice.react-props-in-state.react-props-in-state
         origin: community
   languages:
   - typescript
@@ -972,10 +972,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9764
-        rv_id: 111084
+        rv_id: 835284
         rule_id: r6Uky5
-        version_id: 3ZTkr2Z
-        url: https://semgrep.dev/playground/r/3ZTkr2Z/typescript.react.best-practice.react-props-spreading.react-props-spreading
+        version_id: o5TB1R6
+        url: https://semgrep.dev/playground/r/o5TB1R6/typescript.react.best-practice.react-props-spreading.react-props-spreading
         origin: community
 - id: typescript.react.portability.i18next.i18next-key-format.i18next-key-format
   patterns:
@@ -1039,10 +1039,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20158
-        rv_id: 111085
+        rv_id: 835285
         rule_id: oqUKJr
-        version_id: 44TR6bp
-        url: https://semgrep.dev/playground/r/44TR6bp/typescript.react.portability.i18next.i18next-key-format.i18next-key-format
+        version_id: zyTW3Q7
+        url: https://semgrep.dev/playground/r/zyTW3Q7/typescript.react.portability.i18next.i18next-key-format.i18next-key-format
         origin: community
 - id: typescript.react.portability.i18next.jsx-label-not-i18n.jsx-label-not-i18n
   patterns:
@@ -1075,10 +1075,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20159
-        rv_id: 111086
+        rv_id: 835286
         rule_id: zdUGrY
-        version_id: PkTJde4
-        url: https://semgrep.dev/playground/r/PkTJde4/typescript.react.portability.i18next.jsx-label-not-i18n.jsx-label-not-i18n
+        version_id: pZTXDxj
+        url: https://semgrep.dev/playground/r/pZTXDxj/typescript.react.portability.i18next.jsx-label-not-i18n.jsx-label-not-i18n
         origin: community
 - id: typescript.react.portability.i18next.jsx-not-internationalized.jsx-not-internationalized
   patterns:
@@ -1110,10 +1110,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20052
-        rv_id: 111087
+        rv_id: 835287
         rule_id: KxUwo1
-        version_id: JdTNvnX
-        url: https://semgrep.dev/playground/r/JdTNvnX/typescript.react.portability.i18next.jsx-not-internationalized.jsx-not-internationalized
+        version_id: 2KT7OwO
+        url: https://semgrep.dev/playground/r/2KT7OwO/typescript.react.portability.i18next.jsx-not-internationalized.jsx-not-internationalized
         origin: community
 - id: typescript.react.portability.i18next.mui-snackbar-message.mui-snackbar-message
   patterns:
@@ -1140,10 +1140,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20053
-        rv_id: 111088
+        rv_id: 835288
         rule_id: qNUpO8
-        version_id: 5PTde7b
-        url: https://semgrep.dev/playground/r/5PTde7b/typescript.react.portability.i18next.mui-snackbar-message.mui-snackbar-message
+        version_id: X0T5Kly
+        url: https://semgrep.dev/playground/r/X0T5Kly/typescript.react.portability.i18next.mui-snackbar-message.mui-snackbar-message
         origin: community
 - id: typescript.react.portability.i18next.useselect-label-not-i18n.useselect-label-not-i18n
   patterns:
@@ -1174,8 +1174,8 @@ rules:
     semgrep.dev:
       rule:
         r_id: 24016
-        rv_id: 111089
+        rv_id: 835289
         rule_id: nJUPJL
-        version_id: GxTv8ld
-        url: https://semgrep.dev/playground/r/GxTv8ld/typescript.react.portability.i18next.useselect-label-not-i18n.useselect-label-not-i18n
+        version_id: jQTrjN2
+        url: https://semgrep.dev/playground/r/jQTrjN2/typescript.react.portability.i18next.useselect-label-not-i18n.useselect-label-not-i18n
         origin: community

--- a/assets/semgrep_rules/generated/nonfree/vulns.yaml
+++ b/assets/semgrep_rules/generated/nonfree/vulns.yaml
@@ -34,10 +34,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14554
-        rv_id: 108994
+        rv_id: 833374
         rule_id: KxU7Rq
-        version_id: zyTK8D1
-        url: https://semgrep.dev/playground/r/zyTK8D1/bash.curl.security.curl-eval.curl-eval
+        version_id: rxTDz8A
+        url: https://semgrep.dev/playground/r/rxTDz8A/bash.curl.security.curl-eval.curl-eval
         origin: community
   mode: taint
   pattern-sources:
@@ -93,10 +93,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8832
-        rv_id: 257627
+        rv_id: 833385
         rule_id: JDUyw8
-        version_id: ZRT7Q7O
-        url: https://semgrep.dev/playground/r/ZRT7Q7O/c.lang.security.double-free.double-free
+        version_id: nWTy4wA
+        url: https://semgrep.dev/playground/r/nWTy4wA/c.lang.security.double-free.double-free
         origin: community
   languages:
   - c
@@ -140,10 +140,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 57376
-        rv_id: 257628
+        rv_id: 833386
         rule_id: WAU9Dz
-        version_id: nWT8x8G
-        url: https://semgrep.dev/playground/r/nWT8x8G/c.lang.security.function-use-after-free.function-use-after-free
+        version_id: ExTrDY3
+        url: https://semgrep.dev/playground/r/ExTrDY3/c.lang.security.function-use-after-free.function-use-after-free
         origin: community
   languages:
   - c
@@ -174,10 +174,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8835
-        rv_id: 257630
+        rv_id: 833390
         rule_id: ReUgWx
-        version_id: 7ZT1g1b
-        url: https://semgrep.dev/playground/r/7ZT1g1b/c.lang.security.insecure-use-printf-fn.insecure-use-printf-fn
+        version_id: gETy25d
+        url: https://semgrep.dev/playground/r/gETy25d/c.lang.security.insecure-use-printf-fn.insecure-use-printf-fn
         origin: community
   languages:
   - c
@@ -237,10 +237,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 8841
-        rv_id: 257631
+        rv_id: 833396
         rule_id: KxUb9l
-        version_id: LjT2q2X
-        url: https://semgrep.dev/playground/r/LjT2q2X/c.lang.security.use-after-free.use-after-free
+        version_id: 5PTyDY1
+        url: https://semgrep.dev/playground/r/5PTyDY1/c.lang.security.use-after-free.use-after-free
         origin: community
   languages:
   - c
@@ -284,10 +284,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 71533
-        rv_id: 109018
+        rv_id: 833398
         rule_id: bwU3Gj
-        version_id: gET3xOd
-        url: https://semgrep.dev/playground/r/gET3xOd/clojure.lang.security.documentbuilderfactory-xxe.documentbuilderfactory-xxe
+        version_id: RGTKGwz
+        url: https://semgrep.dev/playground/r/RGTKGwz/clojure.lang.security.documentbuilderfactory-xxe.documentbuilderfactory-xxe
         origin: community
   message: DOCTYPE declarations are enabled for javax.xml.parsers.SAXParserFactory.
     Without prohibiting external entity declarations, this is vulnerable to XML external
@@ -355,10 +355,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 52195
-        rv_id: 258072
+        rv_id: 833399
         rule_id: nJU1ep
-        version_id: 2KTQz3r
-        url: https://semgrep.dev/playground/r/2KTQz3r/clojure.lang.security.use-of-md5.use-of-md5
+        version_id: A8T37nA
+        url: https://semgrep.dev/playground/r/A8T37nA/clojure.lang.security.use-of-md5.use-of-md5
         origin: community
   pattern-either:
   - pattern: (MessageDigest/getInstance "MD5")
@@ -402,10 +402,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 71534
-        rv_id: 111247
+        rv_id: 833400
         rule_id: NbUy12
-        version_id: GxTv8Wq
-        url: https://semgrep.dev/playground/r/GxTv8Wq/clojure.lang.security.use-of-sha1.use-of-sha1
+        version_id: BjTe0G9
+        url: https://semgrep.dev/playground/r/BjTe0G9/clojure.lang.security.use-of-sha1.use-of-sha1
         origin: community
   patterns:
   - pattern-either:
@@ -445,10 +445,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27692
-        rv_id: 109173
+        rv_id: 833402
         rule_id: 2ZUv3R
-        version_id: BjTXrJe
-        url: https://semgrep.dev/playground/r/BjTXrJe/csharp.dotnet.security.audit.ldap-injection.ldap-injection
+        version_id: WrTdp6x
+        url: https://semgrep.dev/playground/r/WrTdp6x/csharp.dotnet.security.audit.ldap-injection.ldap-injection
         origin: community
   languages:
   - csharp
@@ -500,10 +500,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26838
-        rv_id: 109174
+        rv_id: 833403
         rule_id: x8Up5B
-        version_id: DkT6nX2
-        url: https://semgrep.dev/playground/r/DkT6nX2/csharp.dotnet.security.audit.mass-assignment.mass-assignment
+        version_id: 0bTwb6W
+        url: https://semgrep.dev/playground/r/0bTwb6W/csharp.dotnet.security.audit.mass-assignment.mass-assignment
         origin: community
   languages:
   - csharp
@@ -568,10 +568,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26335
-        rv_id: 113528
+        rv_id: 833405
         rule_id: eqU32Y
-        version_id: A8T9gKe
-        url: https://semgrep.dev/playground/r/A8T9gKe/csharp.dotnet.security.audit.missing-or-broken-authorization.missing-or-broken-authorization
+        version_id: qkTQn92
+        url: https://semgrep.dev/playground/r/qkTQn92/csharp.dotnet.security.audit.missing-or-broken-authorization.missing-or-broken-authorization
         origin: community
   languages:
   - csharp
@@ -634,10 +634,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26336
-        rv_id: 109177
+        rv_id: 833406
         rule_id: v8U8Ab
-        version_id: K3Tvj8G
-        url: https://semgrep.dev/playground/r/K3Tvj8G/csharp.dotnet.security.audit.open-directory-listing.open-directory-listing
+        version_id: l4TyOel
+        url: https://semgrep.dev/playground/r/l4TyOel/csharp.dotnet.security.audit.open-directory-listing.open-directory-listing
         origin: community
   languages:
   - csharp
@@ -678,10 +678,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27400
-        rv_id: 109179
+        rv_id: 833408
         rule_id: x8Uj2k
-        version_id: l4T4voZ
-        url: https://semgrep.dev/playground/r/l4T4voZ/csharp.dotnet.security.audit.xpath-injection.xpath-injection
+        version_id: 6xTDgAj
+        url: https://semgrep.dev/playground/r/6xTDgAj/csharp.dotnet.security.audit.xpath-injection.xpath-injection
         origin: community
   languages:
   - csharp
@@ -732,10 +732,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18216
-        rv_id: 109183
+        rv_id: 833412
         rule_id: EwUr68
-        version_id: GxTv6YJ
-        url: https://semgrep.dev/playground/r/GxTv6YJ/csharp.dotnet.security.razor-template-injection.razor-template-injection
+        version_id: 2KT7xAL
+        url: https://semgrep.dev/playground/r/2KT7xAL/csharp.dotnet.security.razor-template-injection.razor-template-injection
         origin: community
   languages:
   - csharp
@@ -783,10 +783,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 36772
-        rv_id: 109184
+        rv_id: 833413
         rule_id: WAUJr0
-        version_id: RGTDknw
-        url: https://semgrep.dev/playground/r/RGTDknw/csharp.dotnet.security.use_deprecated_cipher_algorithm.use_deprecated_cipher_algorithm
+        version_id: X0T5No5
+        url: https://semgrep.dev/playground/r/X0T5No5/csharp.dotnet.security.use_deprecated_cipher_algorithm.use_deprecated_cipher_algorithm
         origin: community
   languages:
   - csharp
@@ -827,10 +827,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 36773
-        rv_id: 109185
+        rv_id: 833414
         rule_id: 0oUqWP
-        version_id: A8T950y
-        url: https://semgrep.dev/playground/r/A8T950y/csharp.dotnet.security.use_ecb_mode.use_ecb_mode
+        version_id: jQTrXLw
+        url: https://semgrep.dev/playground/r/jQTrXLw/csharp.dotnet.security.use_ecb_mode.use_ecb_mode
         origin: community
   languages:
   - csharp
@@ -879,10 +879,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 36774
-        rv_id: 109186
+        rv_id: 833415
         rule_id: KxU3Nq
-        version_id: BjTXrJo
-        url: https://semgrep.dev/playground/r/BjTXrJo/csharp.dotnet.security.use_weak_rng_for_keygeneration.use_weak_rng_for_keygeneration
+        version_id: 1QTPL0o
+        url: https://semgrep.dev/playground/r/1QTPL0o/csharp.dotnet.security.use_weak_rng_for_keygeneration.use_weak_rng_for_keygeneration
         origin: community
   languages:
   - csharp
@@ -938,10 +938,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 35492
-        rv_id: 109187
+        rv_id: 833416
         rule_id: QrU2G5
-        version_id: DkT6nXB
-        url: https://semgrep.dev/playground/r/DkT6nXB/csharp.dotnet.security.use_weak_rsa_encryption_padding.use_weak_rsa_encryption_padding
+        version_id: 9lTJ0EW
+        url: https://semgrep.dev/playground/r/9lTJ0EW/csharp.dotnet.security.use_weak_rsa_encryption_padding.use_weak_rsa_encryption_padding
         origin: community
   languages:
   - csharp
@@ -984,10 +984,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 26718
-        rv_id: 109196
+        rv_id: 833425
         rule_id: KxUGLw
-        version_id: zyTK8NE
-        url: https://semgrep.dev/playground/r/zyTK8NE/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token
+        version_id: e1TDkEE
+        url: https://semgrep.dev/playground/r/e1TDkEE/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token
         origin: community
   languages:
   - csharp
@@ -1020,10 +1020,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18220
-        rv_id: 109194
+        rv_id: 833423
         rule_id: gxUy01
-        version_id: 6xTvJGn
-        url: https://semgrep.dev/playground/r/6xTvJGn/csharp.lang.security.cryptography.x509-subject-name-validation.X509-subject-name-validation
+        version_id: xyTNe9Q
+        url: https://semgrep.dev/playground/r/xyTNe9Q/csharp.lang.security.cryptography.x509-subject-name-validation.X509-subject-name-validation
         origin: community
   message: Validating certificates based on subject name is bad practice. Use the
     X509Certificate2.Verify() method instead.
@@ -1150,10 +1150,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18222
-        rv_id: 109197
+        rv_id: 833426
         rule_id: 3qU3bE
-        version_id: pZT1ye7
-        url: https://semgrep.dev/playground/r/pZT1ye7/csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
+        version_id: vdTOzDJ
+        url: https://semgrep.dev/playground/r/vdTOzDJ/csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
         origin: community
 - id: csharp.lang.security.http.http-listener-wildcard-bindings.http-listener-wildcard-bindings
   severity: WARNING
@@ -1182,10 +1182,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18223
-        rv_id: 109198
+        rv_id: 833427
         rule_id: 4bUQ81
-        version_id: 2KTzr5x
-        url: https://semgrep.dev/playground/r/2KTzr5x/csharp.lang.security.http.http-listener-wildcard-bindings.http-listener-wildcard-bindings
+        version_id: d6TKGnO
+        url: https://semgrep.dev/playground/r/d6TKGnO/csharp.lang.security.http.http-listener-wildcard-bindings.http-listener-wildcard-bindings
         origin: community
   message: The top level wildcard bindings $PREFIX leaves your application open to
     security vulnerabilities and give attackers more control over where traffic is
@@ -1229,10 +1229,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11135
-        rv_id: 109200
+        rv_id: 833429
         rule_id: bwUOjK
-        version_id: jQTgYD5
-        url: https://semgrep.dev/playground/r/jQTgYD5/csharp.lang.security.insecure-deserialization.binary-formatter.insecure-binaryformatter-deserialization
+        version_id: nWTy4dA
+        url: https://semgrep.dev/playground/r/nWTy4dA/csharp.lang.security.insecure-deserialization.binary-formatter.insecure-binaryformatter-deserialization
         origin: community
   message: The BinaryFormatter type is dangerous and is not recommended for data processing.
     Applications should stop using BinaryFormatter as soon as possible, even if they
@@ -1275,10 +1275,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11137
-        rv_id: 109203
+        rv_id: 833432
         rule_id: kxURnR
-        version_id: yeTR2GJ
-        url: https://semgrep.dev/playground/r/yeTR2GJ/csharp.lang.security.insecure-deserialization.fs-pickler.insecure-fspickler-deserialization
+        version_id: LjTEbxn
+        url: https://semgrep.dev/playground/r/LjTEbxn/csharp.lang.security.insecure-deserialization.fs-pickler.insecure-fspickler-deserialization
         origin: community
   message: The FsPickler is dangerous and is not recommended for data processing.
     Default configuration tend to insecure deserialization vulnerability.
@@ -1319,10 +1319,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11138
-        rv_id: 109206
+        rv_id: 833435
         rule_id: wdU87G
-        version_id: NdT3dGO
-        url: https://semgrep.dev/playground/r/NdT3dGO/csharp.lang.security.insecure-deserialization.los-formatter.insecure-losformatter-deserialization
+        version_id: QkTkrB9
+        url: https://semgrep.dev/playground/r/QkTkrB9/csharp.lang.security.insecure-deserialization.los-formatter.insecure-losformatter-deserialization
         origin: community
   message: The LosFormatter type is dangerous and is not recommended for data processing.
     Applications should stop using LosFormatter as soon as possible, even if they
@@ -1365,10 +1365,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11139
-        rv_id: 109207
+        rv_id: 833436
         rule_id: x8UW7x
-        version_id: kbTdx34
-        url: https://semgrep.dev/playground/r/kbTdx34/csharp.lang.security.insecure-deserialization.net-data-contract.insecure-netdatacontract-deserialization
+        version_id: 3ZT3A7y
+        url: https://semgrep.dev/playground/r/3ZT3A7y/csharp.lang.security.insecure-deserialization.net-data-contract.insecure-netdatacontract-deserialization
         origin: community
   message: The NetDataContractSerializer type is dangerous and is not recommended
     for data processing. Applications should stop using NetDataContractSerializer
@@ -1411,10 +1411,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11141
-        rv_id: 109209
+        rv_id: 833438
         rule_id: eqUvND
-        version_id: xyTKZwK
-        url: https://semgrep.dev/playground/r/xyTKZwK/csharp.lang.security.insecure-deserialization.soap-formatter.insecure-soapformatter-deserialization
+        version_id: PkTxrEr
+        url: https://semgrep.dev/playground/r/PkTxrEr/csharp.lang.security.insecure-deserialization.soap-formatter.insecure-soapformatter-deserialization
         origin: community
   message: The SoapFormatter type is dangerous and is not recommended for data processing.
     Applications should stop using SoapFormatter as soon as possible, even if they
@@ -1475,10 +1475,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18228
-        rv_id: 109221
+        rv_id: 833450
         rule_id: ReUK9k
-        version_id: QkTW02w
-        url: https://semgrep.dev/playground/r/QkTW02w/csharp.lang.security.xxe.xmldocument-unsafe-parser-override.xmldocument-unsafe-parser-override
+        version_id: l4TyOYl
+        url: https://semgrep.dev/playground/r/l4TyOYl/csharp.lang.security.xxe.xmldocument-unsafe-parser-override.xmldocument-unsafe-parser-override
         origin: community
 - id: csharp.lang.security.xxe.xmlreadersettings-unsafe-parser-override.xmlreadersettings-unsafe-parser-override
   mode: taint
@@ -1530,10 +1530,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18229
-        rv_id: 109222
+        rv_id: 833451
         rule_id: AbU3pX
-        version_id: 3ZTkQb4
-        url: https://semgrep.dev/playground/r/3ZTkQb4/csharp.lang.security.xxe.xmlreadersettings-unsafe-parser-override.xmlreadersettings-unsafe-parser-override
+        version_id: YDTl0x6
+        url: https://semgrep.dev/playground/r/YDTl0x6/csharp.lang.security.xxe.xmlreadersettings-unsafe-parser-override.xmlreadersettings-unsafe-parser-override
         origin: community
 - id: csharp.lang.security.xxe.xmltextreader-unsafe-defaults.xmltextreader-unsafe-defaults
   mode: taint
@@ -1587,10 +1587,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18230
-        rv_id: 109223
+        rv_id: 833452
         rule_id: BYUevk
-        version_id: 44TRl89
-        url: https://semgrep.dev/playground/r/44TRl89/csharp.lang.security.xxe.xmltextreader-unsafe-defaults.xmltextreader-unsafe-defaults
+        version_id: JdTlr4y
+        url: https://semgrep.dev/playground/r/JdTlr4y/csharp.lang.security.xxe.xmltextreader-unsafe-defaults.xmltextreader-unsafe-defaults
         origin: community
 - id: generic.secrets.gitleaks.adafruit-api-key.adafruit-api-key
   message: A gitleaks adafruit-api-key was detected which attempts to identify hard-coded
@@ -1628,10 +1628,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44669
-        rv_id: 109354
+        rv_id: 833579
         rule_id: kxUQj2
-        version_id: xyTKZ9j
-        url: https://semgrep.dev/playground/r/xyTKZ9j/generic.secrets.gitleaks.adafruit-api-key.adafruit-api-key
+        version_id: kbT2lv4
+        url: https://semgrep.dev/playground/r/kbT2lv4/generic.secrets.gitleaks.adafruit-api-key.adafruit-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:adafruit)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1671,10 +1671,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44670
-        rv_id: 109355
+        rv_id: 833580
         rule_id: wdUqzk
-        version_id: O9TNO48
-        url: https://semgrep.dev/playground/r/O9TNO48/generic.secrets.gitleaks.adobe-client-id.adobe-client-id
+        version_id: w8TAxd1
+        url: https://semgrep.dev/playground/r/w8TAxd1/generic.secrets.gitleaks.adobe-client-id.adobe-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:adobe)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1714,10 +1714,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44671
-        rv_id: 109356
+        rv_id: 833581
         rule_id: x8UlAq
-        version_id: e1T01E4
-        url: https://semgrep.dev/playground/r/e1T01E4/generic.secrets.gitleaks.adobe-client-secret.adobe-client-secret
+        version_id: xyTNeyK
+        url: https://semgrep.dev/playground/r/xyTNeyK/generic.secrets.gitleaks.adobe-client-secret.adobe-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)\b((p8e-)(?i)[a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1757,10 +1757,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44672
-        rv_id: 109357
+        rv_id: 833582
         rule_id: OrUAnO
-        version_id: vdTYNDo
-        url: https://semgrep.dev/playground/r/vdTYNDo/generic.secrets.gitleaks.age-secret-key.age-secret-key
+        version_id: O9TJWKk
+        url: https://semgrep.dev/playground/r/O9TJWKk/generic.secrets.gitleaks.age-secret-key.age-secret-key
         origin: community
   patterns:
   - pattern-regex: AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}
@@ -1800,10 +1800,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44673
-        rv_id: 109358
+        rv_id: 833583
         rule_id: eqUYL3
-        version_id: d6TrAnL
-        url: https://semgrep.dev/playground/r/d6TrAnL/generic.secrets.gitleaks.airtable-api-key.airtable-api-key
+        version_id: e1TDkXL
+        url: https://semgrep.dev/playground/r/e1TDkXL/generic.secrets.gitleaks.airtable-api-key.airtable-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:airtable)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{17})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1843,10 +1843,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44674
-        rv_id: 109359
+        rv_id: 833584
         rule_id: v8UKp0
-        version_id: ZRTQNBX
-        url: https://semgrep.dev/playground/r/ZRTQNBX/generic.secrets.gitleaks.algolia-api-key.algolia-api-key
+        version_id: vdTOzxn
+        url: https://semgrep.dev/playground/r/vdTOzxn/generic.secrets.gitleaks.algolia-api-key.algolia-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:algolia)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1886,10 +1886,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44675
-        rv_id: 109360
+        rv_id: 833585
         rule_id: d8UOQ3
-        version_id: nWTxPdw
-        url: https://semgrep.dev/playground/r/nWTxPdw/generic.secrets.gitleaks.alibaba-access-key-id.alibaba-access-key-id
+        version_id: d6TKG2z
+        url: https://semgrep.dev/playground/r/d6TKG2z/generic.secrets.gitleaks.alibaba-access-key-id.alibaba-access-key-id
         origin: community
   patterns:
   - pattern-regex: (?i)\b((LTAI)(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1929,10 +1929,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44676
-        rv_id: 109361
+        rv_id: 833586
         rule_id: ZqUk7D
-        version_id: ExTjNdd
-        url: https://semgrep.dev/playground/r/ExTjNdd/generic.secrets.gitleaks.alibaba-secret-key.alibaba-secret-key
+        version_id: ZRTlP1g
+        url: https://semgrep.dev/playground/r/ZRTlP1g/generic.secrets.gitleaks.alibaba-secret-key.alibaba-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:alibaba)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -1972,10 +1972,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44677
-        rv_id: 109362
+        rv_id: 833587
         rule_id: nJU58J
-        version_id: 7ZTgo5w
-        url: https://semgrep.dev/playground/r/7ZTgo5w/generic.secrets.gitleaks.asana-client-id.asana-client-id
+        version_id: nWTy4AZ
+        url: https://semgrep.dev/playground/r/nWTy4AZ/generic.secrets.gitleaks.asana-client-id.asana-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:asana)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2015,10 +2015,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44678
-        rv_id: 109363
+        rv_id: 833588
         rule_id: EwUyp6
-        version_id: LjTqQxL
-        url: https://semgrep.dev/playground/r/LjTqQxL/generic.secrets.gitleaks.asana-client-secret.asana-client-secret
+        version_id: ExTrDPq
+        url: https://semgrep.dev/playground/r/ExTrDPq/generic.secrets.gitleaks.asana-client-secret.asana-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:asana)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2058,10 +2058,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44679
-        rv_id: 109364
+        rv_id: 833589
         rule_id: 7KUJ1X
-        version_id: 8KTQ9Wo
-        url: https://semgrep.dev/playground/r/8KTQ9Wo/generic.secrets.gitleaks.atlassian-api-token.atlassian-api-token
+        version_id: 7ZTx9qx
+        url: https://semgrep.dev/playground/r/7ZTx9qx/generic.secrets.gitleaks.atlassian-api-token.atlassian-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:atlassian|confluence|jira)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2101,10 +2101,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66770
-        rv_id: 109365
+        rv_id: 833590
         rule_id: 0oUbQZ
-        version_id: gET3xLG
-        url: https://semgrep.dev/playground/r/gET3xLG/generic.secrets.gitleaks.authress-service-client-access-key.authress-service-client-access-key
+        version_id: LjTEbDz
+        url: https://semgrep.dev/playground/r/LjTEbDz/generic.secrets.gitleaks.authress-service-client-access-key.authress-service-client-access-key
         origin: community
   patterns:
   - pattern-regex: (?i)\b((?:sc|ext|scauth|authress)_[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.acc[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2144,10 +2144,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44681
-        rv_id: 109367
+        rv_id: 833592
         rule_id: 8GUPqW
-        version_id: 3ZTkQ7G
-        url: https://semgrep.dev/playground/r/3ZTkQ7G/generic.secrets.gitleaks.beamer-api-token.beamer-api-token
+        version_id: gETy2Gx
+        url: https://semgrep.dev/playground/r/gETy2Gx/generic.secrets.gitleaks.beamer-api-token.beamer-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:beamer)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(b_[a-z0-9=_\-]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2187,10 +2187,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44682
-        rv_id: 109368
+        rv_id: 833593
         rule_id: gxUvAp
-        version_id: 44TRlxB
-        url: https://semgrep.dev/playground/r/44TRlxB/generic.secrets.gitleaks.bitbucket-client-id.bitbucket-client-id
+        version_id: QkTkrlw
+        url: https://semgrep.dev/playground/r/QkTkrlw/generic.secrets.gitleaks.bitbucket-client-id.bitbucket-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:bitbucket)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2230,10 +2230,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44683
-        rv_id: 109369
+        rv_id: 833594
         rule_id: QrUR7R
-        version_id: PkTJ1Ev
-        url: https://semgrep.dev/playground/r/PkTJ1Ev/generic.secrets.gitleaks.bitbucket-client-secret.bitbucket-client-secret
+        version_id: 3ZT3AD4
+        url: https://semgrep.dev/playground/r/3ZT3AD4/generic.secrets.gitleaks.bitbucket-client-secret.bitbucket-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:bitbucket)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2273,10 +2273,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44684
-        rv_id: 109370
+        rv_id: 833595
         rule_id: 3qU5pK
-        version_id: JdTNp20
-        url: https://semgrep.dev/playground/r/JdTNp20/generic.secrets.gitleaks.bittrex-access-key.bittrex-access-key
+        version_id: 44TQPW9
+        url: https://semgrep.dev/playground/r/44TQPW9/generic.secrets.gitleaks.bittrex-access-key.bittrex-access-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:bittrex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2316,10 +2316,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44685
-        rv_id: 109371
+        rv_id: 833596
         rule_id: 4bUKAW
-        version_id: 5PTdABZ
-        url: https://semgrep.dev/playground/r/5PTdABZ/generic.secrets.gitleaks.bittrex-secret-key.bittrex-secret-key
+        version_id: PkTxrqe
+        url: https://semgrep.dev/playground/r/PkTxrqe/generic.secrets.gitleaks.bittrex-secret-key.bittrex-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:bittrex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2359,10 +2359,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44686
-        rv_id: 109372
+        rv_id: 833597
         rule_id: PeU7WX
-        version_id: GxTv64p
-        url: https://semgrep.dev/playground/r/GxTv64p/generic.secrets.gitleaks.clojars-api-token.clojars-api-token
+        version_id: JdTlrAG
+        url: https://semgrep.dev/playground/r/JdTlrAG/generic.secrets.gitleaks.clojars-api-token.clojars-api-token
         origin: community
   patterns:
   - pattern-regex: "(?i)(CLOJARS_)[a-z0-9]{60}"
@@ -2402,10 +2402,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 132809
-        rv_id: 750521
+        rv_id: 833598
         rule_id: DbU6oZX
-        version_id: RGTqx7R
-        url: https://semgrep.dev/playground/r/RGTqx7R/generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
+        version_id: 5PTyD0E
+        url: https://semgrep.dev/playground/r/5PTyD0E/generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:cloudflare)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2445,10 +2445,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 132810
-        rv_id: 750522
+        rv_id: 833599
         rule_id: WAUW5AJ
-        version_id: A8Tel8g
-        url: https://semgrep.dev/playground/r/A8Tel8g/generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
+        version_id: GxTDE5J
+        url: https://semgrep.dev/playground/r/GxTDE5J/generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:cloudflare)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2488,10 +2488,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 132811
-        rv_id: 750523
+        rv_id: 833600
         rule_id: 0oULkY9
-        version_id: BjTzL5b
-        url: https://semgrep.dev/playground/r/BjTzL5b/generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
+        version_id: RGTKGYw
+        url: https://semgrep.dev/playground/r/RGTKGYw/generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key
         origin: community
   patterns:
   - pattern-regex: \b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2531,10 +2531,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44687
-        rv_id: 109373
+        rv_id: 833601
         rule_id: JDUO3B
-        version_id: RGTDkB4
-        url: https://semgrep.dev/playground/r/RGTDkB4/generic.secrets.gitleaks.codecov-access-token.codecov-access-token
+        version_id: A8T371y
+        url: https://semgrep.dev/playground/r/A8T371y/generic.secrets.gitleaks.codecov-access-token.codecov-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:codecov)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2574,10 +2574,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44688
-        rv_id: 109374
+        rv_id: 833602
         rule_id: 5rUKPQ
-        version_id: A8T95y7
-        url: https://semgrep.dev/playground/r/A8T95y7/generic.secrets.gitleaks.coinbase-access-token.coinbase-access-token
+        version_id: BjTe0Oo
+        url: https://semgrep.dev/playground/r/BjTe0Oo/generic.secrets.gitleaks.coinbase-access-token.coinbase-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:coinbase)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2617,10 +2617,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44689
-        rv_id: 109375
+        rv_id: 833603
         rule_id: GdUbxy
-        version_id: BjTXrQL
-        url: https://semgrep.dev/playground/r/BjTXrQL/generic.secrets.gitleaks.confluent-access-token.confluent-access-token
+        version_id: DkTG04B
+        url: https://semgrep.dev/playground/r/DkTG04B/generic.secrets.gitleaks.confluent-access-token.confluent-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:confluent)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2660,10 +2660,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44690
-        rv_id: 109376
+        rv_id: 833604
         rule_id: ReUNQJ
-        version_id: DkT6n3b
-        url: https://semgrep.dev/playground/r/DkT6n3b/generic.secrets.gitleaks.confluent-secret-key.confluent-secret-key
+        version_id: WrTdp25
+        url: https://semgrep.dev/playground/r/WrTdp25/generic.secrets.gitleaks.confluent-secret-key.confluent-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:confluent)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2703,10 +2703,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44691
-        rv_id: 109377
+        rv_id: 833605
         rule_id: AbUvrB
-        version_id: WrTWQkw
-        url: https://semgrep.dev/playground/r/WrTWQkw/generic.secrets.gitleaks.contentful-delivery-api-token.contentful-delivery-api-token
+        version_id: 0bTwbRR
+        url: https://semgrep.dev/playground/r/0bTwbRR/generic.secrets.gitleaks.contentful-delivery-api-token.contentful-delivery-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:contentful)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2746,10 +2746,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44692
-        rv_id: 109378
+        rv_id: 833606
         rule_id: BYU4D6
-        version_id: 0bTLlQd
-        url: https://semgrep.dev/playground/r/0bTLlQd/generic.secrets.gitleaks.databricks-api-token.databricks-api-token
+        version_id: K3TrqB6
+        url: https://semgrep.dev/playground/r/K3TrqB6/generic.secrets.gitleaks.databricks-api-token.databricks-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(dapi[a-h0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2789,10 +2789,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44693
-        rv_id: 109379
+        rv_id: 833607
         rule_id: DbUB9r
-        version_id: K3TvjPd
-        url: https://semgrep.dev/playground/r/K3TvjPd/generic.secrets.gitleaks.datadog-access-token.datadog-access-token
+        version_id: qkTQnzd
+        url: https://semgrep.dev/playground/r/qkTQnzd/generic.secrets.gitleaks.datadog-access-token.datadog-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:datadog)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2832,10 +2832,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66771
-        rv_id: 109380
+        rv_id: 833608
         rule_id: KxUqPA
-        version_id: qkT2x90
-        url: https://semgrep.dev/playground/r/qkT2x90/generic.secrets.gitleaks.defined-networking-api-token.defined-networking-api-token
+        version_id: l4TyOwg
+        url: https://semgrep.dev/playground/r/l4TyOwg/generic.secrets.gitleaks.defined-networking-api-token.defined-networking-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:dnkey)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2875,10 +2875,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44694
-        rv_id: 109381
+        rv_id: 833609
         rule_id: WAUelp
-        version_id: l4T4ve5
-        url: https://semgrep.dev/playground/r/l4T4ve5/generic.secrets.gitleaks.digitalocean-access-token.digitalocean-access-token
+        version_id: YDTl0j5
+        url: https://semgrep.dev/playground/r/YDTl0j5/generic.secrets.gitleaks.digitalocean-access-token.digitalocean-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(doo_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2918,10 +2918,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44695
-        rv_id: 109382
+        rv_id: 833610
         rule_id: 0oU073
-        version_id: YDTp2zP
-        url: https://semgrep.dev/playground/r/YDTp2zP/generic.secrets.gitleaks.digitalocean-pat.digitalocean-pat
+        version_id: 6xTDgOn
+        url: https://semgrep.dev/playground/r/6xTDgOn/generic.secrets.gitleaks.digitalocean-pat.digitalocean-pat
         origin: community
   patterns:
   - pattern-regex: (?i)\b(dop_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -2961,10 +2961,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44696
-        rv_id: 109383
+        rv_id: 833611
         rule_id: KxUAzk
-        version_id: JdTNp27
-        url: https://semgrep.dev/playground/r/JdTNp27/generic.secrets.gitleaks.digitalocean-refresh-token.digitalocean-refresh-token
+        version_id: o5TBEjA
+        url: https://semgrep.dev/playground/r/o5TBEjA/generic.secrets.gitleaks.digitalocean-refresh-token.digitalocean-refresh-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(dor_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3004,10 +3004,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44697
-        rv_id: 109384
+        rv_id: 833612
         rule_id: qNUA1y
-        version_id: 5PTdAxJ
-        url: https://semgrep.dev/playground/r/5PTdAxJ/generic.secrets.gitleaks.discord-api-token.discord-api-token
+        version_id: zyTWJvE
+        url: https://semgrep.dev/playground/r/zyTWJvE/generic.secrets.gitleaks.discord-api-token.discord-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:discord)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3047,10 +3047,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44698
-        rv_id: 109385
+        rv_id: 833613
         rule_id: lBU3rj
-        version_id: GxTv6gv
-        url: https://semgrep.dev/playground/r/GxTv6gv/generic.secrets.gitleaks.discord-client-id.discord-client-id
+        version_id: pZTXjv7
+        url: https://semgrep.dev/playground/r/pZTXjv7/generic.secrets.gitleaks.discord-client-id.discord-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:discord)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{18})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3090,10 +3090,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44699
-        rv_id: 109386
+        rv_id: 833614
         rule_id: YGUg6J
-        version_id: RGTDkde
-        url: https://semgrep.dev/playground/r/RGTDkde/generic.secrets.gitleaks.discord-client-secret.discord-client-secret
+        version_id: 2KT7xBx
+        url: https://semgrep.dev/playground/r/2KT7xBx/generic.secrets.gitleaks.discord-client-secret.discord-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:discord)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3133,10 +3133,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44700
-        rv_id: 109387
+        rv_id: 833615
         rule_id: 6JU45L
-        version_id: A8T95xr
-        url: https://semgrep.dev/playground/r/A8T95xr/generic.secrets.gitleaks.doppler-api-token.doppler-api-token
+        version_id: X0T5NXK
+        url: https://semgrep.dev/playground/r/X0T5NXK/generic.secrets.gitleaks.doppler-api-token.doppler-api-token
         origin: community
   patterns:
   - pattern-regex: "(dp\\.pt\\.)(?i)[a-z0-9]{43}"
@@ -3176,10 +3176,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44701
-        rv_id: 109388
+        rv_id: 833616
         rule_id: oqUGyn
-        version_id: BjTXroN
-        url: https://semgrep.dev/playground/r/BjTXroN/generic.secrets.gitleaks.droneci-access-token.droneci-access-token
+        version_id: jQTrXA5
+        url: https://semgrep.dev/playground/r/jQTrXA5/generic.secrets.gitleaks.droneci-access-token.droneci-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:droneci)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3219,10 +3219,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44702
-        rv_id: 109389
+        rv_id: 833617
         rule_id: zdU6AR
-        version_id: DkT6nLW
-        url: https://semgrep.dev/playground/r/DkT6nLW/generic.secrets.gitleaks.dropbox-api-token.dropbox-api-token
+        version_id: 1QTPLAv
+        url: https://semgrep.dev/playground/r/1QTPLAv/generic.secrets.gitleaks.dropbox-api-token.dropbox-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:dropbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3262,10 +3262,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44703
-        rv_id: 109390
+        rv_id: 833618
         rule_id: pKUR69
-        version_id: WrTWQgP
-        url: https://semgrep.dev/playground/r/WrTWQgP/generic.secrets.gitleaks.dropbox-long-lived-api-token.dropbox-long-lived-api-token
+        version_id: 9lTJ0YB
+        url: https://semgrep.dev/playground/r/9lTJ0YB/generic.secrets.gitleaks.dropbox-long-lived-api-token.dropbox-long-lived-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:dropbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3305,10 +3305,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44704
-        rv_id: 109391
+        rv_id: 833619
         rule_id: 2ZUnbl
-        version_id: 0bTLlZ2
-        url: https://semgrep.dev/playground/r/0bTLlZ2/generic.secrets.gitleaks.dropbox-short-lived-api-token.dropbox-short-lived-api-token
+        version_id: yeTN19J
+        url: https://semgrep.dev/playground/r/yeTN19J/generic.secrets.gitleaks.dropbox-short-lived-api-token.dropbox-short-lived-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:dropbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(sl\.[a-z0-9\-=_]{135})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3348,10 +3348,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44705
-        rv_id: 109392
+        rv_id: 833620
         rule_id: X5UG8Q
-        version_id: K3TvjR5
-        url: https://semgrep.dev/playground/r/K3TvjR5/generic.secrets.gitleaks.duffel-api-token.duffel-api-token
+        version_id: rxTDzR5
+        url: https://semgrep.dev/playground/r/rxTDzR5/generic.secrets.gitleaks.duffel-api-token.duffel-api-token
         origin: community
   patterns:
   - pattern-regex: duffel_(test|live)_(?i)[a-z0-9_\-=]{43}
@@ -3391,10 +3391,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44706
-        rv_id: 109393
+        rv_id: 833621
         rule_id: j2UGvl
-        version_id: qkT2xrQ
-        url: https://semgrep.dev/playground/r/qkT2xrQ/generic.secrets.gitleaks.dynatrace-api-token.dynatrace-api-token
+        version_id: bZTBeDG
+        url: https://semgrep.dev/playground/r/bZTBeDG/generic.secrets.gitleaks.dynatrace-api-token.dynatrace-api-token
         origin: community
   patterns:
   - pattern-regex: dt0c01\.(?i)[a-z0-9]{24}\.[a-z0-9]{64}
@@ -3434,10 +3434,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44707
-        rv_id: 109394
+        rv_id: 833622
         rule_id: 10UJKb
-        version_id: l4T4vYX
-        url: https://semgrep.dev/playground/r/l4T4vYX/generic.secrets.gitleaks.easypost-api-token.easypost-api-token
+        version_id: NdTB20O
+        url: https://semgrep.dev/playground/r/NdTB20O/generic.secrets.gitleaks.easypost-api-token.easypost-api-token
         origin: community
   patterns:
   - pattern-regex: "\\bEZAK(?i)[a-z0-9]{54}"
@@ -3477,10 +3477,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44708
-        rv_id: 109395
+        rv_id: 833623
         rule_id: 9AU811
-        version_id: YDTp2xv
-        url: https://semgrep.dev/playground/r/YDTp2xv/generic.secrets.gitleaks.easypost-test-api-token.easypost-test-api-token
+        version_id: kbT2l04
+        url: https://semgrep.dev/playground/r/kbT2l04/generic.secrets.gitleaks.easypost-test-api-token.easypost-test-api-token
         origin: community
   patterns:
   - pattern-regex: "\\bEZTK(?i)[a-z0-9]{54}"
@@ -3520,10 +3520,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44709
-        rv_id: 109396
+        rv_id: 833624
         rule_id: yyUYnv
-        version_id: 6xTvJkJ
-        url: https://semgrep.dev/playground/r/6xTvJkJ/generic.secrets.gitleaks.etsy-access-token.etsy-access-token
+        version_id: w8TAxB1
+        url: https://semgrep.dev/playground/r/w8TAxB1/generic.secrets.gitleaks.etsy-access-token.etsy-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:etsy)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3563,10 +3563,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 121950
-        rv_id: 760658
+        rv_id: 833625
         rule_id: 4bUR8vw
-        version_id: w8TleZX
-        url: https://semgrep.dev/playground/r/w8TleZX/generic.secrets.gitleaks.facebook-access-token.facebook-access-token
+        version_id: xyTNeDK
+        url: https://semgrep.dev/playground/r/xyTNeDK/generic.secrets.gitleaks.facebook-access-token.facebook-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3606,10 +3606,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 121951
-        rv_id: 729093
+        rv_id: 833626
         rule_id: PeUJbAl
-        version_id: vdT4bA8
-        url: https://semgrep.dev/playground/r/vdT4bA8/generic.secrets.gitleaks.facebook-page-access-token.facebook-page-access-token
+        version_id: O9TJW2k
+        url: https://semgrep.dev/playground/r/O9TJW2k/generic.secrets.gitleaks.facebook-page-access-token.facebook-page-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(EAA[MC][a-z0-9]{20,})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3649,10 +3649,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 121952
-        rv_id: 729094
+        rv_id: 833627
         rule_id: JDUNK7E
-        version_id: d6T4N5y
-        url: https://semgrep.dev/playground/r/d6T4N5y/generic.secrets.gitleaks.facebook-secret.facebook-secret
+        version_id: e1TDk2L
+        url: https://semgrep.dev/playground/r/e1TDk2L/generic.secrets.gitleaks.facebook-secret.facebook-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:facebook)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3692,10 +3692,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44710
-        rv_id: 109397
+        rv_id: 833628
         rule_id: r6UBr9
-        version_id: o5TglP9
-        url: https://semgrep.dev/playground/r/o5TglP9/generic.secrets.gitleaks.facebook.facebook
+        version_id: vdTOzAn
+        url: https://semgrep.dev/playground/r/vdTOzAn/generic.secrets.gitleaks.facebook.facebook
         origin: community
   patterns:
   - pattern-regex: (?i)(?:facebook)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3735,10 +3735,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44711
-        rv_id: 109398
+        rv_id: 833629
         rule_id: bwUPw8
-        version_id: zyTK89b
-        url: https://semgrep.dev/playground/r/zyTK89b/generic.secrets.gitleaks.fastly-api-token.fastly-api-token
+        version_id: d6TKG5z
+        url: https://semgrep.dev/playground/r/d6TKG5z/generic.secrets.gitleaks.fastly-api-token.fastly-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:fastly)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3778,10 +3778,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44712
-        rv_id: 109399
+        rv_id: 833630
         rule_id: NbUvkX
-        version_id: pZT1yJn
-        url: https://semgrep.dev/playground/r/pZT1yJn/generic.secrets.gitleaks.finicity-api-token.finicity-api-token
+        version_id: ZRTlPvg
+        url: https://semgrep.dev/playground/r/ZRTlPvg/generic.secrets.gitleaks.finicity-api-token.finicity-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:finicity)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3821,10 +3821,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44713
-        rv_id: 109400
+        rv_id: 833631
         rule_id: kxUQk2
-        version_id: 2KTzrXR
-        url: https://semgrep.dev/playground/r/2KTzrXR/generic.secrets.gitleaks.finicity-client-secret.finicity-client-secret
+        version_id: nWTy41Z
+        url: https://semgrep.dev/playground/r/nWTy41Z/generic.secrets.gitleaks.finicity-client-secret.finicity-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:finicity)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3864,10 +3864,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44714
-        rv_id: 109401
+        rv_id: 833632
         rule_id: wdUqJk
-        version_id: X0TQxpk
-        url: https://semgrep.dev/playground/r/X0TQxpk/generic.secrets.gitleaks.finnhub-access-token.finnhub-access-token
+        version_id: ExTrD3q
+        url: https://semgrep.dev/playground/r/ExTrD3q/generic.secrets.gitleaks.finnhub-access-token.finnhub-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:finnhub)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3907,10 +3907,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44715
-        rv_id: 109402
+        rv_id: 833633
         rule_id: x8Ulnq
-        version_id: jQTgYpJ
-        url: https://semgrep.dev/playground/r/jQTgYpJ/generic.secrets.gitleaks.flickr-access-token.flickr-access-token
+        version_id: 7ZTx9jx
+        url: https://semgrep.dev/playground/r/7ZTx9jx/generic.secrets.gitleaks.flickr-access-token.flickr-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:flickr)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -3950,10 +3950,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44716
-        rv_id: 109403
+        rv_id: 833634
         rule_id: OrUA3O
-        version_id: 1QTOYnk
-        url: https://semgrep.dev/playground/r/1QTOYnk/generic.secrets.gitleaks.flutterwave-encryption-key.flutterwave-encryption-key
+        version_id: LjTEboz
+        url: https://semgrep.dev/playground/r/LjTEboz/generic.secrets.gitleaks.flutterwave-encryption-key.flutterwave-encryption-key
         origin: community
   patterns:
   - pattern-regex: FLWSECK_TEST-(?i)[a-h0-9]{12}
@@ -3993,10 +3993,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44717
-        rv_id: 109404
+        rv_id: 833635
         rule_id: eqUY83
-        version_id: 9lTdWLn
-        url: https://semgrep.dev/playground/r/9lTdWLn/generic.secrets.gitleaks.flutterwave-public-key.flutterwave-public-key
+        version_id: 8KTGk7K
+        url: https://semgrep.dev/playground/r/8KTGk7K/generic.secrets.gitleaks.flutterwave-public-key.flutterwave-public-key
         origin: community
   patterns:
   - pattern-regex: FLWPUBK_TEST-(?i)[a-h0-9]{32}-X
@@ -4036,10 +4036,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44718
-        rv_id: 109405
+        rv_id: 833636
         rule_id: v8UKn0
-        version_id: yeTR2zQ
-        url: https://semgrep.dev/playground/r/yeTR2zQ/generic.secrets.gitleaks.flutterwave-secret-key.flutterwave-secret-key
+        version_id: gETy2ox
+        url: https://semgrep.dev/playground/r/gETy2ox/generic.secrets.gitleaks.flutterwave-secret-key.flutterwave-secret-key
         origin: community
   patterns:
   - pattern-regex: FLWSECK_TEST-(?i)[a-h0-9]{32}-X
@@ -4079,10 +4079,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44719
-        rv_id: 109406
+        rv_id: 833637
         rule_id: d8UOj3
-        version_id: rxTyLXX
-        url: https://semgrep.dev/playground/r/rxTyLXX/generic.secrets.gitleaks.frameio-api-token.frameio-api-token
+        version_id: QkTkrjw
+        url: https://semgrep.dev/playground/r/QkTkrjw/generic.secrets.gitleaks.frameio-api-token.frameio-api-token
         origin: community
   patterns:
   - pattern-regex: fio-u-(?i)[a-z0-9\-_=]{64}
@@ -4122,10 +4122,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44720
-        rv_id: 109407
+        rv_id: 833638
         rule_id: ZqUk5D
-        version_id: bZTb1JP
-        url: https://semgrep.dev/playground/r/bZTb1JP/generic.secrets.gitleaks.freshbooks-access-token.freshbooks-access-token
+        version_id: 3ZT3Az4
+        url: https://semgrep.dev/playground/r/3ZT3Az4/generic.secrets.gitleaks.freshbooks-access-token.freshbooks-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:freshbooks)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4165,10 +4165,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44721
-        rv_id: 109408
+        rv_id: 833639
         rule_id: nJU5zJ
-        version_id: NdT3dEW
-        url: https://semgrep.dev/playground/r/NdT3dEW/generic.secrets.gitleaks.gcp-api-key.gcp-api-key
+        version_id: 44TQPw9
+        url: https://semgrep.dev/playground/r/44TQPw9/generic.secrets.gitleaks.gcp-api-key.gcp-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)\b(AIza[0-9A-Za-z\\-_]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4208,10 +4208,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44723
-        rv_id: 109410
+        rv_id: 833641
         rule_id: 7KUJQX
-        version_id: w8T9nvB
-        url: https://semgrep.dev/playground/r/w8T9nvB/generic.secrets.gitleaks.github-app-token.github-app-token
+        version_id: JdTlrYG
+        url: https://semgrep.dev/playground/r/JdTlrYG/generic.secrets.gitleaks.github-app-token.github-app-token
         origin: community
   patterns:
   - pattern-regex: "(ghu|ghs)_[0-9a-zA-Z]{36}"
@@ -4251,10 +4251,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44724
-        rv_id: 109411
+        rv_id: 833642
         rule_id: L1ULyp
-        version_id: xyTKZ1g
-        url: https://semgrep.dev/playground/r/xyTKZ1g/generic.secrets.gitleaks.github-fine-grained-pat.github-fine-grained-pat
+        version_id: 5PTyD2E
+        url: https://semgrep.dev/playground/r/5PTyD2E/generic.secrets.gitleaks.github-fine-grained-pat.github-fine-grained-pat
         origin: community
   patterns:
   - pattern-regex: github_pat_[0-9a-zA-Z_]{82}
@@ -4294,10 +4294,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44725
-        rv_id: 109412
+        rv_id: 833643
         rule_id: 8GUPjW
-        version_id: O9TNOr9
-        url: https://semgrep.dev/playground/r/O9TNOr9/generic.secrets.gitleaks.github-oauth.github-oauth
+        version_id: GxTDEKJ
+        url: https://semgrep.dev/playground/r/GxTDEKJ/generic.secrets.gitleaks.github-oauth.github-oauth
         origin: community
   patterns:
   - pattern-regex: gho_[0-9a-zA-Z]{36}
@@ -4337,10 +4337,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44726
-        rv_id: 109413
+        rv_id: 833644
         rule_id: gxUv1p
-        version_id: e1T01w5
-        url: https://semgrep.dev/playground/r/e1T01w5/generic.secrets.gitleaks.github-pat.github-pat
+        version_id: RGTKGZw
+        url: https://semgrep.dev/playground/r/RGTKGZw/generic.secrets.gitleaks.github-pat.github-pat
         origin: community
   patterns:
   - pattern-regex: ghp_[0-9a-zA-Z]{36}
@@ -4380,10 +4380,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44727
-        rv_id: 109414
+        rv_id: 833645
         rule_id: QrURzR
-        version_id: vdTYNJe
-        url: https://semgrep.dev/playground/r/vdTYNJe/generic.secrets.gitleaks.github-refresh-token.github-refresh-token
+        version_id: A8T37Zy
+        url: https://semgrep.dev/playground/r/A8T37Zy/generic.secrets.gitleaks.github-refresh-token.github-refresh-token
         origin: community
   patterns:
   - pattern-regex: ghr_[0-9a-zA-Z]{36}
@@ -4423,10 +4423,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44728
-        rv_id: 109415
+        rv_id: 833646
         rule_id: 3qU5PK
-        version_id: d6TrAEY
-        url: https://semgrep.dev/playground/r/d6TrAEY/generic.secrets.gitleaks.gitlab-pat.gitlab-pat
+        version_id: BjTe0no
+        url: https://semgrep.dev/playground/r/BjTe0no/generic.secrets.gitleaks.gitlab-pat.gitlab-pat
         origin: community
   patterns:
   - pattern-regex: glpat-[0-9a-zA-Z\-\_]{20}
@@ -4466,10 +4466,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44729
-        rv_id: 109416
+        rv_id: 833647
         rule_id: 4bUKkW
-        version_id: ZRTQNJo
-        url: https://semgrep.dev/playground/r/ZRTQNJo/generic.secrets.gitleaks.gitlab-ptt.gitlab-ptt
+        version_id: DkTG0ZB
+        url: https://semgrep.dev/playground/r/DkTG0ZB/generic.secrets.gitleaks.gitlab-ptt.gitlab-ptt
         origin: community
   patterns:
   - pattern-regex: glptt-[0-9a-f]{40}
@@ -4509,10 +4509,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44730
-        rv_id: 109417
+        rv_id: 833648
         rule_id: PeU7ZX
-        version_id: nWTxPlg
-        url: https://semgrep.dev/playground/r/nWTxPlg/generic.secrets.gitleaks.gitlab-rrt.gitlab-rrt
+        version_id: WrTdpA5
+        url: https://semgrep.dev/playground/r/WrTdpA5/generic.secrets.gitleaks.gitlab-rrt.gitlab-rrt
         origin: community
   patterns:
   - pattern-regex: GR1348941[0-9a-zA-Z\-\_]{20}
@@ -4552,10 +4552,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44731
-        rv_id: 109418
+        rv_id: 833649
         rule_id: JDUOyB
-        version_id: ExTjNbD
-        url: https://semgrep.dev/playground/r/ExTjNbD/generic.secrets.gitleaks.gitter-access-token.gitter-access-token
+        version_id: 0bTwbYR
+        url: https://semgrep.dev/playground/r/0bTwbYR/generic.secrets.gitleaks.gitter-access-token.gitter-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:gitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4595,10 +4595,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44732
-        rv_id: 109419
+        rv_id: 833650
         rule_id: 5rUKOQ
-        version_id: 7ZTgowR
-        url: https://semgrep.dev/playground/r/7ZTgowR/generic.secrets.gitleaks.gocardless-api-token.gocardless-api-token
+        version_id: K3Trq66
+        url: https://semgrep.dev/playground/r/K3Trq66/generic.secrets.gitleaks.gocardless-api-token.gocardless-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:gocardless)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4638,10 +4638,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44733
-        rv_id: 109420
+        rv_id: 833651
         rule_id: GdUb7y
-        version_id: LjTqQJg
-        url: https://semgrep.dev/playground/r/LjTqQJg/generic.secrets.gitleaks.grafana-api-key.grafana-api-key
+        version_id: qkTQnPd
+        url: https://semgrep.dev/playground/r/qkTQnPd/generic.secrets.gitleaks.grafana-api-key.grafana-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4681,10 +4681,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44734
-        rv_id: 109421
+        rv_id: 833652
         rule_id: ReUNgJ
-        version_id: 8KTQ90Z
-        url: https://semgrep.dev/playground/r/8KTQ90Z/generic.secrets.gitleaks.grafana-cloud-api-token.grafana-cloud-api-token
+        version_id: l4TyOAg
+        url: https://semgrep.dev/playground/r/l4TyOAg/generic.secrets.gitleaks.grafana-cloud-api-token.grafana-cloud-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4724,10 +4724,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44735
-        rv_id: 109422
+        rv_id: 833653
         rule_id: AbUvzB
-        version_id: gET3xpl
-        url: https://semgrep.dev/playground/r/gET3xpl/generic.secrets.gitleaks.grafana-service-account-token.grafana-service-account-token
+        version_id: YDTl0K5
+        url: https://semgrep.dev/playground/r/YDTl0K5/generic.secrets.gitleaks.grafana-service-account-token.grafana-service-account-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4767,10 +4767,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 137285
-        rv_id: 762643
+        rv_id: 833654
         rule_id: NbU3pxA
-        version_id: BjTzE9L
-        url: https://semgrep.dev/playground/r/BjTzE9L/generic.secrets.gitleaks.harness-api-key.harness-api-key
+        version_id: JdTlrY0
+        url: https://semgrep.dev/playground/r/JdTlrY0/generic.secrets.gitleaks.harness-api-key.harness-api-key
         origin: community
   patterns:
   - pattern-regex: "((?:pat|sat)\\.[a-zA-Z0-9]{22}\\.[a-zA-Z0-9]{24}\\.[a-zA-Z0-9]{20})"
@@ -4810,10 +4810,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44736
-        rv_id: 109423
+        rv_id: 833655
         rule_id: BYU4N6
-        version_id: QkTW0Lb
-        url: https://semgrep.dev/playground/r/QkTW0Lb/generic.secrets.gitleaks.hashicorp-tf-api-token.hashicorp-tf-api-token
+        version_id: 5PTyD2Z
+        url: https://semgrep.dev/playground/r/5PTyD2Z/generic.secrets.gitleaks.hashicorp-tf-api-token.hashicorp-tf-api-token
         origin: community
   patterns:
   - pattern-regex: "(?i)[a-z0-9]{14}\\.atlasv1\\.[a-z0-9\\-_=]{60,70}"
@@ -4853,10 +4853,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 92970
-        rv_id: 230003
+        rv_id: 833656
         rule_id: BYUXNWY
-        version_id: kbTgNPD
-        url: https://semgrep.dev/playground/r/kbTgNPD/generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
+        version_id: GxTDEKp
+        url: https://semgrep.dev/playground/r/GxTDEKp/generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
         origin: community
   patterns:
   - pattern-regex: (?i)(?:administrator_login_password|password)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4896,10 +4896,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44737
-        rv_id: 109424
+        rv_id: 833657
         rule_id: DbUBpr
-        version_id: 3ZTkQgo
-        url: https://semgrep.dev/playground/r/3ZTkQgo/generic.secrets.gitleaks.heroku-api-key.heroku-api-key
+        version_id: RGTKGZ4
+        url: https://semgrep.dev/playground/r/RGTKGZ4/generic.secrets.gitleaks.heroku-api-key.heroku-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:heroku)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4939,10 +4939,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44738
-        rv_id: 109425
+        rv_id: 833658
         rule_id: WAUeop
-        version_id: 44TRlJo
-        url: https://semgrep.dev/playground/r/44TRlJo/generic.secrets.gitleaks.hubspot-api-key.hubspot-api-key
+        version_id: A8T37Z7
+        url: https://semgrep.dev/playground/r/A8T37Z7/generic.secrets.gitleaks.hubspot-api-key.hubspot-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:hubspot)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -4982,10 +4982,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67936
-        rv_id: 109426
+        rv_id: 833659
         rule_id: j2Ujvk
-        version_id: PkTJ1KL
-        url: https://semgrep.dev/playground/r/PkTJ1KL/generic.secrets.gitleaks.huggingface-access-token.huggingface-access-token
+        version_id: BjTe0nL
+        url: https://semgrep.dev/playground/r/BjTe0nL/generic.secrets.gitleaks.huggingface-access-token.huggingface-access-token
         origin: community
   patterns:
   - pattern-regex: (?:^|[\\'"` >=:])(hf_[a-zA-Z]{34})(?:$|[\\'"` <])
@@ -5025,10 +5025,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67937
-        rv_id: 109427
+        rv_id: 833660
         rule_id: 10UNKO
-        version_id: JdTNp47
-        url: https://semgrep.dev/playground/r/JdTNp47/generic.secrets.gitleaks.huggingface-organization-api-token.huggingface-organization-api-token
+        version_id: DkTG0Zb
+        url: https://semgrep.dev/playground/r/DkTG0Zb/generic.secrets.gitleaks.huggingface-organization-api-token.huggingface-organization-api-token
         origin: community
   patterns:
   - pattern-regex: (?:^|[\\'"` >=:\(,)])(api_org_[a-zA-Z]{34})(?:$|[\\'"` <\),])
@@ -5068,10 +5068,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72099
-        rv_id: 109428
+        rv_id: 833661
         rule_id: 3qU1LG
-        version_id: 5PTdAKJ
-        url: https://semgrep.dev/playground/r/5PTdAKJ/generic.secrets.gitleaks.infracost-api-token.infracost-api-token
+        version_id: WrTdpAw
+        url: https://semgrep.dev/playground/r/WrTdpAw/generic.secrets.gitleaks.infracost-api-token.infracost-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(ico-[a-zA-Z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5111,10 +5111,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44739
-        rv_id: 109429
+        rv_id: 833662
         rule_id: 0oU053
-        version_id: GxTv6bv
-        url: https://semgrep.dev/playground/r/GxTv6bv/generic.secrets.gitleaks.intercom-api-key.intercom-api-key
+        version_id: 0bTwbYd
+        url: https://semgrep.dev/playground/r/0bTwbYd/generic.secrets.gitleaks.intercom-api-key.intercom-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:intercom)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{60})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5154,10 +5154,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 136486
-        rv_id: 760659
+        rv_id: 833663
         rule_id: nJUx1de
-        version_id: xyTGYX6
-        url: https://semgrep.dev/playground/r/xyTGYX6/generic.secrets.gitleaks.intra42-client-secret.intra42-client-secret
+        version_id: K3Trq6d
+        url: https://semgrep.dev/playground/r/K3Trq6d/generic.secrets.gitleaks.intra42-client-secret.intra42-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5197,10 +5197,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66772
-        rv_id: 109430
+        rv_id: 833664
         rule_id: qNUn9g
-        version_id: RGTDkNe
-        url: https://semgrep.dev/playground/r/RGTDkNe/generic.secrets.gitleaks.jfrog-api-key.jfrog-api-key
+        version_id: qkTQnP0
+        url: https://semgrep.dev/playground/r/qkTQnP0/generic.secrets.gitleaks.jfrog-api-key.jfrog-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5240,10 +5240,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66773
-        rv_id: 109431
+        rv_id: 833665
         rule_id: lBUOew
-        version_id: A8T95vr
-        url: https://semgrep.dev/playground/r/A8T95vr/generic.secrets.gitleaks.jfrog-identity-token.jfrog-identity-token
+        version_id: l4TyOA5
+        url: https://semgrep.dev/playground/r/l4TyOA5/generic.secrets.gitleaks.jfrog-identity-token.jfrog-identity-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5283,10 +5283,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67938
-        rv_id: 109432
+        rv_id: 833666
         rule_id: 9AU71e
-        version_id: BjTXr4N
-        url: https://semgrep.dev/playground/r/BjTXr4N/generic.secrets.gitleaks.jwt-base64.jwt-base64
+        version_id: YDTl0KP
+        url: https://semgrep.dev/playground/r/YDTl0KP/generic.secrets.gitleaks.jwt-base64.jwt-base64
         origin: community
   patterns:
   - pattern-regex: "\\bZXlK(?:(?P<alg>aGJHY2lPaU)|(?P<apu>aGNIVWlPaU)|(?P<apv>aGNIWWlPaU)|(?P<aud>aGRXUWlPaU)|(?P<b64>aU5qUWlP)|(?P<crit>amNtbDBJanBi)|(?P<cty>amRIa2lPaU)|(?P<epk>bGNHc2lPbn)|(?P<enc>bGJtTWlPaU)|(?P<jku>cWEzVWlPaU)|(?P<jwk>cWQyc2lPb)|(?P<iss>cGMzTWlPaU)|(?P<iv>cGRpSTZJ)|(?P<kid>cmFXUWlP)|(?P<key_ops>clpYbGZiM0J6SWpwY)|(?P<kty>cmRIa2lPaUp)|(?P<nonce>dWIyNWpaU0k2)|(?P<p2c>d01tTWlP)|(?P<p2s>d01uTWlPaU)|(?P<ppt>d2NIUWlPaU)|(?P<sub>emRXSWlPaU)|(?P<svt>emRuUWlP)|(?P<tag>MFlXY2lPaU)|(?P<typ>MGVYQWlPaUp)|(?P<url>MWNtd2l)|(?P<use>MWMyVWlPaUp)|(?P<ver>MlpYSWlPaU)|(?P<version>MlpYSnphVzl1SWpv)|(?P<x>NElqb2)|(?P<x5c>NE5XTWlP)|(?P<x5t>NE5YUWlPaU)|(?P<x5ts256>NE5YUWpVekkxTmlJNkl)|(?P<x5u>NE5YVWlPaU)|(?P<zip>NmFYQWlPaU))[a-zA-Z0-9\\/\\\\_+\\-\\r\\n]{40,}={0,2}"
@@ -5325,10 +5325,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44740
-        rv_id: 109433
+        rv_id: 833667
         rule_id: KxUAbk
-        version_id: DkT6nBW
-        url: https://semgrep.dev/playground/r/DkT6nBW/generic.secrets.gitleaks.jwt.jwt
+        version_id: 6xTDgwp
+        url: https://semgrep.dev/playground/r/6xTDgwp/generic.secrets.gitleaks.jwt.jwt
         origin: community
   patterns:
   - pattern-regex: \b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5368,10 +5368,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44741
-        rv_id: 109434
+        rv_id: 833668
         rule_id: qNUAjy
-        version_id: WrTWQeP
-        url: https://semgrep.dev/playground/r/WrTWQeP/generic.secrets.gitleaks.kraken-access-token.kraken-access-token
+        version_id: o5TBE3X
+        url: https://semgrep.dev/playground/r/o5TBE3X/generic.secrets.gitleaks.kraken-access-token.kraken-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:kraken)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5411,10 +5411,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44742
-        rv_id: 109435
+        rv_id: 833669
         rule_id: lBU39j
-        version_id: 0bTLl02
-        url: https://semgrep.dev/playground/r/0bTLl02/generic.secrets.gitleaks.kucoin-access-token.kucoin-access-token
+        version_id: zyTWJwK
+        url: https://semgrep.dev/playground/r/zyTWJwK/generic.secrets.gitleaks.kucoin-access-token.kucoin-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:kucoin)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5454,10 +5454,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44743
-        rv_id: 109436
+        rv_id: 833670
         rule_id: PeU7Zg
-        version_id: K3TvjA5
-        url: https://semgrep.dev/playground/r/K3TvjA5/generic.secrets.gitleaks.kucoin-secret-key.kucoin-secret-key
+        version_id: pZTXjdk
+        url: https://semgrep.dev/playground/r/pZTXjdk/generic.secrets.gitleaks.kucoin-secret-key.kucoin-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:kucoin)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5497,10 +5497,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44744
-        rv_id: 109437
+        rv_id: 833671
         rule_id: JDUOyJ
-        version_id: qkT2xAQ
-        url: https://semgrep.dev/playground/r/qkT2xAQ/generic.secrets.gitleaks.launchdarkly-access-token.launchdarkly-access-token
+        version_id: 2KT7xkQ
+        url: https://semgrep.dev/playground/r/2KT7xkQ/generic.secrets.gitleaks.launchdarkly-access-token.launchdarkly-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:launchdarkly)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5540,10 +5540,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44745
-        rv_id: 109438
+        rv_id: 833672
         rule_id: 5rUKO6
-        version_id: l4T4v3X
-        url: https://semgrep.dev/playground/r/l4T4v3X/generic.secrets.gitleaks.linear-api-key.linear-api-key
+        version_id: X0T5Nj8
+        url: https://semgrep.dev/playground/r/X0T5Nj8/generic.secrets.gitleaks.linear-api-key.linear-api-key
         origin: community
   patterns:
   - pattern-regex: lin_api_(?i)[a-z0-9]{40}
@@ -5583,10 +5583,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44746
-        rv_id: 109439
+        rv_id: 833673
         rule_id: GdUb7w
-        version_id: YDTp2gv
-        url: https://semgrep.dev/playground/r/YDTp2gv/generic.secrets.gitleaks.linear-client-secret.linear-client-secret
+        version_id: jQTrX4q
+        url: https://semgrep.dev/playground/r/jQTrX4q/generic.secrets.gitleaks.linear-client-secret.linear-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:linear)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5626,10 +5626,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44747
-        rv_id: 109440
+        rv_id: 833674
         rule_id: ReUNg1
-        version_id: 6xTvJ4J
-        url: https://semgrep.dev/playground/r/6xTvJ4J/generic.secrets.gitleaks.linkedin-client-id.linkedin-client-id
+        version_id: 1QTPLRe
+        url: https://semgrep.dev/playground/r/1QTPLRe/generic.secrets.gitleaks.linkedin-client-id.linkedin-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:linkedin|linked-in)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{14})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5669,10 +5669,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44748
-        rv_id: 109441
+        rv_id: 833675
         rule_id: AbUvWj
-        version_id: o5TglG9
-        url: https://semgrep.dev/playground/r/o5TglG9/generic.secrets.gitleaks.linkedin-client-secret.linkedin-client-secret
+        version_id: 9lTJ0GR
+        url: https://semgrep.dev/playground/r/9lTJ0GR/generic.secrets.gitleaks.linkedin-client-secret.linkedin-client-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:linkedin|linked-in)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5712,10 +5712,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44749
-        rv_id: 109442
+        rv_id: 833676
         rule_id: BYU4BX
-        version_id: zyTK86b
-        url: https://semgrep.dev/playground/r/zyTK86b/generic.secrets.gitleaks.lob-api-key.lob-api-key
+        version_id: yeTN14A
+        url: https://semgrep.dev/playground/r/yeTN14A/generic.secrets.gitleaks.lob-api-key.lob-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5755,10 +5755,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44750
-        rv_id: 109443
+        rv_id: 833677
         rule_id: DbUBWq
-        version_id: pZT1yRn
-        url: https://semgrep.dev/playground/r/pZT1yRn/generic.secrets.gitleaks.lob-pub-api-key.lob-pub-api-key
+        version_id: rxTDzpD
+        url: https://semgrep.dev/playground/r/rxTDzpD/generic.secrets.gitleaks.lob-pub-api-key.lob-pub-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5798,10 +5798,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44751
-        rv_id: 729095
+        rv_id: 833678
         rule_id: WAUeZl
-        version_id: ZRTGRv2
-        url: https://semgrep.dev/playground/r/ZRTGRv2/generic.secrets.gitleaks.mailchimp-api-key.mailchimp-api-key
+        version_id: bZTBe7L
+        url: https://semgrep.dev/playground/r/bZTBe7L/generic.secrets.gitleaks.mailchimp-api-key.mailchimp-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:MailchimpSDK.initialize|mailchimp)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32}-us\d\d)(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5841,10 +5841,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44752
-        rv_id: 109445
+        rv_id: 833679
         rule_id: 0oU0E5
-        version_id: X0TQxGk
-        url: https://semgrep.dev/playground/r/X0TQxGk/generic.secrets.gitleaks.mailgun-private-api-token.mailgun-private-api-token
+        version_id: NdTB2Kq
+        url: https://semgrep.dev/playground/r/NdTB2Kq/generic.secrets.gitleaks.mailgun-private-api-token.mailgun-private-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:mailgun)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5884,10 +5884,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44753
-        rv_id: 109446
+        rv_id: 833680
         rule_id: KxUA44
-        version_id: jQTgYGJ
-        url: https://semgrep.dev/playground/r/jQTgYGJ/generic.secrets.gitleaks.mailgun-pub-key.mailgun-pub-key
+        version_id: kbT2lBx
+        url: https://semgrep.dev/playground/r/kbT2lBx/generic.secrets.gitleaks.mailgun-pub-key.mailgun-pub-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:mailgun)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5927,10 +5927,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44754
-        rv_id: 109447
+        rv_id: 833681
         rule_id: qNUAob
-        version_id: 1QTOYJk
-        url: https://semgrep.dev/playground/r/1QTOYJk/generic.secrets.gitleaks.mailgun-signing-key.mailgun-signing-key
+        version_id: w8TAxPD
+        url: https://semgrep.dev/playground/r/w8TAxPD/generic.secrets.gitleaks.mailgun-signing-key.mailgun-signing-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:mailgun)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -5970,10 +5970,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44755
-        rv_id: 109448
+        rv_id: 833682
         rule_id: lBU3d8
-        version_id: 9lTdW8n
-        url: https://semgrep.dev/playground/r/9lTdW8n/generic.secrets.gitleaks.mapbox-api-token.mapbox-api-token
+        version_id: xyTNegj
+        url: https://semgrep.dev/playground/r/xyTNegj/generic.secrets.gitleaks.mapbox-api-token.mapbox-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:mapbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6013,10 +6013,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44756
-        rv_id: 109449
+        rv_id: 833683
         rule_id: YGUgrA
-        version_id: yeTR2YQ
-        url: https://semgrep.dev/playground/r/yeTR2YQ/generic.secrets.gitleaks.mattermost-access-token.mattermost-access-token
+        version_id: O9TJWq8
+        url: https://semgrep.dev/playground/r/O9TJWq8/generic.secrets.gitleaks.mattermost-access-token.mattermost-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:mattermost)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6056,10 +6056,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44757
-        rv_id: 109450
+        rv_id: 833684
         rule_id: 6JU4qD
-        version_id: rxTyLBX
-        url: https://semgrep.dev/playground/r/rxTyLBX/generic.secrets.gitleaks.messagebird-api-token.messagebird-api-token
+        version_id: e1TDko4
+        url: https://semgrep.dev/playground/r/e1TDko4/generic.secrets.gitleaks.messagebird-api-token.messagebird-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:messagebird|message-bird|message_bird)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6099,10 +6099,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44758
-        rv_id: 109451
+        rv_id: 833685
         rule_id: oqUGzK
-        version_id: bZTb1PP
-        url: https://semgrep.dev/playground/r/bZTb1PP/generic.secrets.gitleaks.messagebird-client-id.messagebird-client-id
+        version_id: vdTOzwo
+        url: https://semgrep.dev/playground/r/vdTOzwo/generic.secrets.gitleaks.messagebird-client-id.messagebird-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:messagebird|message-bird|message_bird)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6142,10 +6142,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44759
-        rv_id: 109452
+        rv_id: 833686
         rule_id: zdU6yl
-        version_id: NdT3dvW
-        url: https://semgrep.dev/playground/r/NdT3dvW/generic.secrets.gitleaks.microsoft-teams-webhook.microsoft-teams-webhook
+        version_id: d6TKG0L
+        url: https://semgrep.dev/playground/r/d6TKG0L/generic.secrets.gitleaks.microsoft-teams-webhook.microsoft-teams-webhook
         origin: community
   patterns:
   - pattern-regex: https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}
@@ -6185,10 +6185,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44760
-        rv_id: 109453
+        rv_id: 833687
         rule_id: pKURGy
-        version_id: kbTdxQ0
-        url: https://semgrep.dev/playground/r/kbTdxQ0/generic.secrets.gitleaks.netlify-access-token.netlify-access-token
+        version_id: ZRTlP9X
+        url: https://semgrep.dev/playground/r/ZRTlP9X/generic.secrets.gitleaks.netlify-access-token.netlify-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:netlify)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6228,10 +6228,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44761
-        rv_id: 109454
+        rv_id: 833688
         rule_id: 2ZUn43
-        version_id: w8T9nqB
-        url: https://semgrep.dev/playground/r/w8T9nqB/generic.secrets.gitleaks.new-relic-browser-api-token.new-relic-browser-api-token
+        version_id: nWTy4bw
+        url: https://semgrep.dev/playground/r/nWTy4bw/generic.secrets.gitleaks.new-relic-browser-api-token.new-relic-browser-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6271,10 +6271,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 136487
-        rv_id: 760660
+        rv_id: 833689
         rule_id: EwUj3dB
-        version_id: O9TlPe5
-        url: https://semgrep.dev/playground/r/O9TlPe5/generic.secrets.gitleaks.new-relic-insert-key.new-relic-insert-key
+        version_id: ExTrDLd
+        url: https://semgrep.dev/playground/r/ExTrDLd/generic.secrets.gitleaks.new-relic-insert-key.new-relic-insert-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRII-[a-z0-9-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6314,10 +6314,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44762
-        rv_id: 109455
+        rv_id: 833690
         rule_id: X5UGZz
-        version_id: xyTKZlg
-        url: https://semgrep.dev/playground/r/xyTKZlg/generic.secrets.gitleaks.new-relic-user-api-id.new-relic-user-api-id
+        version_id: 7ZTx9lw
+        url: https://semgrep.dev/playground/r/7ZTx9lw/generic.secrets.gitleaks.new-relic-user-api-id.new-relic-user-api-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6357,10 +6357,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44763
-        rv_id: 109456
+        rv_id: 833691
         rule_id: j2UGqB
-        version_id: O9TNOA9
-        url: https://semgrep.dev/playground/r/O9TNOA9/generic.secrets.gitleaks.new-relic-user-api-key.new-relic-user-api-key
+        version_id: LjTEbWL
+        url: https://semgrep.dev/playground/r/LjTEbWL/generic.secrets.gitleaks.new-relic-user-api-key.new-relic-user-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6400,10 +6400,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44764
-        rv_id: 109457
+        rv_id: 833692
         rule_id: 10UJZE
-        version_id: e1T01Y5
-        url: https://semgrep.dev/playground/r/e1T01Y5/generic.secrets.gitleaks.npm-access-token.npm-access-token
+        version_id: 8KTGkJo
+        url: https://semgrep.dev/playground/r/8KTGkJo/generic.secrets.gitleaks.npm-access-token.npm-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(npm_[a-z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6443,10 +6443,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44765
-        rv_id: 109458
+        rv_id: 833693
         rule_id: 9AU8Oq
-        version_id: vdTYNKe
-        url: https://semgrep.dev/playground/r/vdTYNKe/generic.secrets.gitleaks.nytimes-access-token.nytimes-access-token
+        version_id: gETy2RG
+        url: https://semgrep.dev/playground/r/gETy2RG/generic.secrets.gitleaks.nytimes-access-token.nytimes-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:nytimes|new-york-times,|newyorktimes)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6486,10 +6486,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44766
-        rv_id: 109459
+        rv_id: 833694
         rule_id: yyUYve
-        version_id: d6TrAOY
-        url: https://semgrep.dev/playground/r/d6TrAOY/generic.secrets.gitleaks.okta-access-token.okta-access-token
+        version_id: QkTkrYj
+        url: https://semgrep.dev/playground/r/QkTkrYj/generic.secrets.gitleaks.okta-access-token.okta-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:okta)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{42})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6529,10 +6529,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66774
-        rv_id: 109460
+        rv_id: 833695
         rule_id: YGU0zK
-        version_id: ZRTQNko
-        url: https://semgrep.dev/playground/r/ZRTQNko/generic.secrets.gitleaks.openai-api-key.openai-api-key
+        version_id: 3ZT3AGG
+        url: https://semgrep.dev/playground/r/3ZT3AGG/generic.secrets.gitleaks.openai-api-key.openai-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6572,10 +6572,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44767
-        rv_id: 109461
+        rv_id: 833696
         rule_id: r6UBkG
-        version_id: nWTxP5g
-        url: https://semgrep.dev/playground/r/nWTxP5g/generic.secrets.gitleaks.plaid-api-token.plaid-api-token
+        version_id: 44TQPLB
+        url: https://semgrep.dev/playground/r/44TQPLB/generic.secrets.gitleaks.plaid-api-token.plaid-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6615,10 +6615,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44768
-        rv_id: 109462
+        rv_id: 833697
         rule_id: bwUPO4
-        version_id: ExTjNyD
-        url: https://semgrep.dev/playground/r/ExTjNyD/generic.secrets.gitleaks.plaid-client-id.plaid-client-id
+        version_id: PkTxrlv
+        url: https://semgrep.dev/playground/r/PkTxrlv/generic.secrets.gitleaks.plaid-client-id.plaid-client-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6658,10 +6658,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44769
-        rv_id: 109463
+        rv_id: 833698
         rule_id: NbUvA5
-        version_id: 7ZTgoJR
-        url: https://semgrep.dev/playground/r/7ZTgoJR/generic.secrets.gitleaks.plaid-secret-key.plaid-secret-key
+        version_id: JdTlrB0
+        url: https://semgrep.dev/playground/r/JdTlrB0/generic.secrets.gitleaks.plaid-secret-key.plaid-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6701,10 +6701,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44770
-        rv_id: 109464
+        rv_id: 833699
         rule_id: kxUQR9
-        version_id: LjTqQLg
-        url: https://semgrep.dev/playground/r/LjTqQLg/generic.secrets.gitleaks.planetscale-api-token.planetscale-api-token
+        version_id: 5PTyDRZ
+        url: https://semgrep.dev/playground/r/5PTyDRZ/generic.secrets.gitleaks.planetscale-api-token.planetscale-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(pscale_tkn_(?i)[a-z0-9=\-_\.]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6744,10 +6744,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44771
-        rv_id: 109465
+        rv_id: 833700
         rule_id: wdUq8q
-        version_id: 8KTQ9PZ
-        url: https://semgrep.dev/playground/r/8KTQ9PZ/generic.secrets.gitleaks.planetscale-oauth-token.planetscale-oauth-token
+        version_id: GxTDEnp
+        url: https://semgrep.dev/playground/r/GxTDEnp/generic.secrets.gitleaks.planetscale-oauth-token.planetscale-oauth-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(pscale_oauth_(?i)[a-z0-9=\-_\.]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6787,10 +6787,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44772
-        rv_id: 109466
+        rv_id: 833701
         rule_id: x8UlWb
-        version_id: gET3xvl
-        url: https://semgrep.dev/playground/r/gET3xvl/generic.secrets.gitleaks.planetscale-password.planetscale-password
+        version_id: RGTKG64
+        url: https://semgrep.dev/playground/r/RGTKG64/generic.secrets.gitleaks.planetscale-password.planetscale-password
         origin: community
   patterns:
   - pattern-regex: (?i)\b(pscale_pw_(?i)[a-z0-9=\-_\.]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6830,10 +6830,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44773
-        rv_id: 109467
+        rv_id: 833702
         rule_id: OrUAGK
-        version_id: QkTW0Rb
-        url: https://semgrep.dev/playground/r/QkTW0Rb/generic.secrets.gitleaks.postman-api-token.postman-api-token
+        version_id: A8T37O7
+        url: https://semgrep.dev/playground/r/A8T37O7/generic.secrets.gitleaks.postman-api-token.postman-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6873,10 +6873,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44774
-        rv_id: 109468
+        rv_id: 833703
         rule_id: eqUYv2
-        version_id: 3ZTkQ5o
-        url: https://semgrep.dev/playground/r/3ZTkQ5o/generic.secrets.gitleaks.prefect-api-token.prefect-api-token
+        version_id: BjTe0gL
+        url: https://semgrep.dev/playground/r/BjTe0gL/generic.secrets.gitleaks.prefect-api-token.prefect-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(pnu_[a-z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -6916,10 +6916,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44775
-        rv_id: 109469
+        rv_id: 833704
         rule_id: v8UK5w
-        version_id: 44TRlKo
-        url: https://semgrep.dev/playground/r/44TRlKo/generic.secrets.gitleaks.private-key.private-key
+        version_id: DkTG0Pb
+        url: https://semgrep.dev/playground/r/DkTG0Pb/generic.secrets.gitleaks.private-key.private-key
         origin: community
   patterns:
   - pattern-regex: "(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\\s\\S-]*KEY(
@@ -6960,10 +6960,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44776
-        rv_id: 109470
+        rv_id: 833705
         rule_id: d8UOzo
-        version_id: PkTJ17L
-        url: https://semgrep.dev/playground/r/PkTJ17L/generic.secrets.gitleaks.pulumi-api-token.pulumi-api-token
+        version_id: WrTdpXw
+        url: https://semgrep.dev/playground/r/WrTdpXw/generic.secrets.gitleaks.pulumi-api-token.pulumi-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(pul-[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7003,10 +7003,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44777
-        rv_id: 109471
+        rv_id: 833706
         rule_id: ZqUkqn
-        version_id: JdTNpO7
-        url: https://semgrep.dev/playground/r/JdTNpO7/generic.secrets.gitleaks.pypi-upload-token.pypi-upload-token
+        version_id: 0bTwb8d
+        url: https://semgrep.dev/playground/r/0bTwb8d/generic.secrets.gitleaks.pypi-upload-token.pypi-upload-token
         origin: community
   patterns:
   - pattern-regex: pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,1000}
@@ -7046,10 +7046,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44778
-        rv_id: 109472
+        rv_id: 833707
         rule_id: nJU5YX
-        version_id: 5PTdAlJ
-        url: https://semgrep.dev/playground/r/5PTdAlJ/generic.secrets.gitleaks.rapidapi-access-token.rapidapi-access-token
+        version_id: K3TrqDd
+        url: https://semgrep.dev/playground/r/K3TrqDd/generic.secrets.gitleaks.rapidapi-access-token.rapidapi-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:rapidapi)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7089,10 +7089,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44779
-        rv_id: 109473
+        rv_id: 833708
         rule_id: EwUy4Z
-        version_id: GxTv6Ov
-        url: https://semgrep.dev/playground/r/GxTv6Ov/generic.secrets.gitleaks.readme-api-token.readme-api-token
+        version_id: qkTQnd0
+        url: https://semgrep.dev/playground/r/qkTQnd0/generic.secrets.gitleaks.readme-api-token.readme-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(rdme_[a-z0-9]{70})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7132,10 +7132,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44780
-        rv_id: 109474
+        rv_id: 833709
         rule_id: 7KUJek
-        version_id: RGTDkWe
-        url: https://semgrep.dev/playground/r/RGTDkWe/generic.secrets.gitleaks.rubygems-api-token.rubygems-api-token
+        version_id: l4TyOK5
+        url: https://semgrep.dev/playground/r/l4TyOK5/generic.secrets.gitleaks.rubygems-api-token.rubygems-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(rubygems_[a-f0-9]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7175,10 +7175,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67939
-        rv_id: 750524
+        rv_id: 833710
         rule_id: yyUgnB
-        version_id: DkTxyJw
-        url: https://semgrep.dev/playground/r/DkTxyJw/generic.secrets.gitleaks.scalingo-api-token.scalingo-api-token
+        version_id: YDTl01P
+        url: https://semgrep.dev/playground/r/YDTl01P/generic.secrets.gitleaks.scalingo-api-token.scalingo-api-token
         origin: community
   patterns:
   - pattern-regex: \b(tk-us-[a-zA-Z0-9-_]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7218,10 +7218,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44781
-        rv_id: 109476
+        rv_id: 833711
         rule_id: L1UL48
-        version_id: BjTXrjN
-        url: https://semgrep.dev/playground/r/BjTXrjN/generic.secrets.gitleaks.sendbird-access-id.sendbird-access-id
+        version_id: 6xTDglp
+        url: https://semgrep.dev/playground/r/6xTDglp/generic.secrets.gitleaks.sendbird-access-id.sendbird-access-id
         origin: community
   patterns:
   - pattern-regex: (?i)(?:sendbird)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7261,10 +7261,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44782
-        rv_id: 109477
+        rv_id: 833712
         rule_id: 8GUPEk
-        version_id: DkT6noW
-        url: https://semgrep.dev/playground/r/DkT6noW/generic.secrets.gitleaks.sendbird-access-token.sendbird-access-token
+        version_id: o5TBEOX
+        url: https://semgrep.dev/playground/r/o5TBEOX/generic.secrets.gitleaks.sendbird-access-token.sendbird-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:sendbird)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7304,10 +7304,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44783
-        rv_id: 109478
+        rv_id: 833713
         rule_id: gxUvWX
-        version_id: WrTWQ5P
-        url: https://semgrep.dev/playground/r/WrTWQ5P/generic.secrets.gitleaks.sendgrid-api-token.sendgrid-api-token
+        version_id: zyTWJOK
+        url: https://semgrep.dev/playground/r/zyTWJOK/generic.secrets.gitleaks.sendgrid-api-token.sendgrid-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7347,10 +7347,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44784
-        rv_id: 109479
+        rv_id: 833714
         rule_id: QrUR6q
-        version_id: 0bTLlk2
-        url: https://semgrep.dev/playground/r/0bTLlk2/generic.secrets.gitleaks.sendinblue-api-token.sendinblue-api-token
+        version_id: pZTXj8k
+        url: https://semgrep.dev/playground/r/pZTXj8k/generic.secrets.gitleaks.sendinblue-api-token.sendinblue-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7390,10 +7390,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44785
-        rv_id: 109480
+        rv_id: 833715
         rule_id: 3qU5B1
-        version_id: K3Tvj95
-        url: https://semgrep.dev/playground/r/K3Tvj95/generic.secrets.gitleaks.sentry-access-token.sentry-access-token
+        version_id: 2KT7xZQ
+        url: https://semgrep.dev/playground/r/2KT7xZQ/generic.secrets.gitleaks.sentry-access-token.sentry-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:sentry)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7433,10 +7433,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44786
-        rv_id: 109481
+        rv_id: 833716
         rule_id: 4bUKzO
-        version_id: qkT2xgQ
-        url: https://semgrep.dev/playground/r/qkT2xgQ/generic.secrets.gitleaks.shippo-api-token.shippo-api-token
+        version_id: X0T5N18
+        url: https://semgrep.dev/playground/r/X0T5N18/generic.secrets.gitleaks.shippo-api-token.shippo-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(shippo_(live|test)_[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -7476,10 +7476,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44787
-        rv_id: 109482
+        rv_id: 833717
         rule_id: PeU7kg
-        version_id: l4T4vqX
-        url: https://semgrep.dev/playground/r/l4T4vqX/generic.secrets.gitleaks.shopify-access-token.shopify-access-token
+        version_id: jQTrX8q
+        url: https://semgrep.dev/playground/r/jQTrX8q/generic.secrets.gitleaks.shopify-access-token.shopify-access-token
         origin: community
   patterns:
   - pattern-regex: shpat_[a-fA-F0-9]{32}
@@ -7519,10 +7519,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44788
-        rv_id: 109483
+        rv_id: 833718
         rule_id: JDUOPJ
-        version_id: YDTp2Gv
-        url: https://semgrep.dev/playground/r/YDTp2Gv/generic.secrets.gitleaks.shopify-custom-access-token.shopify-custom-access-token
+        version_id: 1QTPLre
+        url: https://semgrep.dev/playground/r/1QTPLre/generic.secrets.gitleaks.shopify-custom-access-token.shopify-custom-access-token
         origin: community
   patterns:
   - pattern-regex: shpca_[a-fA-F0-9]{32}
@@ -7562,10 +7562,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44789
-        rv_id: 109484
+        rv_id: 833719
         rule_id: 5rUK46
-        version_id: JdTNpwp
-        url: https://semgrep.dev/playground/r/JdTNpwp/generic.secrets.gitleaks.shopify-private-app-access-token.shopify-private-app-access-token
+        version_id: 9lTJ0vR
+        url: https://semgrep.dev/playground/r/9lTJ0vR/generic.secrets.gitleaks.shopify-private-app-access-token.shopify-private-app-access-token
         origin: community
   patterns:
   - pattern-regex: shppa_[a-fA-F0-9]{32}
@@ -7605,10 +7605,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44790
-        rv_id: 109485
+        rv_id: 833720
         rule_id: GdUb0w
-        version_id: 5PTdAle
-        url: https://semgrep.dev/playground/r/5PTdAle/generic.secrets.gitleaks.shopify-shared-secret.shopify-shared-secret
+        version_id: yeTN1EA
+        url: https://semgrep.dev/playground/r/yeTN1EA/generic.secrets.gitleaks.shopify-shared-secret.shopify-shared-secret
         origin: community
   patterns:
   - pattern-regex: shpss_[a-fA-F0-9]{32}
@@ -7648,10 +7648,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44791
-        rv_id: 109486
+        rv_id: 833721
         rule_id: ReUNP1
-        version_id: GxTv6Ok
-        url: https://semgrep.dev/playground/r/GxTv6Ok/generic.secrets.gitleaks.sidekiq-secret.sidekiq-secret
+        version_id: rxTDzED
+        url: https://semgrep.dev/playground/r/rxTDzED/generic.secrets.gitleaks.sidekiq-secret.sidekiq-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[0-9a-z\-_\t
@@ -7692,10 +7692,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44792
-        rv_id: 109487
+        rv_id: 833722
         rule_id: AbUvGj
-        version_id: RGTDkWp
-        url: https://semgrep.dev/playground/r/RGTDkWp/generic.secrets.gitleaks.sidekiq-sensitive-url.sidekiq-sensitive-url
+        version_id: bZTBenL
+        url: https://semgrep.dev/playground/r/bZTBenL/generic.secrets.gitleaks.sidekiq-sensitive-url.sidekiq-sensitive-url
         origin: community
   patterns:
   - pattern-regex: "(?i)\\b(http(?:s??):\\/\\/)([a-f0-9]{8}:[a-f0-9]{8})@(?:gems.contribsys.com|enterprise.contribsys.com)(?:[\\/|\\#|\\?|:]|$)"
@@ -7735,10 +7735,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66775
-        rv_id: 109488
+        rv_id: 833723
         rule_id: 6JUgAl
-        version_id: A8T95PE
-        url: https://semgrep.dev/playground/r/A8T95PE/generic.secrets.gitleaks.slack-app-token.slack-app-token
+        version_id: NdTB2bq
+        url: https://semgrep.dev/playground/r/NdTB2bq/generic.secrets.gitleaks.slack-app-token.slack-app-token
         origin: community
   patterns:
   - pattern-regex: "(?i)(xapp-\\d-[A-Z0-9]+-\\d+-[a-z0-9]+)"
@@ -7778,10 +7778,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66776
-        rv_id: 109489
+        rv_id: 833724
         rule_id: oqUEWO
-        version_id: BjTXrjJ
-        url: https://semgrep.dev/playground/r/BjTXrjJ/generic.secrets.gitleaks.slack-bot-token.slack-bot-token
+        version_id: kbT2lEx
+        url: https://semgrep.dev/playground/r/kbT2lEx/generic.secrets.gitleaks.slack-bot-token.slack-bot-token
         origin: community
   patterns:
   - pattern-regex: "(xoxb-[0-9]{10,13}\\-[0-9]{10,13}[a-zA-Z0-9-]*)"
@@ -7821,10 +7821,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66777
-        rv_id: 109490
+        rv_id: 833725
         rule_id: zdUJXd
-        version_id: DkT6no7
-        url: https://semgrep.dev/playground/r/DkT6no7/generic.secrets.gitleaks.slack-config-access-token.slack-config-access-token
+        version_id: w8TAxED
+        url: https://semgrep.dev/playground/r/w8TAxED/generic.secrets.gitleaks.slack-config-access-token.slack-config-access-token
         origin: community
   patterns:
   - pattern-regex: "(?i)(xoxe.xox[bp]-\\d-[A-Z0-9]{163,166})"
@@ -7864,10 +7864,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66778
-        rv_id: 109491
+        rv_id: 833726
         rule_id: pKUjqZ
-        version_id: WrTWQ5j
-        url: https://semgrep.dev/playground/r/WrTWQ5j/generic.secrets.gitleaks.slack-config-refresh-token.slack-config-refresh-token
+        version_id: xyTNeEj
+        url: https://semgrep.dev/playground/r/xyTNeEj/generic.secrets.gitleaks.slack-config-refresh-token.slack-config-refresh-token
         origin: community
   patterns:
   - pattern-regex: "(?i)(xoxe-\\d-[A-Z0-9]{146})"
@@ -7907,10 +7907,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66779
-        rv_id: 109492
+        rv_id: 833727
         rule_id: 2ZUxA8
-        version_id: 0bTLlk6
-        url: https://semgrep.dev/playground/r/0bTLlk6/generic.secrets.gitleaks.slack-legacy-bot-token.slack-legacy-bot-token
+        version_id: O9TJW98
+        url: https://semgrep.dev/playground/r/O9TJW98/generic.secrets.gitleaks.slack-legacy-bot-token.slack-legacy-bot-token
         origin: community
   patterns:
   - pattern-regex: "(xoxb-[0-9]{8,14}\\-[a-zA-Z0-9]{18,26})"
@@ -7950,10 +7950,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66780
-        rv_id: 109493
+        rv_id: 833728
         rule_id: X5UNor
-        version_id: K3Tvj9P
-        url: https://semgrep.dev/playground/r/K3Tvj9P/generic.secrets.gitleaks.slack-legacy-token.slack-legacy-token
+        version_id: e1TDkl4
+        url: https://semgrep.dev/playground/r/e1TDkl4/generic.secrets.gitleaks.slack-legacy-token.slack-legacy-token
         origin: community
   patterns:
   - pattern-regex: "(xox[os]-\\d+-\\d+-\\d+-[a-fA-F\\d]+)"
@@ -7993,10 +7993,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66781
-        rv_id: 109494
+        rv_id: 833729
         rule_id: j2UXL7
-        version_id: qkT2xgr
-        url: https://semgrep.dev/playground/r/qkT2xgr/generic.secrets.gitleaks.slack-legacy-workspace-token.slack-legacy-workspace-token
+        version_id: vdTOzEo
+        url: https://semgrep.dev/playground/r/vdTOzEo/generic.secrets.gitleaks.slack-legacy-workspace-token.slack-legacy-workspace-token
         origin: community
   patterns:
   - pattern-regex: "(xox[ar]-(?:\\d-)?[0-9a-zA-Z]{8,48})"
@@ -8036,10 +8036,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66782
-        rv_id: 109495
+        rv_id: 833730
         rule_id: 10UL0L
-        version_id: l4T4vq3
-        url: https://semgrep.dev/playground/r/l4T4vq3/generic.secrets.gitleaks.slack-user-token.slack-user-token
+        version_id: d6TKGoL
+        url: https://semgrep.dev/playground/r/d6TKGoL/generic.secrets.gitleaks.slack-user-token.slack-user-token
         origin: community
   patterns:
   - pattern-regex: "(xox[pe](?:-[0-9]{10,13}){3}-[a-zA-Z0-9-]{28,34})"
@@ -8079,10 +8079,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66783
-        rv_id: 109496
+        rv_id: 833731
         rule_id: 9AU0E7
-        version_id: YDTp2GG
-        url: https://semgrep.dev/playground/r/YDTp2GG/generic.secrets.gitleaks.slack-webhook-url.slack-webhook-url
+        version_id: ZRTlP8X
+        url: https://semgrep.dev/playground/r/ZRTlP8X/generic.secrets.gitleaks.slack-webhook-url.slack-webhook-url
         origin: community
   patterns:
   - pattern-regex: "(https?:\\/\\/)?hooks.slack.com\\/(services|workflows)\\/[A-Za-z0-9+\\/]{43,46}"
@@ -8122,10 +8122,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66784
-        rv_id: 109497
+        rv_id: 833732
         rule_id: yyU1Qp
-        version_id: 6xTvJ7O
-        url: https://semgrep.dev/playground/r/6xTvJ7O/generic.secrets.gitleaks.snyk-api-token.snyk-api-token
+        version_id: nWTy4Ew
+        url: https://semgrep.dev/playground/r/nWTy4Ew/generic.secrets.gitleaks.snyk-api-token.snyk-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:snyk_token|snyk_key|snyk_api_token|snyk_api_key|snyk_oauth_token)(?:[0-9a-z\-_\t
@@ -8166,10 +8166,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44795
-        rv_id: 729096
+        rv_id: 833733
         rule_id: WAUePl
-        version_id: nWTGD1Q
-        url: https://semgrep.dev/playground/r/nWTGD1Q/generic.secrets.gitleaks.square-access-token.square-access-token
+        version_id: ExTrDld
+        url: https://semgrep.dev/playground/r/ExTrDld/generic.secrets.gitleaks.square-access-token.square-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b((EAAA|sq0atp-)[0-9A-Za-z\-_]{22,60})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8209,10 +8209,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44796
-        rv_id: 109499
+        rv_id: 833734
         rule_id: 0oU0J5
-        version_id: zyTK8gw
-        url: https://semgrep.dev/playground/r/zyTK8gw/generic.secrets.gitleaks.squarespace-access-token.squarespace-access-token
+        version_id: 7ZTx9Gw
+        url: https://semgrep.dev/playground/r/7ZTx9Gw/generic.secrets.gitleaks.squarespace-access-token.squarespace-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:squarespace)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8252,10 +8252,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44797
-        rv_id: 750525
+        rv_id: 833735
         rule_id: KxUAY4
-        version_id: WrTNn9G
-        url: https://semgrep.dev/playground/r/WrTNn9G/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
+        version_id: LjTEbnL
+        url: https://semgrep.dev/playground/r/LjTEbnL/generic.secrets.gitleaks.stripe-access-token.stripe-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b((sk|rk)_(test|live|prod)_[0-9a-z]{10,99})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8295,10 +8295,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44798
-        rv_id: 109501
+        rv_id: 833736
         rule_id: qNUAbb
-        version_id: 2KTzrNe
-        url: https://semgrep.dev/playground/r/2KTzrNe/generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id
+        version_id: 8KTGk6o
+        url: https://semgrep.dev/playground/r/8KTGk6o/generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id
         origin: community
   patterns:
   - pattern-regex: (?i:(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8338,10 +8338,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44799
-        rv_id: 109502
+        rv_id: 833737
         rule_id: lBU3z8
-        version_id: X0TQxeD
-        url: https://semgrep.dev/playground/r/X0TQxeD/generic.secrets.gitleaks.sumologic-access-token.sumologic-access-token
+        version_id: gETy2zG
+        url: https://semgrep.dev/playground/r/gETy2zG/generic.secrets.gitleaks.sumologic-access-token.sumologic-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8381,10 +8381,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44800
-        rv_id: 762644
+        rv_id: 833738
         rule_id: YGUgQA
-        version_id: DkTxQOb
-        url: https://semgrep.dev/playground/r/DkTxQOb/generic.secrets.gitleaks.telegram-bot-api-token.telegram-bot-api-token
+        version_id: QkTkr5j
+        url: https://semgrep.dev/playground/r/QkTkr5j/generic.secrets.gitleaks.telegram-bot-api-token.telegram-bot-api-token
         origin: community
   patterns:
   - pattern-regex: (?i:(?:telegr)(?:[0-9a-z\(-_\t .\\]{0,40})(?:[\s|']|[\s|"]){0,3})(?:=|\|\|:|<=|=>|:|\?=|\()(?:'|\"|\s|=|\x60){0,5}([0-9]{5,16}:A[a-z0-9_\-]{34})(?:['|\"|\n|\r|\s|\x60|;|\\]|$)
@@ -8424,10 +8424,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44801
-        rv_id: 109504
+        rv_id: 833739
         rule_id: 6JU46D
-        version_id: 1QTOYW1
-        url: https://semgrep.dev/playground/r/1QTOYW1/generic.secrets.gitleaks.travisci-access-token.travisci-access-token
+        version_id: 3ZT3AZG
+        url: https://semgrep.dev/playground/r/3ZT3AZG/generic.secrets.gitleaks.travisci-access-token.travisci-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:travis)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8467,10 +8467,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44802
-        rv_id: 109505
+        rv_id: 833740
         rule_id: oqUGrK
-        version_id: 9lTdWNP
-        url: https://semgrep.dev/playground/r/9lTdWNP/generic.secrets.gitleaks.twilio-api-key.twilio-api-key
+        version_id: 44TQPBB
+        url: https://semgrep.dev/playground/r/44TQPBB/generic.secrets.gitleaks.twilio-api-key.twilio-api-key
         origin: community
   patterns:
   - pattern-regex: SK[0-9a-fA-F]{32}
@@ -8510,10 +8510,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44803
-        rv_id: 109506
+        rv_id: 833741
         rule_id: zdU61l
-        version_id: yeTR2b1
-        url: https://semgrep.dev/playground/r/yeTR2b1/generic.secrets.gitleaks.twitch-api-token.twitch-api-token
+        version_id: PkTxr9v
+        url: https://semgrep.dev/playground/r/PkTxr9v/generic.secrets.gitleaks.twitch-api-token.twitch-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitch)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8553,10 +8553,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44804
-        rv_id: 109507
+        rv_id: 833742
         rule_id: pKURwy
-        version_id: rxTyLgv
-        url: https://semgrep.dev/playground/r/rxTyLgv/generic.secrets.gitleaks.twitter-access-secret.twitter-access-secret
+        version_id: JdTlrE0
+        url: https://semgrep.dev/playground/r/JdTlrE0/generic.secrets.gitleaks.twitter-access-secret.twitter-access-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{45})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8596,10 +8596,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44805
-        rv_id: 109508
+        rv_id: 833743
         rule_id: 2ZUnK3
-        version_id: bZTb1W3
-        url: https://semgrep.dev/playground/r/bZTb1W3/generic.secrets.gitleaks.twitter-access-token.twitter-access-token
+        version_id: 5PTyDQZ
+        url: https://semgrep.dev/playground/r/5PTyDQZ/generic.secrets.gitleaks.twitter-access-token.twitter-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8639,10 +8639,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44806
-        rv_id: 109509
+        rv_id: 833744
         rule_id: X5UG7z
-        version_id: NdT3dWj
-        url: https://semgrep.dev/playground/r/NdT3dWj/generic.secrets.gitleaks.twitter-api-key.twitter-api-key
+        version_id: GxTDE3p
+        url: https://semgrep.dev/playground/r/GxTDE3p/generic.secrets.gitleaks.twitter-api-key.twitter-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8682,10 +8682,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44807
-        rv_id: 109510
+        rv_id: 833745
         rule_id: j2UGRB
-        version_id: kbTdxvX
-        url: https://semgrep.dev/playground/r/kbTdxvX/generic.secrets.gitleaks.twitter-api-secret.twitter-api-secret
+        version_id: RGTKG84
+        url: https://semgrep.dev/playground/r/RGTKG84/generic.secrets.gitleaks.twitter-api-secret.twitter-api-secret
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8725,10 +8725,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44808
-        rv_id: 109511
+        rv_id: 833746
         rule_id: 10UJeE
-        version_id: w8T9ngZ
-        url: https://semgrep.dev/playground/r/w8T9ngZ/generic.secrets.gitleaks.twitter-bearer-token.twitter-bearer-token
+        version_id: A8T37K7
+        url: https://semgrep.dev/playground/r/A8T37K7/generic.secrets.gitleaks.twitter-bearer-token.twitter-bearer-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:twitter)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8768,10 +8768,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44809
-        rv_id: 109512
+        rv_id: 833747
         rule_id: 9AU8kq
-        version_id: xyTKZbY
-        url: https://semgrep.dev/playground/r/xyTKZbY/generic.secrets.gitleaks.typeform-api-token.typeform-api-token
+        version_id: BjTe0lL
+        url: https://semgrep.dev/playground/r/BjTe0lL/generic.secrets.gitleaks.typeform-api-token.typeform-api-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:typeform)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8811,10 +8811,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44810
-        rv_id: 109513
+        rv_id: 833748
         rule_id: yyUYye
-        version_id: O9TNOLy
-        url: https://semgrep.dev/playground/r/O9TNOLy/generic.secrets.gitleaks.vault-batch-token.vault-batch-token
+        version_id: DkTG0gb
+        url: https://semgrep.dev/playground/r/DkTG0gb/generic.secrets.gitleaks.vault-batch-token.vault-batch-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(hvb\.[a-z0-9_-]{138,212})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8854,10 +8854,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44811
-        rv_id: 109514
+        rv_id: 833749
         rule_id: r6UB9G
-        version_id: e1T01Pd
-        url: https://semgrep.dev/playground/r/e1T01Pd/generic.secrets.gitleaks.vault-service-token.vault-service-token
+        version_id: WrTdpDw
+        url: https://semgrep.dev/playground/r/WrTdpDw/generic.secrets.gitleaks.vault-service-token.vault-service-token
         origin: community
   patterns:
   - pattern-regex: (?i)\b(hvs\.[a-z0-9_-]{90,100})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8897,10 +8897,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44812
-        rv_id: 109515
+        rv_id: 833750
         rule_id: bwUPN4
-        version_id: vdTYNbW
-        url: https://semgrep.dev/playground/r/vdTYNbW/generic.secrets.gitleaks.yandex-access-token.yandex-access-token
+        version_id: 0bTwbDd
+        url: https://semgrep.dev/playground/r/0bTwbDd/generic.secrets.gitleaks.yandex-access-token.yandex-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:yandex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8940,10 +8940,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44813
-        rv_id: 109516
+        rv_id: 833751
         rule_id: NbUvY5
-        version_id: d6TrA2w
-        url: https://semgrep.dev/playground/r/d6TrA2w/generic.secrets.gitleaks.yandex-api-key.yandex-api-key
+        version_id: K3TrqZd
+        url: https://semgrep.dev/playground/r/K3TrqZd/generic.secrets.gitleaks.yandex-api-key.yandex-api-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:yandex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -8983,10 +8983,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44814
-        rv_id: 109517
+        rv_id: 833752
         rule_id: kxUQ89
-        version_id: ZRTQN1Q
-        url: https://semgrep.dev/playground/r/ZRTQN1Q/generic.secrets.gitleaks.yandex-aws-access-token.yandex-aws-access-token
+        version_id: qkTQnE0
+        url: https://semgrep.dev/playground/r/qkTQnE0/generic.secrets.gitleaks.yandex-aws-access-token.yandex-aws-access-token
         origin: community
   patterns:
   - pattern-regex: (?i)(?:yandex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -9026,10 +9026,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44815
-        rv_id: 109518
+        rv_id: 833753
         rule_id: wdUqGq
-        version_id: nWTxPAO
-        url: https://semgrep.dev/playground/r/nWTxPAO/generic.secrets.gitleaks.zendesk-secret-key.zendesk-secret-key
+        version_id: l4TyOg5
+        url: https://semgrep.dev/playground/r/l4TyOg5/generic.secrets.gitleaks.zendesk-secret-key.zendesk-secret-key
         origin: community
   patterns:
   - pattern-regex: (?i)(?:zendesk)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)
@@ -9074,10 +9074,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9084
-        rv_id: 109566
+        rv_id: 833801
         rule_id: DbUple
-        version_id: 8KTQ97x
-        url: https://semgrep.dev/playground/r/8KTQ97x/generic.secrets.security.detected-username-and-password-in-uri.detected-username-and-password-in-uri
+        version_id: GxTDENv
+        url: https://semgrep.dev/playground/r/GxTDENv/generic.secrets.security.detected-username-and-password-in-uri.detected-username-and-password-in-uri
         origin: community
 - id: generic.visualforce.security.ncino.html.usesriforcdns.use-SRI-for-CDNs
   languages:
@@ -9118,10 +9118,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72422
-        rv_id: 109569
+        rv_id: 833804
         rule_id: AbU20Y
-        version_id: 3ZTkQz3
-        url: https://semgrep.dev/playground/r/3ZTkQz3/generic.visualforce.security.ncino.html.usesriforcdns.use-SRI-for-CDNs
+        version_id: BjTe0qN
+        url: https://semgrep.dev/playground/r/BjTe0qN/generic.visualforce.security.ncino.html.usesriforcdns.use-SRI-for-CDNs
         origin: community
   patterns:
   - pattern-either:
@@ -9178,10 +9178,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72423
-        rv_id: 109570
+        rv_id: 833805
         rule_id: BYUAJ2
-        version_id: 44TRlwe
-        url: https://semgrep.dev/playground/r/44TRlwe/generic.visualforce.security.ncino.vf.xssfromunescapedurlparam.xss-from-unescaped-url-param
+        version_id: DkTG0lW
+        url: https://semgrep.dev/playground/r/DkTG0lW/generic.visualforce.security.ncino.vf.xssfromunescapedurlparam.xss-from-unescaped-url-param
         origin: community
   patterns:
   - pattern-either:
@@ -9227,10 +9227,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72424
-        rv_id: 109571
+        rv_id: 833806
         rule_id: DbUj7d
-        version_id: PkTJ1XQ
-        url: https://semgrep.dev/playground/r/PkTJ1XQ/generic.visualforce.security.ncino.xml.cspheaderattribute.csp-header-attribute
+        version_id: WrTdpBP
+        url: https://semgrep.dev/playground/r/WrTdpBP/generic.visualforce.security.ncino.xml.cspheaderattribute.csp-header-attribute
         origin: community
   patterns:
   - pattern: "<apex:page...>...</apex:page>"
@@ -9274,10 +9274,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72425
-        rv_id: 109572
+        rv_id: 833807
         rule_id: WAUwJW
-        version_id: JdTNpYp
-        url: https://semgrep.dev/playground/r/JdTNpYp/generic.visualforce.security.ncino.xml.visualforceapiversion.visualforce-page-api-version
+        version_id: 0bTwbN2
+        url: https://semgrep.dev/playground/r/0bTwbN2/generic.visualforce.security.ncino.xml.visualforceapiversion.visualforce-page-api-version
         origin: community
   patterns:
   - pattern-inside: "<apiVersion.../apiVersion>"
@@ -9326,10 +9326,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18232
-        rv_id: 109573
+        rv_id: 833808
         rule_id: WAUdJ7
-        version_id: 5PTdA2e
-        url: https://semgrep.dev/playground/r/5PTdA2e/go.aws-lambda.security.database-sqli.database-sqli
+        version_id: K3TrqE5
+        url: https://semgrep.dev/playground/r/K3TrqE5/go.aws-lambda.security.database-sqli.database-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -9399,10 +9399,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18233
-        rv_id: 109574
+        rv_id: 833809
         rule_id: 0oUwqg
-        version_id: GxTv6Kk
-        url: https://semgrep.dev/playground/r/GxTv6Kk/go.aws-lambda.security.tainted-sql-string.tainted-sql-string
+        version_id: qkTQn6Q
+        url: https://semgrep.dev/playground/r/qkTQn6Q/go.aws-lambda.security.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sources:
@@ -9517,10 +9517,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 24693
-        rv_id: 109579
+        rv_id: 833815
         rule_id: AbU5o3
-        version_id: WrTWQAj
-        url: https://semgrep.dev/playground/r/WrTWQAj/go.gorm.security.audit.gorm-dangerous-methods-usage.gorm-dangerous-method-usage
+        version_id: pZTXjZn
+        url: https://semgrep.dev/playground/r/pZTXjZn/go.gorm.security.audit.gorm-dangerous-methods-usage.gorm-dangerous-method-usage
         origin: community
 - id: go.jwt-go.security.jwt.hardcoded-jwt-key
   message: A hard-coded credential was detected. It is not recommended to store credentials
@@ -9557,10 +9557,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9093
-        rv_id: 109584
+        rv_id: 833820
         rule_id: GdU7Ny
-        version_id: YDTp2KG
-        url: https://semgrep.dev/playground/r/YDTp2KG/go.jwt-go.security.jwt.hardcoded-jwt-key
+        version_id: 9lTJ0rn
+        url: https://semgrep.dev/playground/r/9lTJ0rn/go.jwt-go.security.jwt.hardcoded-jwt-key
         origin: community
   severity: WARNING
   languages:
@@ -9600,10 +9600,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9115
-        rv_id: 762645
+        rv_id: 833834
         rule_id: bwUwy8
-        version_id: WrTNbRw
-        url: https://semgrep.dev/playground/r/WrTNbRw/go.lang.security.audit.crypto.math_random.math-random-used
+        version_id: ExTrD7D
+        url: https://semgrep.dev/playground/r/ExTrD7D/go.lang.security.audit.crypto.math_random.math-random-used
         origin: community
   message: Do not use `math/rand`. Use `crypto/rand` instead.
   languages:
@@ -9661,10 +9661,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9117
-        rv_id: 109600
+        rv_id: 833836
         rule_id: kxUkJ2
-        version_id: zyTK80x
-        url: https://semgrep.dev/playground/r/zyTK80x/go.lang.security.audit.crypto.ssl.ssl-v3-is-insecure
+        version_id: LjTEbZg
+        url: https://semgrep.dev/playground/r/LjTEbZg/go.lang.security.audit.crypto.ssl.ssl-v3-is-insecure
         origin: community
   languages:
   - go
@@ -9703,10 +9703,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9118
-        rv_id: 109601
+        rv_id: 833837
         rule_id: wdUJYk
-        version_id: pZT1y4r
-        url: https://semgrep.dev/playground/r/pZT1y4r/go.lang.security.audit.crypto.tls.tls-with-insecure-cipher
+        version_id: 8KTGkRZ
+        url: https://semgrep.dev/playground/r/8KTGkRZ/go.lang.security.audit.crypto.tls.tls-with-insecure-cipher
         origin: community
   languages:
   - go
@@ -9799,10 +9799,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9121
-        rv_id: 109604
+        rv_id: 833840
         rule_id: eqU8B3
-        version_id: jQTgY4k
-        url: https://semgrep.dev/playground/r/jQTgY4k/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-DES
+        version_id: 3ZT3Aqo
+        url: https://semgrep.dev/playground/r/3ZT3Aqo/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-DES
         origin: community
   patterns:
   - pattern-inside: |
@@ -9847,10 +9847,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9119
-        rv_id: 258075
+        rv_id: 833838
         rule_id: x8Un6q
-        version_id: 1QTbO72
-        url: https://semgrep.dev/playground/r/1QTbO72/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
+        version_id: gETy2dl
+        url: https://semgrep.dev/playground/r/gETy2dl/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
         origin: community
   patterns:
   - pattern-inside: |
@@ -9894,10 +9894,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9122
-        rv_id: 109605
+        rv_id: 833841
         rule_id: v8Unl0
-        version_id: 1QTOYRO
-        url: https://semgrep.dev/playground/r/1QTOYRO/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-rc4
+        version_id: 44TQP4o
+        url: https://semgrep.dev/playground/r/44TQP4o/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-rc4
         origin: community
   patterns:
   - pattern-inside: |
@@ -9936,10 +9936,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9120
-        rv_id: 258076
+        rv_id: 833839
         rule_id: OrU31O
-        version_id: 9lTod53
-        url: https://semgrep.dev/playground/r/9lTod53/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
+        version_id: QkTkrPb
+        url: https://semgrep.dev/playground/r/QkTkrPb/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1
         origin: community
   patterns:
   - pattern-inside: |
@@ -9990,10 +9990,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14688
-        rv_id: 109612
+        rv_id: 833848
         rule_id: 4bU1Wj
-        version_id: w8T9nPl
-        url: https://semgrep.dev/playground/r/w8T9nPl/go.lang.security.audit.md5-used-as-password.md5-used-as-password
+        version_id: BjTe0RN
+        url: https://semgrep.dev/playground/r/BjTe0RN/go.lang.security.audit.md5-used-as-password.md5-used-as-password
         origin: community
   mode: taint
   pattern-sources:
@@ -10047,10 +10047,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9126
-        rv_id: 109614
+        rv_id: 833850
         rule_id: EwU2Z6
-        version_id: O9TNOqv
-        url: https://semgrep.dev/playground/r/O9TNOqv/go.lang.security.audit.net.cookie-missing-httponly.cookie-missing-httponly
+        version_id: WrTdpLP
+        url: https://semgrep.dev/playground/r/WrTdpLP/go.lang.security.audit.net.cookie-missing-httponly.cookie-missing-httponly
         origin: community
   fix-regex:
     regex: "(HttpOnly\\s*:\\s+)false"
@@ -10098,10 +10098,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9127
-        rv_id: 109615
+        rv_id: 833851
         rule_id: 7KUQ8X
-        version_id: e1T01o9
-        url: https://semgrep.dev/playground/r/e1T01o9/go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+        version_id: 0bTwbn2
+        url: https://semgrep.dev/playground/r/0bTwbn2/go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
         origin: community
   fix-regex:
     regex: "(Secure\\s*:\\s+)false"
@@ -10138,10 +10138,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9128
-        rv_id: 109616
+        rv_id: 833852
         rule_id: L1Uyjp
-        version_id: vdTYNwN
-        url: https://semgrep.dev/playground/r/vdTYNwN/go.lang.security.audit.net.dynamic-httptrace-clienttrace.dynamic-httptrace-clienttrace
+        version_id: K3Trqx5
+        url: https://semgrep.dev/playground/r/K3Trqx5/go.lang.security.audit.net.dynamic-httptrace-clienttrace.dynamic-httptrace-clienttrace
         origin: community
   patterns:
   - pattern-not-inside: |
@@ -10211,10 +10211,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21300
-        rv_id: 109618
+        rv_id: 833854
         rule_id: 5rU9JO
-        version_id: ZRTQN9K
-        url: https://semgrep.dev/playground/r/ZRTQN9K/go.lang.security.audit.net.fs-directory-listing.fs-directory-listing
+        version_id: l4TyOEX
+        url: https://semgrep.dev/playground/r/l4TyOEX/go.lang.security.audit.net.fs-directory-listing.fs-directory-listing
         origin: community
 - id: go.lang.security.audit.net.wip-xss-using-responsewriter-and-printf.wip-xss-using-responsewriter-and-printf
   patterns:
@@ -10291,10 +10291,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9135
-        rv_id: 109624
+        rv_id: 833860
         rule_id: JDUyXB
-        version_id: gET3xR5
-        url: https://semgrep.dev/playground/r/gET3xR5/go.lang.security.audit.net.wip-xss-using-responsewriter-and-printf.wip-xss-using-responsewriter-and-printf
+        version_id: A8T37BE
+        url: https://semgrep.dev/playground/r/A8T37BE/go.lang.security.audit.net.wip-xss-using-responsewriter-and-printf.wip-xss-using-responsewriter-and-printf
         origin: community
   severity: WARNING
   languages:
@@ -10368,10 +10368,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10258
-        rv_id: 109626
+        rv_id: 833862
         rule_id: YGUrnQ
-        version_id: 3ZTkQGg
-        url: https://semgrep.dev/playground/r/3ZTkQGg/go.lang.security.audit.sqli.gosql-sqli.gosql-sqli
+        version_id: DkTG0E7
+        url: https://semgrep.dev/playground/r/DkTG0E7/go.lang.security.audit.sqli.gosql-sqli.gosql-sqli
         origin: community
   severity: ERROR
 - id: go.lang.security.audit.sqli.pg-orm-sqli.pg-orm-sqli
@@ -10469,10 +10469,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10259
-        rv_id: 109627
+        rv_id: 833863
         rule_id: 6JUqQ1
-        version_id: 44TRlLK
-        url: https://semgrep.dev/playground/r/44TRlLK/go.lang.security.audit.sqli.pg-orm-sqli.pg-orm-sqli
+        version_id: WrTdpLj
+        url: https://semgrep.dev/playground/r/WrTdpLj/go.lang.security.audit.sqli.pg-orm-sqli.pg-orm-sqli
         origin: community
   severity: ERROR
 - id: go.lang.security.audit.sqli.pg-sqli.pg-sqli
@@ -10511,10 +10511,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10294
-        rv_id: 109628
+        rv_id: 833864
         rule_id: AbUWXY
-        version_id: PkTJ1lw
-        url: https://semgrep.dev/playground/r/PkTJ1lw/go.lang.security.audit.sqli.pg-sqli.pg-sqli
+        version_id: 0bTwbn6
+        url: https://semgrep.dev/playground/r/0bTwbn6/go.lang.security.audit.sqli.pg-sqli.pg-sqli
         origin: community
   severity: ERROR
   patterns:
@@ -10587,10 +10587,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10260
-        rv_id: 109629
+        rv_id: 833865
         rule_id: oqUz92
-        version_id: JdTNpBA
-        url: https://semgrep.dev/playground/r/JdTNpBA/go.lang.security.audit.sqli.pgx-sqli.pgx-sqli
+        version_id: K3TrqxP
+        url: https://semgrep.dev/playground/r/K3TrqxP/go.lang.security.audit.sqli.pgx-sqli.pgx-sqli
         origin: community
   patterns:
   - pattern-either:
@@ -10698,10 +10698,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18235
-        rv_id: 109643
+        rv_id: 833879
         rule_id: qNUQJe
-        version_id: o5Tgl30
-        url: https://semgrep.dev/playground/r/o5Tgl30/go.lang.security.filepath-clean-misuse.filepath-clean-misuse
+        version_id: rxTDzWv
+        url: https://semgrep.dev/playground/r/rxTDzWv/go.lang.security.filepath-clean-misuse.filepath-clean-misuse
         origin: community
 - id: go.lang.security.injection.open-redirect.open-redirect
   languages:
@@ -10739,10 +10739,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113619
-        rv_id: 254642
+        rv_id: 833880
         rule_id: DbU6RlN
-        version_id: 9lTeD84
-        url: https://semgrep.dev/playground/r/9lTeD84/go.lang.security.injection.open-redirect.open-redirect
+        version_id: bZTBey3
+        url: https://semgrep.dev/playground/r/bZTBey3/go.lang.security.injection.open-redirect.open-redirect
         origin: community
   mode: taint
   pattern-sources:
@@ -10810,10 +10810,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14443
-        rv_id: 109644
+        rv_id: 833881
         rule_id: PeUonQ
-        version_id: zyTK8wx
-        url: https://semgrep.dev/playground/r/zyTK8wx/go.lang.security.injection.raw-html-format.raw-html-format
+        version_id: NdTB24j
+        url: https://semgrep.dev/playground/r/NdTB24j/go.lang.security.injection.raw-html-format.raw-html-format
         origin: community
   mode: taint
   pattern-sources:
@@ -10877,10 +10877,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14689
-        rv_id: 109645
+        rv_id: 833882
         rule_id: PeUoqy
-        version_id: pZT1ydr
-        url: https://semgrep.dev/playground/r/pZT1ydr/go.lang.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: kbT2lJX
+        url: https://semgrep.dev/playground/r/kbT2lJX/go.lang.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   severity: ERROR
@@ -10966,10 +10966,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14391
-        rv_id: 254643
+        rv_id: 833883
         rule_id: AbUQLr
-        version_id: yeT3wYO
-        url: https://semgrep.dev/playground/r/yeT3wYO/go.lang.security.injection.tainted-url-host.tainted-url-host
+        version_id: w8TAxYZ
+        url: https://semgrep.dev/playground/r/w8TAxYZ/go.lang.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sources:
@@ -11045,10 +11045,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39193
-        rv_id: 109656
+        rv_id: 833891
         rule_id: AbUnNo
-        version_id: w8T9nEl
-        url: https://semgrep.dev/playground/r/w8T9nEl/html.security.plaintext-http-link.plaintext-http-link
+        version_id: ExTrDzp
+        url: https://semgrep.dev/playground/r/ExTrDzp/html.security.plaintext-http-link.plaintext-http-link
         origin: community
   patterns:
   - pattern: <a href="$URL">...</a>
@@ -11106,10 +11106,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60632
-        rv_id: 109664
+        rv_id: 833899
         rule_id: v8Ul0r
-        version_id: ExTjNle
-        url: https://semgrep.dev/playground/r/ExTjNle/java.android.security.exported_activity.exported_activity
+        version_id: PkTxrNQ
+        url: https://semgrep.dev/playground/r/PkTxrNQ/java.android.security.exported_activity.exported_activity
         origin: community
 - id: java.aws-lambda.security.tainted-sql-string.tainted-sql-string
   languages:
@@ -11151,10 +11151,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18237
-        rv_id: 109665
+        rv_id: 833900
         rule_id: YGUl4z
-        version_id: 7ZTgoGZ
-        url: https://semgrep.dev/playground/r/7ZTgoGZ/java.aws-lambda.security.tainted-sql-string.tainted-sql-string
+        version_id: JdTlr8p
+        url: https://semgrep.dev/playground/r/JdTlr8p/java.aws-lambda.security.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sources:
@@ -11268,10 +11268,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18238
-        rv_id: 109666
+        rv_id: 833901
         rule_id: 6JUDWk
-        version_id: LjTqQnB
-        url: https://semgrep.dev/playground/r/LjTqQnB/java.aws-lambda.security.tainted-sqli.tainted-sqli
+        version_id: 5PTyDbe
+        url: https://semgrep.dev/playground/r/5PTyDbe/java.aws-lambda.security.tainted-sqli.tainted-sqli
         origin: community
 - id: java.java-jwt.security.audit.jwt-decode-without-verify.java-jwt-decode-without-verify
   message: Detected the decoding of a JWT token without a verify step. JWT tokens
@@ -11302,10 +11302,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9151
-        rv_id: 109667
+        rv_id: 833902
         rule_id: pKUOE9
-        version_id: 8KTQ96B
-        url: https://semgrep.dev/playground/r/8KTQ96B/java.java-jwt.security.audit.jwt-decode-without-verify.java-jwt-decode-without-verify
+        version_id: GxTDEpk
+        url: https://semgrep.dev/playground/r/GxTDEpk/java.java-jwt.security.audit.jwt-decode-without-verify.java-jwt-decode-without-verify
         origin: community
   languages:
   - java
@@ -11356,10 +11356,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9149
-        rv_id: 109668
+        rv_id: 833903
         rule_id: oqUeAn
-        version_id: gET3xz5
-        url: https://semgrep.dev/playground/r/gET3xz5/java.java-jwt.security.jwt-hardcode.java-jwt-hardcoded-secret
+        version_id: RGTKGjp
+        url: https://semgrep.dev/playground/r/RGTKGjp/java.java-jwt.security.jwt-hardcode.java-jwt-hardcoded-secret
         origin: community
   languages:
   - java
@@ -11419,10 +11419,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9150
-        rv_id: 109669
+        rv_id: 833904
         rule_id: zdUkzR
-        version_id: QkTW05B
-        url: https://semgrep.dev/playground/r/QkTW05B/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg
+        version_id: A8T37wE
+        url: https://semgrep.dev/playground/r/A8T37wE/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg
         origin: community
   languages:
   - java
@@ -11474,10 +11474,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9152
-        rv_id: 109672
+        rv_id: 833907
         rule_id: 2ZUb9l
-        version_id: PkTJ19w
-        url: https://semgrep.dev/playground/r/PkTJ19w/java.jax-rs.security.jax-rs-path-traversal.jax-rs-path-traversal
+        version_id: WrTdp0j
+        url: https://semgrep.dev/playground/r/WrTdp0j/java.jax-rs.security.jax-rs-path-traversal.jax-rs-path-traversal
         origin: community
   message: Detected a potential path traversal. A malicious actor could control the
     location of this file, to include going backwards in the directory with '../'.
@@ -11557,10 +11557,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9153
-        rv_id: 109674
+        rv_id: 833909
         rule_id: X5U8rQ
-        version_id: 5PTdAQ2
-        url: https://semgrep.dev/playground/r/5PTdAQ2/java.jboss.security.session_sqli.find-sql-string-concatenation
+        version_id: K3Trq1P
+        url: https://semgrep.dev/playground/r/K3Trq1P/java.jboss.security.session_sqli.find-sql-string-concatenation
         origin: community
 - id: java.lang.security.audit.crlf-injection-logs.crlf-injection-logs
   message: When data from an untrusted source is put into a logger and not neutralized
@@ -11589,10 +11589,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9173
-        rv_id: 109689
+        rv_id: 833923
         rule_id: 8GUjwW
-        version_id: RGTDk8b
-        url: https://semgrep.dev/playground/r/RGTDk8b/java.lang.security.audit.crlf-injection-logs.crlf-injection-logs
+        version_id: rxTDzQv
+        url: https://semgrep.dev/playground/r/rxTDzQv/java.lang.security.audit.crlf-injection-logs.crlf-injection-logs
         origin: community
   severity: WARNING
   languages:
@@ -11691,10 +11691,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9191
-        rv_id: 109690
+        rv_id: 833924
         rule_id: PeUZNg
-        version_id: A8T95KY
-        url: https://semgrep.dev/playground/r/A8T95KY/java.lang.security.audit.crypto.des-is-deprecated.des-is-deprecated
+        version_id: bZTBe23
+        url: https://semgrep.dev/playground/r/bZTBe23/java.lang.security.audit.crypto.des-is-deprecated.des-is-deprecated
         origin: community
   severity: WARNING
   patterns:
@@ -11744,10 +11744,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9192
-        rv_id: 109691
+        rv_id: 833925
         rule_id: JDUy8J
-        version_id: BjTXrl2
-        url: https://semgrep.dev/playground/r/BjTXrl2/java.lang.security.audit.crypto.desede-is-deprecated.desede-is-deprecated
+        version_id: NdTB27j
+        url: https://semgrep.dev/playground/r/NdTB27j/java.lang.security.audit.crypto.desede-is-deprecated.desede-is-deprecated
         origin: community
   severity: WARNING
   patterns:
@@ -11789,10 +11789,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9193
-        rv_id: 109692
+        rv_id: 833926
         rule_id: 5rUOb6
-        version_id: DkT6nJd
-        url: https://semgrep.dev/playground/r/DkT6nJd/java.lang.security.audit.crypto.ecb-cipher.ecb-cipher
+        version_id: kbT2l1X
+        url: https://semgrep.dev/playground/r/kbT2l1X/java.lang.security.audit.crypto.ecb-cipher.ecb-cipher
         origin: community
   message: Cipher in ECB mode is detected. ECB mode produces the same output for the
     same input each time which allows an attacker to intercept and replay the data.
@@ -11834,10 +11834,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11908
-        rv_id: 109694
+        rv_id: 833928
         rule_id: GdUZZ3
-        version_id: 0bTLlBy
-        url: https://semgrep.dev/playground/r/0bTLlBy/java.lang.security.audit.crypto.gcm-nonce-reuse.gcm-nonce-reuse
+        version_id: xyTNekY
+        url: https://semgrep.dev/playground/r/xyTNekY/java.lang.security.audit.crypto.gcm-nonce-reuse.gcm-nonce-reuse
         origin: community
   languages:
   - java
@@ -11883,10 +11883,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9194
-        rv_id: 109695
+        rv_id: 833929
         rule_id: GdU7pw
-        version_id: K3Tvjez
-        url: https://semgrep.dev/playground/r/K3Tvjez/java.lang.security.audit.crypto.no-null-cipher.no-null-cipher
+        version_id: O9TJW5y
+        url: https://semgrep.dev/playground/r/O9TJW5y/java.lang.security.audit.crypto.no-null-cipher.no-null-cipher
         origin: community
   message: 'NullCipher was detected. This will not encrypt anything; the cipher text
     will be the same as the plain text. Use a valid, secure cipher: Cipher.getInstance("AES/CBC/PKCS7PADDING").
@@ -11928,10 +11928,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9195
-        rv_id: 109696
+        rv_id: 833930
         rule_id: ReUgj1
-        version_id: qkT2xGj
-        url: https://semgrep.dev/playground/r/qkT2xGj/java.lang.security.audit.crypto.no-static-initialization-vector.no-static-initialization-vector
+        version_id: e1TDkJd
+        url: https://semgrep.dev/playground/r/e1TDkJd/java.lang.security.audit.crypto.no-static-initialization-vector.no-static-initialization-vector
         origin: community
   severity: WARNING
   languages:
@@ -11989,10 +11989,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9196
-        rv_id: 109697
+        rv_id: 833931
         rule_id: AbUzoj
-        version_id: l4T4vbd
-        url: https://semgrep.dev/playground/r/l4T4vbd/java.lang.security.audit.crypto.rsa-no-padding.rsa-no-padding
+        version_id: vdTOzyW
+        url: https://semgrep.dev/playground/r/vdTOzyW/java.lang.security.audit.crypto.rsa-no-padding.rsa-no-padding
         origin: community
   message: Using RSA without OAEP mode weakens the encryption.
   severity: WARNING
@@ -12033,10 +12033,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9197
-        rv_id: 109702
+        rv_id: 833936
         rule_id: BYUN3X
-        version_id: pZT1yob
-        url: https://semgrep.dev/playground/r/pZT1yob/java.lang.security.audit.crypto.unencrypted-socket.unencrypted-socket
+        version_id: 7ZTx94Q
+        url: https://semgrep.dev/playground/r/7ZTx94Q/java.lang.security.audit.crypto.unencrypted-socket.unencrypted-socket
         origin: community
   message: Detected use of a Java socket that is not encrypted. As a result, the traffic
     could be read by an attacker intercepting the network traffic. Use an SSLSocket
@@ -12076,10 +12076,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48734
-        rv_id: 109703
+        rv_id: 833937
         rule_id: WAU2yA
-        version_id: 2KTzreY
-        url: https://semgrep.dev/playground/r/2KTzreY/java.lang.security.audit.crypto.use-of-aes-ecb.use-of-aes-ecb
+        version_id: LjTEb84
+        url: https://semgrep.dev/playground/r/LjTEb84/java.lang.security.audit.crypto.use-of-aes-ecb.use-of-aes-ecb
         origin: community
   message: 'Use of AES with ECB mode detected. ECB doesn''t provide message confidentiality
     and  is not semantically secure so should not be used. Instead, use a strong,
@@ -12117,10 +12117,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48735
-        rv_id: 109704
+        rv_id: 833938
         rule_id: 0oUR28
-        version_id: X0TQxEx
-        url: https://semgrep.dev/playground/r/X0TQxEx/java.lang.security.audit.crypto.use-of-blowfish.use-of-blowfish
+        version_id: 8KTGk8x
+        url: https://semgrep.dev/playground/r/8KTGk8x/java.lang.security.audit.crypto.use-of-blowfish.use-of-blowfish
         origin: community
   message: 'Use of Blowfish was detected. Blowfish uses a 64-bit block size that  makes
     it vulnerable to birthday attacks, and is therefore considered non-compliant.  Instead,
@@ -12188,10 +12188,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48736
-        rv_id: 109705
+        rv_id: 833939
         rule_id: KxUB7Z
-        version_id: jQTgYWy
-        url: https://semgrep.dev/playground/r/jQTgYWy/java.lang.security.audit.crypto.use-of-default-aes.use-of-default-aes
+        version_id: gETy2Qg
+        url: https://semgrep.dev/playground/r/gETy2Qg/java.lang.security.audit.crypto.use-of-default-aes.use-of-default-aes
         origin: community
   message: 'Use of AES with no settings detected. By default, java.crypto.Cipher uses
     ECB mode. ECB doesn''t  provide message confidentiality and is not semantically
@@ -12235,10 +12235,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 39194
-        rv_id: 109706
+        rv_id: 833940
         rule_id: BYUGK0
-        version_id: 1QTOYBy
-        url: https://semgrep.dev/playground/r/1QTOYBy/java.lang.security.audit.crypto.use-of-md5-digest-utils.use-of-md5-digest-utils
+        version_id: QkTkren
+        url: https://semgrep.dev/playground/r/QkTkren/java.lang.security.audit.crypto.use-of-md5-digest-utils.use-of-md5-digest-utils
         origin: community
   patterns:
   - pattern: "$DU.$GET_ALGO().digest(...)\n"
@@ -12286,10 +12286,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17325
-        rv_id: 109707
+        rv_id: 833941
         rule_id: KxU5lW
-        version_id: 9lTdW2l
-        url: https://semgrep.dev/playground/r/9lTdW2l/java.lang.security.audit.crypto.use-of-md5.use-of-md5
+        version_id: 3ZT3A03
+        url: https://semgrep.dev/playground/r/3ZT3A03/java.lang.security.audit.crypto.use-of-md5.use-of-md5
         origin: community
   patterns:
   - pattern: 'java.security.MessageDigest.getInstance($ALGO, ...);
@@ -12331,10 +12331,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48737
-        rv_id: 109708
+        rv_id: 833942
         rule_id: qNUzXG
-        version_id: yeTR28q
-        url: https://semgrep.dev/playground/r/yeTR28q/java.lang.security.audit.crypto.use-of-rc2.use-of-rc2
+        version_id: 44TQP0e
+        url: https://semgrep.dev/playground/r/44TQP0e/java.lang.security.audit.crypto.use-of-rc2.use-of-rc2
         origin: community
   message: 'Use of RC2 was detected. RC2 is vulnerable to related-key attacks, and
     is therefore considered non-compliant. Instead, use a strong, secure cipher: Cipher.getInstance("AES/CBC/PKCS7PADDING").
@@ -12372,10 +12372,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48738
-        rv_id: 109709
+        rv_id: 833943
         rule_id: lBUw8k
-        version_id: rxTyLql
-        url: https://semgrep.dev/playground/r/rxTyLql/java.lang.security.audit.crypto.use-of-rc4.use-of-rc4
+        version_id: PkTxrPQ
+        url: https://semgrep.dev/playground/r/PkTxrPQ/java.lang.security.audit.crypto.use-of-rc4.use-of-rc4
         origin: community
   message: 'Use of RC4 was detected. RC4 is vulnerable to several attacks, including
     stream cipher attacks and bit flipping attacks. Instead, use a strong, secure
@@ -12424,10 +12424,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17326
-        rv_id: 109710
+        rv_id: 833944
         rule_id: qNUWNn
-        version_id: bZTb1rl
-        url: https://semgrep.dev/playground/r/bZTb1rl/java.lang.security.audit.crypto.use-of-sha1.use-of-sha1
+        version_id: JdTlr9p
+        url: https://semgrep.dev/playground/r/JdTlr9p/java.lang.security.audit.crypto.use-of-sha1.use-of-sha1
         origin: community
   pattern-either:
   - patterns:
@@ -12475,10 +12475,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9200
-        rv_id: 109712
+        rv_id: 833946
         rule_id: 0oU5P5
-        version_id: kbTdxpZ
-        url: https://semgrep.dev/playground/r/kbTdxpZ/java.lang.security.audit.crypto.weak-rsa.use-of-weak-rsa-key
+        version_id: GxTDEdk
+        url: https://semgrep.dev/playground/r/GxTDEdk/java.lang.security.audit.crypto.weak-rsa.use-of-weak-rsa-key
         origin: community
   patterns:
   - pattern: |
@@ -12524,10 +12524,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9175
-        rv_id: 109715
+        rv_id: 833949
         rule_id: QrUzxR
-        version_id: O9TNOzA
-        url: https://semgrep.dev/playground/r/O9TNOzA/java.lang.security.audit.formatted-sql-string.formatted-sql-string
+        version_id: BjTe03J
+        url: https://semgrep.dev/playground/r/BjTe03J/java.lang.security.audit.formatted-sql-string.formatted-sql-string
         origin: community
   options:
     taint_assume_safe_numbers: true
@@ -12614,10 +12614,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9176
-        rv_id: 109716
+        rv_id: 833950
         rule_id: 3qUPyK
-        version_id: e1T015P
-        url: https://semgrep.dev/playground/r/e1T015P/java.lang.security.audit.http-response-splitting.http-response-splitting
+        version_id: DkTG0r7
+        url: https://semgrep.dev/playground/r/DkTG0r7/java.lang.security.audit.http-response-splitting.http-response-splitting
         origin: community
   message: Older Java application servers are vulnerable to HTTP response splitting,
     which may occur if an HTTP request can be injected with CRLF characters. This
@@ -12667,10 +12667,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9177
-        rv_id: 109717
+        rv_id: 833951
         rule_id: 4bUkrW
-        version_id: vdTYNgx
-        url: https://semgrep.dev/playground/r/vdTYNgx/java.lang.security.audit.insecure-smtp-connection.insecure-smtp-connection
+        version_id: WrTdp4j
+        url: https://semgrep.dev/playground/r/WrTdp4j/java.lang.security.audit.insecure-smtp-connection.insecure-smtp-connection
         origin: community
   message: Insecure SMTP connection detected. This connection will trust any SSL certificate.
     Enable certificate verification by setting 'email.setSSLCheckServerIdentity(true)'.
@@ -12722,10 +12722,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14690
-        rv_id: 109722
+        rv_id: 833956
         rule_id: JDULAW
-        version_id: 7ZTgod0
-        url: https://semgrep.dev/playground/r/7ZTgod0/java.lang.security.audit.md5-used-as-password.md5-used-as-password
+        version_id: YDTl09G
+        url: https://semgrep.dev/playground/r/YDTl09G/java.lang.security.audit.md5-used-as-password.md5-used-as-password
         origin: community
   mode: taint
   pattern-sources:
@@ -12776,10 +12776,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18239
-        rv_id: 109732
+        rv_id: 833966
         rule_id: oqUBJG
-        version_id: GxTv6yG
-        url: https://semgrep.dev/playground/r/GxTv6yG/java.lang.security.audit.sqli.tainted-sql-from-http-request.tainted-sql-from-http-request
+        version_id: K3TrqWq
+        url: https://semgrep.dev/playground/r/K3TrqWq/java.lang.security.audit.sqli.tainted-sql-from-http-request.tainted-sql-from-http-request
         origin: community
   languages:
   - java
@@ -12888,10 +12888,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18240
-        rv_id: 109735
+        rv_id: 833969
         rule_id: zdUWrg
-        version_id: BjTXr52
-        url: https://semgrep.dev/playground/r/BjTXr52/java.lang.security.audit.tainted-cmd-from-http-request.tainted-cmd-from-http-request
+        version_id: YDTl097
+        url: https://semgrep.dev/playground/r/YDTl097/java.lang.security.audit.tainted-cmd-from-http-request.tainted-cmd-from-http-request
         origin: community
 - id: java.lang.security.audit.tainted-env-from-http-request.tainted-env-from-http-request
   message: Detected input from a HTTPServletRequest going into the environment variables
@@ -12944,10 +12944,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 70981
-        rv_id: 109736
+        rv_id: 833970
         rule_id: nJULjy
-        version_id: DkT6nld
-        url: https://semgrep.dev/playground/r/DkT6nld/java.lang.security.audit.tainted-env-from-http-request.tainted-env-from-http-request
+        version_id: 6xTDgPY
+        url: https://semgrep.dev/playground/r/6xTDgPY/java.lang.security.audit.tainted-env-from-http-request.tainted-env-from-http-request
         origin: community
 - id: java.lang.security.audit.tainted-ldapi-from-http-request.tainted-ldapi-from-http-request
   message: Detected input from a HTTPServletRequest going into an LDAP query. This
@@ -12979,10 +12979,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18241
-        rv_id: 109737
+        rv_id: 833971
         rule_id: pKUXAv
-        version_id: WrTWQBW
-        url: https://semgrep.dev/playground/r/WrTWQBW/java.lang.security.audit.tainted-ldapi-from-http-request.tainted-ldapi-from-http-request
+        version_id: o5TBE80
+        url: https://semgrep.dev/playground/r/o5TBE80/java.lang.security.audit.tainted-ldapi-from-http-request.tainted-ldapi-from-http-request
         origin: community
   severity: WARNING
   languages:
@@ -13075,10 +13075,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18242
-        rv_id: 109738
+        rv_id: 833972
         rule_id: 2ZU7Eo
-        version_id: 0bTLlNy
-        url: https://semgrep.dev/playground/r/0bTLlNy/java.lang.security.audit.tainted-session-from-http-request.tainted-session-from-http-request
+        version_id: zyTWJ7x
+        url: https://semgrep.dev/playground/r/zyTWJ7x/java.lang.security.audit.tainted-session-from-http-request.tainted-session-from-http-request
         origin: community
 - id: java.lang.security.audit.tainted-xpath-from-http-request.tainted-xpath-from-http-request
   message: Detected input from a HTTPServletRequest going into a XPath evaluate or
@@ -13122,10 +13122,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18243
-        rv_id: 109739
+        rv_id: 833973
         rule_id: X5U5nj
-        version_id: K3TvjEz
-        url: https://semgrep.dev/playground/r/K3TvjEz/java.lang.security.audit.tainted-xpath-from-http-request.tainted-xpath-from-http-request
+        version_id: pZTXj7r
+        url: https://semgrep.dev/playground/r/pZTXj7r/java.lang.security.audit.tainted-xpath-from-http-request.tainted-xpath-from-http-request
         origin: community
 - id: java.lang.security.audit.unvalidated-redirect.unvalidated-redirect
   message: Application redirects to a destination URL specified by a user-supplied
@@ -13160,10 +13160,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9186
-        rv_id: 109741
+        rv_id: 833975
         rule_id: WAUo0p
-        version_id: l4T4vkd
-        url: https://semgrep.dev/playground/r/l4T4vkd/java.lang.security.audit.unvalidated-redirect.unvalidated-redirect
+        version_id: X0T5N6B
+        url: https://semgrep.dev/playground/r/X0T5N6B/java.lang.security.audit.unvalidated-redirect.unvalidated-redirect
         origin: community
   severity: WARNING
   languages:
@@ -13293,10 +13293,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9187
-        rv_id: 109742
+        rv_id: 833976
         rule_id: 0oU5j3
-        version_id: YDTp2WQ
-        url: https://semgrep.dev/playground/r/YDTp2WQ/java.lang.security.audit.url-rewriting.url-rewriting
+        version_id: jQTrXXk
+        url: https://semgrep.dev/playground/r/jQTrXXk/java.lang.security.audit.url-rewriting.url-rewriting
         origin: community
   severity: WARNING
   languages:
@@ -13395,10 +13395,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18244
-        rv_id: 109751
+        rv_id: 833985
         rule_id: j2UrJ8
-        version_id: 9lTdWrl
-        url: https://semgrep.dev/playground/r/9lTdWrl/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-false.documentbuilderfactory-disallow-doctype-decl-false
+        version_id: xyTNeeN
+        url: https://semgrep.dev/playground/r/xyTNeeN/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-false.documentbuilderfactory-disallow-doctype-decl-false
         origin: community
   message: DOCTYPE declarations are enabled for $DBFACTORY. Without prohibiting external
     entity declarations, this is vulnerable to XML external entity attacks. Disable
@@ -13480,10 +13480,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18245
-        rv_id: 109752
+        rv_id: 833986
         rule_id: 10UPQB
-        version_id: yeTR2lq
-        url: https://semgrep.dev/playground/r/yeTR2lq/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing
+        version_id: O9TJWWv
+        url: https://semgrep.dev/playground/r/O9TJWWv/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing
         origin: community
   message: DOCTYPE declarations are enabled for this DocumentBuilderFactory. This
     is vulnerable to XML external entity attacks. Disable this by setting the feature
@@ -13643,10 +13643,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18246
-        rv_id: 109753
+        rv_id: 833987
         rule_id: 9AUJ6r
-        version_id: rxTyLdl
-        url: https://semgrep.dev/playground/r/rxTyLdl/java.lang.security.audit.xxe.documentbuilderfactory-external-general-entities-true.documentbuilderfactory-external-general-entities-true
+        version_id: e1TDkk9
+        url: https://semgrep.dev/playground/r/e1TDkk9/java.lang.security.audit.xxe.documentbuilderfactory-external-general-entities-true.documentbuilderfactory-external-general-entities-true
         origin: community
   message: External entities are allowed for $DBFACTORY. This is vulnerable to XML
     external entity attacks. Disable this by setting the feature "http://xml.org/sax/features/external-general-entities"
@@ -13693,10 +13693,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18247
-        rv_id: 109754
+        rv_id: 833988
         rule_id: yyUNeo
-        version_id: bZTb1pl
-        url: https://semgrep.dev/playground/r/bZTb1pl/java.lang.security.audit.xxe.documentbuilderfactory-external-parameter-entities-true.documentbuilderfactory-external-parameter-entities-true
+        version_id: vdTOzzN
+        url: https://semgrep.dev/playground/r/vdTOzzN/java.lang.security.audit.xxe.documentbuilderfactory-external-parameter-entities-true.documentbuilderfactory-external-parameter-entities-true
         origin: community
   message: External entities are allowed for $DBFACTORY. This is vulnerable to XML
     external entity attacks. Disable this by setting the feature "http://xml.org/sax/features/external-parameter-entities"
@@ -13744,10 +13744,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 59048
-        rv_id: 109755
+        rv_id: 833989
         rule_id: j2Udpk
-        version_id: NdT3dPr
-        url: https://semgrep.dev/playground/r/NdT3dPr/java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing
+        version_id: d6TKGGv
+        url: https://semgrep.dev/playground/r/d6TKGGv/java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing
         origin: community
   message: DOCTYPE declarations are enabled for this SAXParserFactory. This is vulnerable
     to XML external entity attacks. Disable this by setting the feature `http://apache.org/xml/features/disallow-doctype-decl`
@@ -13910,10 +13910,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 59622
-        rv_id: 109756
+        rv_id: 833990
         rule_id: v8UeQ1
-        version_id: kbTdxNZ
-        url: https://semgrep.dev/playground/r/kbTdxNZ/java.lang.security.audit.xxe.transformerfactory-dtds-not-disabled.transformerfactory-dtds-not-disabled
+        version_id: ZRTlPPK
+        url: https://semgrep.dev/playground/r/ZRTlPPK/java.lang.security.audit.xxe.transformerfactory-dtds-not-disabled.transformerfactory-dtds-not-disabled
         origin: community
   message: DOCTYPE declarations are enabled for this TransformerFactory. This is vulnerable
     to XML external entity attacks. Disable this by setting the attributes "accessExternalDTD"
@@ -14093,10 +14093,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9160
-        rv_id: 109758
+        rv_id: 833992
         rule_id: NbUk7X
-        version_id: xyTKZP1
-        url: https://semgrep.dev/playground/r/xyTKZP1/java.lang.security.httpservlet-path-traversal.httpservlet-path-traversal
+        version_id: ExTrDDe
+        url: https://semgrep.dev/playground/r/ExTrDDe/java.lang.security.httpservlet-path-traversal.httpservlet-path-traversal
         origin: community
   message: Detected a potential path traversal. A malicious actor could control the
     location of this file, to include going backwards in the directory with '../'.
@@ -14169,10 +14169,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9161
-        rv_id: 109759
+        rv_id: 833993
         rule_id: kxUk12
-        version_id: O9TNOwA
-        url: https://semgrep.dev/playground/r/O9TNOwA/java.lang.security.insecure-jms-deserialization.insecure-jms-deserialization
+        version_id: 7ZTx99Z
+        url: https://semgrep.dev/playground/r/7ZTx99Z/java.lang.security.insecure-jms-deserialization.insecure-jms-deserialization
         origin: community
   message: JMS Object messages depend on Java Serialization for marshalling/unmarshalling
     of the message payload when ObjectMessage.getObject() is called. Deserialization
@@ -14225,10 +14225,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9162
-        rv_id: 109761
+        rv_id: 833995
         rule_id: wdUJOk
-        version_id: vdTYNex
-        url: https://semgrep.dev/playground/r/vdTYNex/java.lang.security.servletresponse-writer-xss.servletresponse-writer-xss
+        version_id: 8KTGkkB
+        url: https://semgrep.dev/playground/r/8KTGkkB/java.lang.security.servletresponse-writer-xss.servletresponse-writer-xss
         origin: community
   severity: ERROR
   patterns:
@@ -14278,10 +14278,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9164
-        rv_id: 745880
+        rv_id: 833998
         rule_id: OrU35O
-        version_id: 0bTrP1z
-        url: https://semgrep.dev/playground/r/0bTrP1z/java.lang.security.xmlinputfactory-possible-xxe.xmlinputfactory-possible-xxe
+        version_id: 3ZT3AAg
+        url: https://semgrep.dev/playground/r/3ZT3AAg/java.lang.security.xmlinputfactory-possible-xxe.xmlinputfactory-possible-xxe
         origin: community
   message: XML external entities are not explicitly disabled for this XMLInputFactory.
     This could be vulnerable to XML external entity vulnerabilities. Explicitly disable
@@ -14365,10 +14365,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 29422
-        rv_id: 109771
+        rv_id: 834005
         rule_id: eqUerQ
-        version_id: 3ZTkQqw
-        url: https://semgrep.dev/playground/r/3ZTkQqw/java.spring.security.audit.spring-actuator-fully-enabled-yaml.spring-actuator-fully-enabled-yaml
+        version_id: A8T3778
+        url: https://semgrep.dev/playground/r/A8T3778/java.spring.security.audit.spring-actuator-fully-enabled-yaml.spring-actuator-fully-enabled-yaml
         origin: community
 - id: java.spring.security.audit.spring-actuator-fully-enabled.spring-actuator-fully-enabled
   pattern: management.endpoints.web.exposure.include=*
@@ -14409,10 +14409,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10439
-        rv_id: 109772
+        rv_id: 834006
         rule_id: EwU4vg
-        version_id: 44TRl4j
-        url: https://semgrep.dev/playground/r/44TRl4j/java.spring.security.audit.spring-actuator-fully-enabled.spring-actuator-fully-enabled
+        version_id: BjTe00q
+        url: https://semgrep.dev/playground/r/BjTe00q/java.spring.security.audit.spring-actuator-fully-enabled.spring-actuator-fully-enabled
         origin: community
 - id: java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
   patterns:
@@ -14465,10 +14465,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 32290
-        rv_id: 109773
+        rv_id: 834007
         rule_id: kxUWpX
-        version_id: PkTJ14y
-        url: https://semgrep.dev/playground/r/PkTJ14y/java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
+        version_id: DkTG00E
+        url: https://semgrep.dev/playground/r/DkTG00E/java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
         origin: community
 - id: java.spring.security.audit.spring-actuator-non-health-enabled.spring-actuator-dangerous-endpoints-enabled
   patterns:
@@ -14510,10 +14510,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 32291
-        rv_id: 109774
+        rv_id: 834008
         rule_id: wdUWrZ
-        version_id: JdTNp0W
-        url: https://semgrep.dev/playground/r/JdTNp0W/java.spring.security.audit.spring-actuator-non-health-enabled.spring-actuator-dangerous-endpoints-enabled
+        version_id: WrTdpp0
+        url: https://semgrep.dev/playground/r/WrTdpp0/java.spring.security.audit.spring-actuator-non-health-enabled.spring-actuator-dangerous-endpoints-enabled
         origin: community
 - id: java.spring.security.audit.spring-sqli.spring-sqli
   mode: taint
@@ -14592,10 +14592,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9222
-        rv_id: 109777
+        rv_id: 834011
         rule_id: eqU8N2
-        version_id: RGTDkJb
-        url: https://semgrep.dev/playground/r/RGTDkJb/java.spring.security.audit.spring-sqli.spring-sqli
+        version_id: qkTQnnw
+        url: https://semgrep.dev/playground/r/qkTQnnw/java.spring.security.audit.spring-sqli.spring-sqli
         origin: community
 - id: java.spring.security.audit.spring-unvalidated-redirect.spring-unvalidated-redirect
   message: Application redirects a user to a destination URL specified by a user supplied
@@ -14624,10 +14624,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9223
-        rv_id: 109778
+        rv_id: 834012
         rule_id: v8Un7w
-        version_id: A8T95DY
-        url: https://semgrep.dev/playground/r/A8T95DY/java.spring.security.audit.spring-unvalidated-redirect.spring-unvalidated-redirect
+        version_id: l4TyOOR
+        url: https://semgrep.dev/playground/r/l4TyOOR/java.spring.security.audit.spring-unvalidated-redirect.spring-unvalidated-redirect
         origin: community
   severity: WARNING
   languages:
@@ -14695,10 +14695,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22074
-        rv_id: 109780
+        rv_id: 834013
         rule_id: lBUxok
-        version_id: DkT6nEd
-        url: https://semgrep.dev/playground/r/DkT6nEd/java.spring.security.injection.tainted-file-path.tainted-file-path
+        version_id: YDTl007
+        url: https://semgrep.dev/playground/r/YDTl007/java.spring.security.injection.tainted-file-path.tainted-file-path
         origin: community
   mode: taint
   pattern-sources:
@@ -14784,10 +14784,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22075
-        rv_id: 109781
+        rv_id: 834014
         rule_id: YGUvkL
-        version_id: WrTWQLW
-        url: https://semgrep.dev/playground/r/WrTWQLW/java.spring.security.injection.tainted-html-string.tainted-html-string
+        version_id: 6xTDggY
+        url: https://semgrep.dev/playground/r/6xTDggY/java.spring.security.injection.tainted-html-string.tainted-html-string
         origin: community
   mode: taint
   pattern-sources:
@@ -14904,10 +14904,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14767
-        rv_id: 109782
+        rv_id: 834015
         rule_id: 10UdRR
-        version_id: 0bTLlny
-        url: https://semgrep.dev/playground/r/0bTLlny/java.spring.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: o5TBEE0
+        url: https://semgrep.dev/playground/r/o5TBEE0/java.spring.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   options:
     taint_assume_safe_numbers: true
@@ -15078,10 +15078,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22076
-        rv_id: 109783
+        rv_id: 834016
         rule_id: 6JUxGN
-        version_id: K3Tvjxz
-        url: https://semgrep.dev/playground/r/K3Tvjxz/java.spring.security.injection.tainted-system-command.tainted-system-command
+        version_id: zyTWJJx
+        url: https://semgrep.dev/playground/r/zyTWJJx/java.spring.security.injection.tainted-system-command.tainted-system-command
         origin: community
 - id: java.spring.security.injection.tainted-url-host.tainted-url-host
   languages:
@@ -15123,10 +15123,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22077
-        rv_id: 762646
+        rv_id: 834017
         rule_id: oqUZo8
-        version_id: 0bTrv4d
-        url: https://semgrep.dev/playground/r/0bTrv4d/java.spring.security.injection.tainted-url-host.tainted-url-host
+        version_id: pZTXjjr
+        url: https://semgrep.dev/playground/r/pZTXjjr/java.spring.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sources:
@@ -15212,10 +15212,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9224
-        rv_id: 109787
+        rv_id: 834020
         rule_id: d8Ujdo
-        version_id: JdTNpXL
-        url: https://semgrep.dev/playground/r/JdTNpXL/javascript.angular.security.detect-angular-element-methods.detect-angular-element-methods
+        version_id: jQTrXjk
+        url: https://semgrep.dev/playground/r/jQTrXjk/javascript.angular.security.detect-angular-element-methods.detect-angular-element-methods
         origin: community
   languages:
   - javascript
@@ -15289,10 +15289,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21503
-        rv_id: 109788
+        rv_id: 834021
         rule_id: GdUP71
-        version_id: 5PTdAZp
-        url: https://semgrep.dev/playground/r/5PTdAZp/javascript.angular.security.detect-angular-element-taint.detect-angular-element-taint
+        version_id: 1QTPLNO
+        url: https://semgrep.dev/playground/r/1QTPLNO/javascript.angular.security.detect-angular-element-taint.detect-angular-element-taint
         origin: community
   languages:
   - javascript
@@ -15382,10 +15382,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9227
-        rv_id: 109791
+        rv_id: 834024
         rule_id: EwU20Z
-        version_id: A8T95BJ
-        url: https://semgrep.dev/playground/r/A8T95BJ/javascript.angular.security.detect-angular-sce-disabled.detect-angular-sce-disabled
+        version_id: rxTDzvr
+        url: https://semgrep.dev/playground/r/rxTDzvr/javascript.angular.security.detect-angular-sce-disabled.detect-angular-sce-disabled
         origin: community
   languages:
   - javascript
@@ -15423,10 +15423,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9231
-        rv_id: 109795
+        rv_id: 834028
         rule_id: gxU1QX
-        version_id: 0bTLlno
-        url: https://semgrep.dev/playground/r/0bTLlno/javascript.angular.security.detect-angular-trust-as-method.detect-angular-trust-as-method
+        version_id: w8TAxbl
+        url: https://semgrep.dev/playground/r/w8TAxbl/javascript.angular.security.detect-angular-trust-as-method.detect-angular-trust-as-method
         origin: community
   languages:
   - javascript
@@ -15474,10 +15474,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20150
-        rv_id: 109800
+        rv_id: 834033
         rule_id: DbU2X8
-        version_id: 6xTvJB0
-        url: https://semgrep.dev/playground/r/6xTvJB0/javascript.argon2.security.unsafe-argon2-config.unsafe-argon2-config
+        version_id: d6TKGgv
+        url: https://semgrep.dev/playground/r/d6TKGgv/javascript.argon2.security.unsafe-argon2-config.unsafe-argon2-config
         origin: community
   languages:
   - javascript
@@ -15532,10 +15532,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18248
-        rv_id: 109802
+        rv_id: 834035
         rule_id: r6UDNQ
-        version_id: zyTK8z9
-        url: https://semgrep.dev/playground/r/zyTK8z9/javascript.aws-lambda.security.detect-child-process.detect-child-process
+        version_id: nWTy4N9
+        url: https://semgrep.dev/playground/r/nWTy4N9/javascript.aws-lambda.security.detect-child-process.detect-child-process
         origin: community
   languages:
   - javascript
@@ -15607,10 +15607,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21320
-        rv_id: 109803
+        rv_id: 834036
         rule_id: 0oU1xk
-        version_id: pZT1yER
-        url: https://semgrep.dev/playground/r/pZT1yER/javascript.aws-lambda.security.dynamodb-request-object.dynamodb-request-object
+        version_id: ExTrDWe
+        url: https://semgrep.dev/playground/r/ExTrDWe/javascript.aws-lambda.security.dynamodb-request-object.dynamodb-request-object
         origin: community
   languages:
   - javascript
@@ -15691,10 +15691,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18249
-        rv_id: 109804
+        rv_id: 834037
         rule_id: bwUBlj
-        version_id: 2KTzr8N
-        url: https://semgrep.dev/playground/r/2KTzr8N/javascript.aws-lambda.security.knex-sqli.knex-sqli
+        version_id: 7ZTx9RZ
+        url: https://semgrep.dev/playground/r/7ZTx9RZ/javascript.aws-lambda.security.knex-sqli.knex-sqli
         origin: community
   languages:
   - javascript
@@ -15766,10 +15766,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18250
-        rv_id: 109805
+        rv_id: 834038
         rule_id: NbUBJ2
-        version_id: X0TQxRX
-        url: https://semgrep.dev/playground/r/X0TQxRX/javascript.aws-lambda.security.mysql-sqli.mysql-sqli
+        version_id: LjTEbeB
+        url: https://semgrep.dev/playground/r/LjTEbeB/javascript.aws-lambda.security.mysql-sqli.mysql-sqli
         origin: community
   languages:
   - javascript
@@ -15852,10 +15852,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18251
-        rv_id: 109806
+        rv_id: 834039
         rule_id: kxU25P
-        version_id: jQTgYP0
-        url: https://semgrep.dev/playground/r/jQTgYP0/javascript.aws-lambda.security.pg-sqli.pg-sqli
+        version_id: 8KTGklB
+        url: https://semgrep.dev/playground/r/8KTGklB/javascript.aws-lambda.security.pg-sqli.pg-sqli
         origin: community
   languages:
   - javascript
@@ -15925,10 +15925,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18252
-        rv_id: 109807
+        rv_id: 834040
         rule_id: wdUA5o
-        version_id: 1QTOYGR
-        url: https://semgrep.dev/playground/r/1QTOYGR/javascript.aws-lambda.security.sequelize-sqli.sequelize-sqli
+        version_id: gETy2X5
+        url: https://semgrep.dev/playground/r/gETy2X5/javascript.aws-lambda.security.sequelize-sqli.sequelize-sqli
         origin: community
   languages:
   - javascript
@@ -15993,10 +15993,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18253
-        rv_id: 109808
+        rv_id: 834041
         rule_id: x8UNw5
-        version_id: 9lTdWpv
-        url: https://semgrep.dev/playground/r/9lTdWpv/javascript.aws-lambda.security.tainted-eval.tainted-eval
+        version_id: QkTkrNB
+        url: https://semgrep.dev/playground/r/QkTkrNB/javascript.aws-lambda.security.tainted-eval.tainted-eval
         origin: community
   languages:
   - javascript
@@ -16058,10 +16058,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18254
-        rv_id: 109809
+        rv_id: 834042
         rule_id: OrUJBY
-        version_id: yeTR2o8
-        url: https://semgrep.dev/playground/r/yeTR2o8/javascript.aws-lambda.security.tainted-html-response.tainted-html-response
+        version_id: 3ZT3Awg
+        url: https://semgrep.dev/playground/r/3ZT3Awg/javascript.aws-lambda.security.tainted-html-response.tainted-html-response
         origin: community
   languages:
   - javascript
@@ -16122,10 +16122,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18483
-        rv_id: 109810
+        rv_id: 834043
         rule_id: PeUxwW
-        version_id: rxTyLWd
-        url: https://semgrep.dev/playground/r/rxTyLWd/javascript.aws-lambda.security.tainted-html-string.tainted-html-string
+        version_id: 44TQPqK
+        url: https://semgrep.dev/playground/r/44TQPqK/javascript.aws-lambda.security.tainted-html-string.tainted-html-string
         origin: community
   languages:
   - javascript
@@ -16205,10 +16205,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18255
-        rv_id: 109811
+        rv_id: 834044
         rule_id: eqUDqW
-        version_id: bZTb1yy
-        url: https://semgrep.dev/playground/r/bZTb1yy/javascript.aws-lambda.security.tainted-sql-string.tainted-sql-string
+        version_id: PkTxrGw
+        url: https://semgrep.dev/playground/r/PkTxrGw/javascript.aws-lambda.security.tainted-sql-string.tainted-sql-string
         origin: community
   languages:
   - javascript
@@ -16282,10 +16282,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18256
-        rv_id: 109812
+        rv_id: 834045
         rule_id: v8UOdZ
-        version_id: NdT3d47
-        url: https://semgrep.dev/playground/r/NdT3d47/javascript.aws-lambda.security.vm-runincontext-injection.vm-runincontext-injection
+        version_id: JdTlrRA
+        url: https://semgrep.dev/playground/r/JdTlrRA/javascript.aws-lambda.security.vm-runincontext-injection.vm-runincontext-injection
         origin: community
   languages:
   - javascript
@@ -16357,10 +16357,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9236
-        rv_id: 109813
+        rv_id: 834046
         rule_id: JDUy9J
-        version_id: kbTdxJn
-        url: https://semgrep.dev/playground/r/kbTdxJn/javascript.bluebird.security.audit.tofastproperties-code-execution.tofastproperties-code-execution
+        version_id: 5PTyDG2
+        url: https://semgrep.dev/playground/r/5PTyDG2/javascript.bluebird.security.audit.tofastproperties-code-execution.tofastproperties-code-execution
         origin: community
   languages:
   - javascript
@@ -16421,10 +16421,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9243
-        rv_id: 109821
+        rv_id: 834053
         rule_id: WAUopl
-        version_id: nWTxP37
-        url: https://semgrep.dev/playground/r/nWTxP37/javascript.browser.security.open-redirect.js-open-redirect
+        version_id: 0bTwb3P
+        url: https://semgrep.dev/playground/r/0bTwb3P/javascript.browser.security.open-redirect.js-open-redirect
         origin: community
   languages:
   - javascript
@@ -16526,10 +16526,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9244
-        rv_id: 109822
+        rv_id: 834054
         rule_id: 0oU5b5
-        version_id: ExTjNZk
-        url: https://semgrep.dev/playground/r/ExTjNZk/javascript.browser.security.raw-html-concat.raw-html-concat
+        version_id: K3TrqLq
+        url: https://semgrep.dev/playground/r/K3TrqLq/javascript.browser.security.raw-html-concat.raw-html-concat
         origin: community
   languages:
   - javascript
@@ -16704,10 +16704,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9246
-        rv_id: 109825
+        rv_id: 834057
         rule_id: qNUjnb
-        version_id: 8KTQ9wQ
-        url: https://semgrep.dev/playground/r/8KTQ9wQ/javascript.chrome-remote-interface.security.audit.chrome-remote-interface-compilescript-injection.chrome-remote-interface-compilescript-injection
+        version_id: YDTl0b7
+        url: https://semgrep.dev/playground/r/YDTl0b7/javascript.chrome-remote-interface.security.audit.chrome-remote-interface-compilescript-injection.chrome-remote-interface-compilescript-injection
         origin: community
   languages:
   - javascript
@@ -16765,10 +16765,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9927
-        rv_id: 109830
+        rv_id: 834058
         rule_id: x8UWWg
-        version_id: PkTJ1NB
-        url: https://semgrep.dev/playground/r/PkTJ1NB/javascript.deno.security.audit.deno-dangerous-run.deno-dangerous-run
+        version_id: JdTlrRW
+        url: https://semgrep.dev/playground/r/JdTlrRW/javascript.deno.security.audit.deno-dangerous-run.deno-dangerous-run
         origin: community
   languages:
   - javascript
@@ -16829,10 +16829,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22552
-        rv_id: 109833
+        rv_id: 834060
         rule_id: x8UqEb
-        version_id: GxTv6pD
-        url: https://semgrep.dev/playground/r/GxTv6pD/javascript.express.security.audit.express-check-directory-listing.express-check-directory-listing
+        version_id: GxTDEXG
+        url: https://semgrep.dev/playground/r/GxTDEXG/javascript.express.security.audit.express-check-directory-listing.express-check-directory-listing
         origin: community
   languages:
   - javascript
@@ -16893,10 +16893,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9266
-        rv_id: 109834
+        rv_id: 834061
         rule_id: eqU8k2
-        version_id: RGTDkj2
-        url: https://semgrep.dev/playground/r/RGTDkj2/javascript.express.security.audit.express-cookie-settings.express-cookie-session-default-name
+        version_id: RGTKGxb
+        url: https://semgrep.dev/playground/r/RGTKGxb/javascript.express.security.audit.express-cookie-settings.express-cookie-session-default-name
         origin: community
   patterns:
   - pattern-either:
@@ -16952,10 +16952,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9269
-        rv_id: 109837
+        rv_id: 834064
         rule_id: ZqU5Pn
-        version_id: DkT6nAY
-        url: https://semgrep.dev/playground/r/DkT6nAY/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-domain
+        version_id: DkTG0bd
+        url: https://semgrep.dev/playground/r/DkTG0bd/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-domain
         origin: community
   patterns:
   - pattern-either:
@@ -17028,10 +17028,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9271
-        rv_id: 109839
+        rv_id: 834066
         rule_id: EwU2DZ
-        version_id: 0bTLljo
-        url: https://semgrep.dev/playground/r/0bTLljo/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-expires
+        version_id: 0bTwbzy
+        url: https://semgrep.dev/playground/r/0bTwbzy/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-expires
         origin: community
   patterns:
   - pattern-either:
@@ -17105,10 +17105,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9268
-        rv_id: 109836
+        rv_id: 834063
         rule_id: d8UjGo
-        version_id: BjTXr6r
-        url: https://semgrep.dev/playground/r/BjTXr6r/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-httponly
+        version_id: BjTe0L2
+        url: https://semgrep.dev/playground/r/BjTe0L2/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-httponly
         origin: community
   patterns:
   - pattern-either:
@@ -17182,10 +17182,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9270
-        rv_id: 109838
+        rv_id: 834065
         rule_id: nJUz4X
-        version_id: WrTWQ0q
-        url: https://semgrep.dev/playground/r/WrTWQ0q/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-path
+        version_id: WrTdpKW
+        url: https://semgrep.dev/playground/r/WrTdpKW/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-path
         origin: community
   patterns:
   - pattern-either:
@@ -17258,10 +17258,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9267
-        rv_id: 109835
+        rv_id: 834062
         rule_id: v8Unzw
-        version_id: A8T95wJ
-        url: https://semgrep.dev/playground/r/A8T95wJ/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-secure
+        version_id: A8T37lY
+        url: https://semgrep.dev/playground/r/A8T37lY/javascript.express.security.audit.express-cookie-settings.express-cookie-session-no-secure
         origin: community
   patterns:
   - pattern-either:
@@ -17335,10 +17335,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9272
-        rv_id: 109841
+        rv_id: 834068
         rule_id: 7KUQ9k
-        version_id: qkT2x3L
-        url: https://semgrep.dev/playground/r/qkT2x3L/javascript.express.security.audit.express-jwt-not-revoked.express-jwt-not-revoked
+        version_id: qkTQn7j
+        url: https://semgrep.dev/playground/r/qkTQn7j/javascript.express.security.audit.express-jwt-not-revoked.express-jwt-not-revoked
         origin: community
   languages:
   - javascript
@@ -17388,10 +17388,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22079
-        rv_id: 109842
+        rv_id: 834069
         rule_id: pKUNeD
-        version_id: l4T4vG1
-        url: https://semgrep.dev/playground/r/l4T4vG1/javascript.express.security.audit.express-libxml-noent.express-libxml-noent
+        version_id: l4TyORd
+        url: https://semgrep.dev/playground/r/l4TyORd/javascript.express.security.audit.express-libxml-noent.express-libxml-noent
         origin: community
   languages:
   - javascript
@@ -17482,10 +17482,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22081
-        rv_id: 109844
+        rv_id: 834071
         rule_id: X5ULkq
-        version_id: 6xTvJN0
-        url: https://semgrep.dev/playground/r/6xTvJN0/javascript.express.security.audit.express-open-redirect.express-open-redirect
+        version_id: 6xTDg91
+        url: https://semgrep.dev/playground/r/6xTDg91/javascript.express.security.audit.express-open-redirect.express-open-redirect
         origin: community
   languages:
   - javascript
@@ -17604,10 +17604,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9273
-        rv_id: 109845
+        rv_id: 834072
         rule_id: L1Uyb8
-        version_id: o5Tgl6W
-        url: https://semgrep.dev/playground/r/o5Tgl6W/javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal
+        version_id: o5TBED2
+        url: https://semgrep.dev/playground/r/o5TBED2/javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal
         origin: community
   languages:
   - javascript
@@ -17709,10 +17709,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22082
-        rv_id: 109846
+        rv_id: 834073
         rule_id: j2UzDx
-        version_id: zyTK8E9
-        url: https://semgrep.dev/playground/r/zyTK8E9/javascript.express.security.audit.express-res-sendfile.express-res-sendfile
+        version_id: zyTWJ2W
+        url: https://semgrep.dev/playground/r/zyTWJ2W/javascript.express.security.audit.express-res-sendfile.express-res-sendfile
         origin: community
   languages:
   - javascript
@@ -17803,10 +17803,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22083
-        rv_id: 109847
+        rv_id: 834074
         rule_id: 10Uo39
-        version_id: pZT1y5R
-        url: https://semgrep.dev/playground/r/pZT1y5R/javascript.express.security.audit.express-session-hardcoded-secret.express-session-hardcoded-secret
+        version_id: pZTXj3b
+        url: https://semgrep.dev/playground/r/pZTXj3b/javascript.express.security.audit.express-session-hardcoded-secret.express-session-hardcoded-secret
         origin: community
   languages:
   - javascript
@@ -17868,10 +17868,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22554
-        rv_id: 109848
+        rv_id: 834075
         rule_id: eqU9l2
-        version_id: 2KTzr9N
-        url: https://semgrep.dev/playground/r/2KTzr9N/javascript.express.security.audit.express-ssrf.express-ssrf
+        version_id: 2KT7x2Y
+        url: https://semgrep.dev/playground/r/2KT7x2Y/javascript.express.security.audit.express-ssrf.express-ssrf
         origin: community
   languages:
   - javascript
@@ -18066,10 +18066,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22084
-        rv_id: 109849
+        rv_id: 834076
         rule_id: 9AUyqj
-        version_id: X0TQxrX
-        url: https://semgrep.dev/playground/r/X0TQxrX/javascript.express.security.audit.express-third-party-object-deserialization.express-third-party-object-deserialization
+        version_id: X0T5Nyx
+        url: https://semgrep.dev/playground/r/X0T5Nyx/javascript.express.security.audit.express-third-party-object-deserialization.express-third-party-object-deserialization
         origin: community
   languages:
   - javascript
@@ -18161,10 +18161,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9274
-        rv_id: 109850
+        rv_id: 834077
         rule_id: 8GUjkk
-        version_id: jQTgYo0
-        url: https://semgrep.dev/playground/r/jQTgYo0/javascript.express.security.audit.express-xml2json-xxe-event.express-xml2json-xxe-event
+        version_id: jQTrX5y
+        url: https://semgrep.dev/playground/r/jQTrX5y/javascript.express.security.audit.express-xml2json-xxe-event.express-xml2json-xxe-event
         origin: community
   languages:
   - javascript
@@ -18241,10 +18241,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13579
-        rv_id: 109852
+        rv_id: 834079
         rule_id: JDUL1B
-        version_id: 9lTdWxv
-        url: https://semgrep.dev/playground/r/9lTdWxv/javascript.express.security.audit.remote-property-injection.remote-property-injection
+        version_id: 9lTJ0bl
+        url: https://semgrep.dev/playground/r/9lTJ0bl/javascript.express.security.audit.remote-property-injection.remote-property-injection
         origin: community
   languages:
   - javascript
@@ -18331,10 +18331,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9276
-        rv_id: 109853
+        rv_id: 834080
         rule_id: QrUzrq
-        version_id: yeTR2K8
-        url: https://semgrep.dev/playground/r/yeTR2K8/javascript.express.security.audit.res-render-injection.res-render-injection
+        version_id: yeTN1pq
+        url: https://semgrep.dev/playground/r/yeTN1pq/javascript.express.security.audit.res-render-injection.res-render-injection
         origin: community
   languages:
   - javascript
@@ -18411,10 +18411,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9277
-        rv_id: 751090
+        rv_id: 834081
         rule_id: 3qUPA1
-        version_id: qkTWwqp
-        url: https://semgrep.dev/playground/r/qkTWwqp/javascript.express.security.audit.xss.direct-response-write.direct-response-write
+        version_id: rxTDzKl
+        url: https://semgrep.dev/playground/r/rxTDzKl/javascript.express.security.audit.xss.direct-response-write.direct-response-write
         origin: community
   languages:
   - javascript
@@ -18650,10 +18650,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13580
-        rv_id: 109867
+        rv_id: 834094
         rule_id: 5rULJQ
-        version_id: 7ZTgokN
-        url: https://semgrep.dev/playground/r/7ZTgokN/javascript.express.security.cors-misconfiguration.cors-misconfiguration
+        version_id: 7ZTx930
+        url: https://semgrep.dev/playground/r/7ZTx930/javascript.express.security.cors-misconfiguration.cors-misconfiguration
         origin: community
   languages:
   - javascript
@@ -18740,10 +18740,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9251
-        rv_id: 109869
+        rv_id: 834096
         rule_id: zdUkJl
-        version_id: 8KTQ98Q
-        url: https://semgrep.dev/playground/r/8KTQ98Q/javascript.express.security.express-expat-xxe.express-expat-xxe
+        version_id: 8KTGkrw
+        url: https://semgrep.dev/playground/r/8KTGkrw/javascript.express.security.express-expat-xxe.express-expat-xxe
         origin: community
   languages:
   - javascript
@@ -18846,10 +18846,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19226
-        rv_id: 109870
+        rv_id: 834097
         rule_id: EwUr9k
-        version_id: gET3xQ6
-        url: https://semgrep.dev/playground/r/gET3xQ6/javascript.express.security.express-insecure-template-usage.express-insecure-template-usage
+        version_id: gETy27Q
+        url: https://semgrep.dev/playground/r/gETy27Q/javascript.express.security.express-insecure-template-usage.express-insecure-template-usage
         origin: community
   languages:
   - javascript
@@ -19019,10 +19019,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9253
-        rv_id: 109872
+        rv_id: 834099
         rule_id: 2ZUbx3
-        version_id: 3ZTkQ0P
-        url: https://semgrep.dev/playground/r/3ZTkQ0P/javascript.express.security.express-phantom-injection.express-phantom-injection
+        version_id: 3ZT3AXw
+        url: https://semgrep.dev/playground/r/3ZT3AXw/javascript.express.security.express-phantom-injection.express-phantom-injection
         origin: community
   languages:
   - javascript
@@ -19104,10 +19104,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9254
-        rv_id: 109873
+        rv_id: 834100
         rule_id: X5U8Nz
-        version_id: 44TRl0z
-        url: https://semgrep.dev/playground/r/44TRl0z/javascript.express.security.express-puppeteer-injection.express-puppeteer-injection
+        version_id: 44TQPjj
+        url: https://semgrep.dev/playground/r/44TQPjj/javascript.express.security.express-puppeteer-injection.express-puppeteer-injection
         origin: community
   languages:
   - javascript
@@ -19190,10 +19190,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9255
-        rv_id: 109874
+        rv_id: 834101
         rule_id: j2UvXB
-        version_id: PkTJ1PB
-        url: https://semgrep.dev/playground/r/PkTJ1PB/javascript.express.security.express-sandbox-injection.express-sandbox-code-injection
+        version_id: PkTxr3y
+        url: https://semgrep.dev/playground/r/PkTxr3y/javascript.express.security.express-sandbox-injection.express-sandbox-code-injection
         origin: community
   languages:
   - javascript
@@ -19272,10 +19272,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12821
-        rv_id: 109875
+        rv_id: 834102
         rule_id: DbUKPX
-        version_id: JdTNp9L
-        url: https://semgrep.dev/playground/r/JdTNp9L/javascript.express.security.express-vm-injection.express-vm-injection
+        version_id: JdTlrxW
+        url: https://semgrep.dev/playground/r/JdTlrxW/javascript.express.security.express-vm-injection.express-vm-injection
         origin: community
   languages:
   - javascript
@@ -19350,10 +19350,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12822
-        rv_id: 109876
+        rv_id: 834103
         rule_id: WAUPXJ
-        version_id: 5PTdAgp
-        url: https://semgrep.dev/playground/r/5PTdAgp/javascript.express.security.express-vm2-injection.express-vm2-injection
+        version_id: 5PTyD1X
+        url: https://semgrep.dev/playground/r/5PTyD1X/javascript.express.security.express-vm2-injection.express-vm2-injection
         origin: community
   languages:
   - javascript
@@ -19447,10 +19447,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9262
-        rv_id: 109877
+        rv_id: 834104
         rule_id: kxUkl9
-        version_id: GxTv6dD
-        url: https://semgrep.dev/playground/r/GxTv6dD/javascript.express.security.express-wkhtml-injection.express-wkhtmltoimage-injection
+        version_id: GxTDEeG
+        url: https://semgrep.dev/playground/r/GxTDEeG/javascript.express.security.express-wkhtml-injection.express-wkhtmltoimage-injection
         origin: community
   severity: ERROR
   languages:
@@ -19520,10 +19520,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9263
-        rv_id: 109878
+        rv_id: 834105
         rule_id: wdUJxq
-        version_id: RGTDk42
-        url: https://semgrep.dev/playground/r/RGTDk42/javascript.express.security.express-wkhtml-injection.express-wkhtmltopdf-injection
+        version_id: RGTKGLb
+        url: https://semgrep.dev/playground/r/RGTKGLb/javascript.express.security.express-wkhtml-injection.express-wkhtmltopdf-injection
         origin: community
   languages:
   - javascript
@@ -19602,10 +19602,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9264
-        rv_id: 109879
+        rv_id: 834106
         rule_id: x8Uneb
-        version_id: A8T95oJ
-        url: https://semgrep.dev/playground/r/A8T95oJ/javascript.express.security.express-xml2json-xxe.express-xml2json-xxe
+        version_id: A8T37dY
+        url: https://semgrep.dev/playground/r/A8T37dY/javascript.express.security.express-xml2json-xxe.express-xml2json-xxe
         origin: community
   languages:
   - javascript
@@ -19690,10 +19690,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14691
-        rv_id: 109880
+        rv_id: 834107
         rule_id: 5rUL0X
-        version_id: BjTXr3r
-        url: https://semgrep.dev/playground/r/BjTXr3r/javascript.express.security.injection.raw-html-format.raw-html-format
+        version_id: BjTe0Z2
+        url: https://semgrep.dev/playground/r/BjTe0Z2/javascript.express.security.injection.raw-html-format.raw-html-format
         origin: community
   languages:
   - javascript
@@ -19794,10 +19794,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14715
-        rv_id: 763098
+        rv_id: 834108
         rule_id: NbUNpr
-        version_id: PkT0LoB
-        url: https://semgrep.dev/playground/r/PkT0LoB/javascript.express.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: DkTG0jd
+        url: https://semgrep.dev/playground/r/DkTG0jd/javascript.express.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   languages:
   - javascript
@@ -19872,10 +19872,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9265
-        rv_id: 109882
+        rv_id: 834109
         rule_id: OrU3WK
-        version_id: WrTWQ4q
-        url: https://semgrep.dev/playground/r/WrTWQ4q/javascript.express.security.require-request.require-request
+        version_id: WrTdpwW
+        url: https://semgrep.dev/playground/r/WrTdpwW/javascript.express.security.require-request.require-request
         origin: community
   languages:
   - javascript
@@ -19944,10 +19944,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13581
-        rv_id: 109883
+        rv_id: 834110
         rule_id: GdUrLy
-        version_id: 0bTLlPo
-        url: https://semgrep.dev/playground/r/0bTLlPo/javascript.express.security.x-frame-options-misconfiguration.x-frame-options-misconfiguration
+        version_id: 0bTwbXy
+        url: https://semgrep.dev/playground/r/0bTwbXy/javascript.express.security.x-frame-options-misconfiguration.x-frame-options-misconfiguration
         origin: community
   languages:
   - javascript
@@ -20035,10 +20035,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9293
-        rv_id: 109889
+        rv_id: 834115
         rule_id: JDUyRl
-        version_id: 5PTdAgB
-        url: https://semgrep.dev/playground/r/5PTdAgB/javascript.jose.security.jwt-hardcode.hardcoded-jwt-secret
+        version_id: 6xTDgo1
+        url: https://semgrep.dev/playground/r/6xTDgo1/javascript.jose.security.jwt-hardcode.hardcoded-jwt-secret
         origin: community
   languages:
   - javascript
@@ -20117,10 +20117,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9294
-        rv_id: 109890
+        rv_id: 834116
         rule_id: 5rUOGN
-        version_id: GxTv6dg
-        url: https://semgrep.dev/playground/r/GxTv6dg/javascript.jose.security.jwt-none-alg.jwt-none-alg
+        version_id: o5TBEw2
+        url: https://semgrep.dev/playground/r/o5TBEw2/javascript.jose.security.jwt-none-alg.jwt-none-alg
         origin: community
   languages:
   - javascript
@@ -20183,10 +20183,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9300
-        rv_id: 230007
+        rv_id: 834122
         rule_id: WAUon7
-        version_id: e1TgQKG
-        url: https://semgrep.dev/playground/r/e1TgQKG/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
+        version_id: 1QTPLvy
+        url: https://semgrep.dev/playground/r/1QTPLvy/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
         origin: community
   languages:
   - javascript
@@ -20259,10 +20259,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9301
-        rv_id: 109898
+        rv_id: 834123
         rule_id: 0oU53g
-        version_id: qkT2x86
-        url: https://semgrep.dev/playground/r/qkT2x86/javascript.jsonwebtoken.security.jwt-none-alg.jwt-none-alg
+        version_id: 9lTJ0wl
+        url: https://semgrep.dev/playground/r/9lTJ0wl/javascript.jsonwebtoken.security.jwt-none-alg.jwt-none-alg
         origin: community
   languages:
   - javascript
@@ -20310,10 +20310,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 120561
-        rv_id: 724919
+        rv_id: 834124
         rule_id: r6UyNLy
-        version_id: 44TgJGG
-        url: https://semgrep.dev/playground/r/44TgJGG/javascript.jwt-simple.security.jwt-simple-noverify.jwt-simple-noverify
+        version_id: yeTN1rq
+        url: https://semgrep.dev/playground/r/yeTN1rq/javascript.jwt-simple.security.jwt-simple-noverify.jwt-simple-noverify
         origin: community
   languages:
   - javascript
@@ -20369,10 +20369,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13023
-        rv_id: 109911
+        rv_id: 834137
         rule_id: DbUKEz
-        version_id: rxTyL7P
-        url: https://semgrep.dev/playground/r/rxTyL7P/javascript.lang.security.audit.code-string-concat.code-string-concat
+        version_id: ExTrDwO
+        url: https://semgrep.dev/playground/r/ExTrDwO/javascript.lang.security.audit.code-string-concat.code-string-concat
         origin: community
   languages:
   - javascript
@@ -20466,10 +20466,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9852
-        rv_id: 109912
+        rv_id: 834138
         rule_id: qNUo10
-        version_id: bZTb1eA
-        url: https://semgrep.dev/playground/r/bZTb1eA/javascript.lang.security.audit.dangerous-spawn-shell.dangerous-spawn-shell
+        version_id: 7ZTx9y0
+        url: https://semgrep.dev/playground/r/7ZTx9y0/javascript.lang.security.audit.dangerous-spawn-shell.dangerous-spawn-shell
         origin: community
   languages:
   - javascript
@@ -20547,10 +20547,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12685
-        rv_id: 109915
+        rv_id: 834140
         rule_id: zdU1gD
-        version_id: w8T9nxz
-        url: https://semgrep.dev/playground/r/w8T9nxz/javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+        version_id: 8KTGkZw
+        url: https://semgrep.dev/playground/r/8KTGkZw/javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
         origin: community
   languages:
   - javascript
@@ -20605,10 +20605,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14692
-        rv_id: 109920
+        rv_id: 834145
         rule_id: GdUr5G
-        version_id: d6TrAG4
-        url: https://semgrep.dev/playground/r/d6TrAG4/javascript.lang.security.audit.md5-used-as-password.md5-used-as-password
+        version_id: PkTxryy
+        url: https://semgrep.dev/playground/r/PkTxryy/javascript.lang.security.audit.md5-used-as-password.md5-used-as-password
         origin: community
   languages:
   - javascript
@@ -20655,10 +20655,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9331
-        rv_id: 109922
+        rv_id: 834146
         rule_id: 8GUjrq
-        version_id: nWTxP4n
-        url: https://semgrep.dev/playground/r/nWTxP4n/javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+        version_id: JdTlrjW
+        url: https://semgrep.dev/playground/r/JdTlrjW/javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
         origin: community
   languages:
   - javascript
@@ -20747,10 +20747,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18257
-        rv_id: 109927
+        rv_id: 834150
         rule_id: d8UKLD
-        version_id: gET3x2P
-        url: https://semgrep.dev/playground/r/gET3x2P/javascript.lang.security.audit.sqli.node-knex-sqli.node-knex-sqli
+        version_id: A8T372Y
+        url: https://semgrep.dev/playground/r/A8T372Y/javascript.lang.security.audit.sqli.node-knex-sqli.node-knex-sqli
         origin: community
   languages:
   - javascript
@@ -20842,10 +20842,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13157
-        rv_id: 109928
+        rv_id: 834151
         rule_id: kxU8Pd
-        version_id: QkTW0rE
-        url: https://semgrep.dev/playground/r/QkTW0rE/javascript.lang.security.audit.sqli.node-mssql-sqli.node-mssql-sqli
+        version_id: BjTe0A2
+        url: https://semgrep.dev/playground/r/BjTe0A2/javascript.lang.security.audit.sqli.node-mssql-sqli.node-mssql-sqli
         origin: community
   languages:
   - javascript
@@ -20910,10 +20910,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18258
-        rv_id: 109929
+        rv_id: 834152
         rule_id: ZqUlWE
-        version_id: 3ZTkQAW
-        url: https://semgrep.dev/playground/r/3ZTkQAW/javascript.lang.security.audit.sqli.node-mysql-sqli.node-mysql-sqli
+        version_id: DkTG05d
+        url: https://semgrep.dev/playground/r/DkTG05d/javascript.lang.security.audit.sqli.node-mysql-sqli.node-mysql-sqli
         origin: community
   languages:
   - javascript
@@ -20987,10 +20987,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10710
-        rv_id: 109930
+        rv_id: 834153
         rule_id: ReUPN9
-        version_id: 44TRlP8
-        url: https://semgrep.dev/playground/r/44TRlP8/javascript.lang.security.audit.sqli.node-postgres-sqli.node-postgres-sqli
+        version_id: WrTdp1W
+        url: https://semgrep.dev/playground/r/WrTdp1W/javascript.lang.security.audit.sqli.node-postgres-sqli.node-postgres-sqli
         origin: community
   languages:
   - javascript
@@ -21058,10 +21058,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9315
-        rv_id: 109946
+        rv_id: 834160
         rule_id: yyUngo
-        version_id: o5TglEE
-        url: https://semgrep.dev/playground/r/o5TglEE/javascript.lang.security.detect-eval-with-expression.detect-eval-with-expression
+        version_id: 5PTyDwp
+        url: https://semgrep.dev/playground/r/5PTyDwp/javascript.lang.security.detect-eval-with-expression.detect-eval-with-expression
         origin: community
   languages:
   - javascript
@@ -21156,10 +21156,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12819
-        rv_id: 109952
+        rv_id: 834165
         rule_id: AbUGOq
-        version_id: 1QTOYLD
-        url: https://semgrep.dev/playground/r/1QTOYLD/javascript.lang.security.insecure-object-assign.insecure-object-assign
+        version_id: DkTG05Y
+        url: https://semgrep.dev/playground/r/DkTG05Y/javascript.lang.security.insecure-object-assign.insecure-object-assign
         origin: community
   languages:
   - javascript
@@ -21210,10 +21210,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9333
-        rv_id: 109956
+        rv_id: 834169
         rule_id: QrUzq6
-        version_id: bZTb1oA
-        url: https://semgrep.dev/playground/r/bZTb1oA/javascript.passport-jwt.security.passport-hardcode.hardcoded-passport-secret
+        version_id: qkTQnZL
+        url: https://semgrep.dev/playground/r/qkTQnZL/javascript.passport-jwt.security.passport-hardcode.hardcoded-passport-secret
         origin: community
   languages:
   - javascript
@@ -21328,10 +21328,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22085
-        rv_id: 109973
+        rv_id: 834186
         rule_id: yyU0GX
-        version_id: 3ZTkQwW
-        url: https://semgrep.dev/playground/r/3ZTkQwW/javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection
+        version_id: w8TAxwx
+        url: https://semgrep.dev/playground/r/w8TAxwx/javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection
         origin: community
   languages:
   - javascript
@@ -21414,10 +21414,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13413
-        rv_id: 109986
+        rv_id: 834199
         rule_id: 7KUpLy
-        version_id: qkT2xw6
-        url: https://semgrep.dev/playground/r/qkT2xw6/json.aws.security.public-s3-bucket.public-s3-bucket
+        version_id: QkTkrb7
+        url: https://semgrep.dev/playground/r/QkTkrb7/json.aws.security.public-s3-bucket.public-s3-bucket
         origin: community
   patterns:
   - pattern-inside: |
@@ -21490,10 +21490,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9358
-        rv_id: 109987
+        rv_id: 834200
         rule_id: 9AU1br
-        version_id: l4T4vDE
-        url: https://semgrep.dev/playground/r/l4T4vDE/json.aws.security.public-s3-policy-statement.public-s3-policy-statement
+        version_id: 3ZT3AvP
+        url: https://semgrep.dev/playground/r/3ZT3AvP/json.aws.security.public-s3-policy-statement.public-s3-policy-statement
         origin: community
   severity: WARNING
   languages:
@@ -21536,10 +21536,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15138
-        rv_id: 109988
+        rv_id: 834201
         rule_id: JDULx5
-        version_id: YDTp2bd
-        url: https://semgrep.dev/playground/r/YDTp2bd/json.aws.security.wildcard-assume-role.wildcard-assume-role
+        version_id: 44TQPnz
+        url: https://semgrep.dev/playground/r/44TQPnz/json.aws.security.wildcard-assume-role.wildcard-assume-role
         origin: community
   languages:
   - json
@@ -21579,10 +21579,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 137856
-        rv_id: 764626
+        rv_id: 834203
         rule_id: ReUD6Kg
-        version_id: YDTAPoy
-        url: https://semgrep.dev/playground/r/YDTAPoy/kotlin.gradle.security.build-gradle-password-hardcoded.build-gradle-password-hardcoded
+        version_id: JdTlrdL
+        url: https://semgrep.dev/playground/r/JdTlrdL/kotlin.gradle.security.build-gradle-password-hardcoded.build-gradle-password-hardcoded
         origin: community
   languages:
   - kotlin
@@ -21631,10 +21631,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15125
-        rv_id: 109990
+        rv_id: 834204
         rule_id: v8U9Q7
-        version_id: 5PTdAGD
-        url: https://semgrep.dev/playground/r/5PTdAGD/kotlin.lang.security.anonymous-ldap-bind.anonymous-ldap-bind
+        version_id: 5PTyDXp
+        url: https://semgrep.dev/playground/r/5PTyDXp/kotlin.lang.security.anonymous-ldap-bind.anonymous-ldap-bind
         origin: community
   message: Detected anonymous LDAP bind. This permits anonymous users to execute LDAP
     statements. Consider enforcing authentication for LDAP. See https://docs.oracle.com/javase/tutorial/jndi/ldap/auth_mechs.html
@@ -21672,10 +21672,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14696
-        rv_id: 109996
+        rv_id: 834210
         rule_id: DbU1Zd
-        version_id: WrTWQnR
-        url: https://semgrep.dev/playground/r/WrTWQnR/kotlin.lang.security.ecb-cipher.ecb-cipher
+        version_id: WrTdpvq
+        url: https://semgrep.dev/playground/r/WrTdpvq/kotlin.lang.security.ecb-cipher.ecb-cipher
         origin: community
   message: Cipher in ECB mode is detected. ECB mode produces the same output for the
     same input each time which allows an attacker to intercept and replay the data.
@@ -21732,10 +21732,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14698
-        rv_id: 109998
+        rv_id: 834212
         rule_id: 0oU2Yy
-        version_id: K3TvjLy
-        url: https://semgrep.dev/playground/r/K3TvjLy/kotlin.lang.security.no-null-cipher.no-null-cipher
+        version_id: K3Trqdg
+        url: https://semgrep.dev/playground/r/K3Trqdg/kotlin.lang.security.no-null-cipher.no-null-cipher
         origin: community
   message: 'NullCipher was detected. This will not encrypt anything; the cipher text
     will be the same as the plain text. Use a valid, secure cipher: Cipher.getInstance("AES/CBC/PKCS7PADDING").
@@ -21777,10 +21777,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14700
-        rv_id: 258077
+        rv_id: 834214
         rule_id: qNUXPj
-        version_id: yeTBRZG
-        url: https://semgrep.dev/playground/r/yeTBRZG/kotlin.lang.security.use-of-md5.use-of-md5
+        version_id: l4TyO71
+        url: https://semgrep.dev/playground/r/l4TyO71/kotlin.lang.security.use-of-md5.use-of-md5
         origin: community
   pattern-either:
   - pattern: '$VAR = $MD.getInstance("MD5")
@@ -21824,10 +21824,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15127
-        rv_id: 110001
+        rv_id: 834215
         rule_id: ZqUOdd
-        version_id: YDTp2ep
-        url: https://semgrep.dev/playground/r/YDTp2ep/kotlin.lang.security.use-of-sha1.use-of-sha1
+        version_id: YDTl0JO
+        url: https://semgrep.dev/playground/r/YDTl0JO/kotlin.lang.security.use-of-sha1.use-of-sha1
         origin: community
   pattern-either:
   - patterns:
@@ -21873,10 +21873,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13965
-        rv_id: 110030
+        rv_id: 834251
         rule_id: kxUw23
-        version_id: 3ZTkQXq
-        url: https://semgrep.dev/playground/r/3ZTkQXq/php.doctrine.security.audit.doctrine-orm-dangerous-query.doctrine-orm-dangerous-query
+        version_id: A8T376J
+        url: https://semgrep.dev/playground/r/A8T376J/php.doctrine.security.audit.doctrine-orm-dangerous-query.doctrine-orm-dangerous-query
         origin: community
   mode: taint
   pattern-sinks:
@@ -21968,10 +21968,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9387
-        rv_id: 110031
+        rv_id: 834252
         rule_id: DbUpjk
-        version_id: 44TRljD
-        url: https://semgrep.dev/playground/r/44TRljD/php.lang.security.assert-use.assert-use
+        version_id: BjTe09r
+        url: https://semgrep.dev/playground/r/BjTe09r/php.lang.security.assert-use.assert-use
         origin: community
   languages:
   - php
@@ -22013,10 +22013,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9389
-        rv_id: 110035
+        rv_id: 834257
         rule_id: 0oU5Xg
-        version_id: GxTv6eX
-        url: https://semgrep.dev/playground/r/GxTv6eX/php.lang.security.curl-ssl-verifypeer-off.curl-ssl-verifypeer-off
+        version_id: qkTQn0L
+        url: https://semgrep.dev/playground/r/qkTQn0L/php.lang.security.curl-ssl-verifypeer-off.curl-ssl-verifypeer-off
         origin: community
   languages:
   - php
@@ -22062,10 +22062,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18259
-        rv_id: 110036
+        rv_id: 834258
         rule_id: nJUykq
-        version_id: RGTDkLL
-        url: https://semgrep.dev/playground/r/RGTDkLL/php.lang.security.deserialization.extract-user-data
+        version_id: l4TyOL1
+        url: https://semgrep.dev/playground/r/l4TyOL1/php.lang.security.deserialization.extract-user-data
         origin: community
   severity: ERROR
 - id: php.lang.security.injection.echoed-request.echoed-request
@@ -22131,10 +22131,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31707
-        rv_id: 743482
+        rv_id: 834263
         rule_id: BYUyyg
-        version_id: 9lTZxd4
-        url: https://semgrep.dev/playground/r/9lTZxd4/php.lang.security.injection.echoed-request.echoed-request
+        version_id: RGTKGXN
+        url: https://semgrep.dev/playground/r/RGTKGXN/php.lang.security.injection.echoed-request.echoed-request
         origin: community
 - id: php.lang.security.injection.printed-request.printed-request
   mode: taint
@@ -22199,10 +22199,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 128886
-        rv_id: 743483
+        rv_id: 834264
         rule_id: KxUvRBw
-        version_id: yeTAKRO
-        url: https://semgrep.dev/playground/r/yeTAKRO/php.lang.security.injection.printed-request.printed-request
+        version_id: A8T376P
+        url: https://semgrep.dev/playground/r/A8T376P/php.lang.security.injection.printed-request.printed-request
         origin: community
 - id: php.lang.security.injection.tainted-filename.tainted-filename
   severity: WARNING
@@ -22232,10 +22232,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16250
-        rv_id: 110042
+        rv_id: 834265
         rule_id: 5rUpro
-        version_id: K3Tvjky
-        url: https://semgrep.dev/playground/r/K3Tvjky/php.lang.security.injection.tainted-filename.tainted-filename
+        version_id: BjTe09O
+        url: https://semgrep.dev/playground/r/BjTe09O/php.lang.security.injection.tainted-filename.tainted-filename
         origin: community
   languages:
   - php
@@ -22425,10 +22425,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16438
-        rv_id: 110043
+        rv_id: 834266
         rule_id: v8U4DA
-        version_id: qkT2x7l
-        url: https://semgrep.dev/playground/r/qkT2x7l/php.lang.security.injection.tainted-object-instantiation.tainted-object-instantiation
+        version_id: DkTG0OZ
+        url: https://semgrep.dev/playground/r/DkTG0OZ/php.lang.security.injection.tainted-object-instantiation.tainted-object-instantiation
         origin: community
   mode: taint
   pattern-sources:
@@ -22475,10 +22475,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 73470
-        rv_id: 113532
+        rv_id: 834267
         rule_id: 4bUdoP
-        version_id: 0bTLKDl
-        url: https://semgrep.dev/playground/r/0bTLKDl/php.lang.security.injection.tainted-session.tainted-session
+        version_id: WrTdpRX
+        url: https://semgrep.dev/playground/r/WrTdpRX/php.lang.security.injection.tainted-session.tainted-session
         origin: community
   languages:
   - php
@@ -22567,10 +22567,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14757
-        rv_id: 251682
+        rv_id: 834268
         rule_id: qNUXdL
-        version_id: RGTevOe
-        url: https://semgrep.dev/playground/r/RGTevOe/php.lang.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: 0bTwb4D
+        url: https://semgrep.dev/playground/r/0bTwb4D/php.lang.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -22644,10 +22644,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14758
-        rv_id: 762647
+        rv_id: 834269
         rule_id: lBU8K1
-        version_id: K3T5lpd
-        url: https://semgrep.dev/playground/r/K3T5lpd/php.lang.security.injection.tainted-url-host.tainted-url-host
+        version_id: K3Trqpe
+        url: https://semgrep.dev/playground/r/K3Trqpe/php.lang.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sources:
@@ -22720,10 +22720,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14759
-        rv_id: 110050
+        rv_id: 834274
         rule_id: YGUD1O
-        version_id: 2KTzrjK
-        url: https://semgrep.dev/playground/r/2KTzrjK/php.lang.security.md5-used-as-password.md5-used-as-password
+        version_id: o5TBE7E
+        url: https://semgrep.dev/playground/r/o5TBE7E/php.lang.security.md5-used-as-password.md5-used-as-password
         origin: community
   mode: taint
   pattern-sources:
@@ -22774,10 +22774,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19039
-        rv_id: 110052
+        rv_id: 834275
         rule_id: DbUGbE
-        version_id: jQTgY2Q
-        url: https://semgrep.dev/playground/r/jQTgY2Q/php.lang.security.openssl-cbc-static-iv.openssl-cbc-static-iv
+        version_id: zyTWJx3
+        url: https://semgrep.dev/playground/r/zyTWJx3/php.lang.security.openssl-cbc-static-iv.openssl-cbc-static-iv
         origin: community
 - id: php.lang.security.phpinfo-use.phpinfo-use
   pattern: phpinfo(...);
@@ -22807,10 +22807,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9397
-        rv_id: 110055
+        rv_id: 834278
         rule_id: ReUglY
-        version_id: yeTR2r0
-        url: https://semgrep.dev/playground/r/yeTR2r0/php.lang.security.phpinfo-use.phpinfo-use
+        version_id: X0T5Nv9
+        url: https://semgrep.dev/playground/r/X0T5Nv9/php.lang.security.phpinfo-use.phpinfo-use
         origin: community
   languages:
   - php
@@ -22856,10 +22856,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 35493
-        rv_id: 110057
+        rv_id: 834279
         rule_id: 3qUb4n
-        version_id: bZTb1d9
-        url: https://semgrep.dev/playground/r/bZTb1d9/php.lang.security.redirect-to-request-uri.redirect-to-request-uri
+        version_id: jQTrXEb
+        url: https://semgrep.dev/playground/r/jQTrXEb/php.lang.security.redirect-to-request-uri.redirect-to-request-uri
         origin: community
   languages:
   - php
@@ -22909,10 +22909,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 73146
-        rv_id: 110058
+        rv_id: 834280
         rule_id: 9AUw06
-        version_id: NdT3djz
-        url: https://semgrep.dev/playground/r/NdT3djz/php.lang.security.tainted-exec.tainted-exec
+        version_id: 1QTPLDD
+        url: https://semgrep.dev/playground/r/1QTPLDD/php.lang.security.tainted-exec.tainted-exec
         origin: community
   languages:
   - php
@@ -22968,10 +22968,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21674
-        rv_id: 110063
+        rv_id: 834285
         rule_id: zdUln0
-        version_id: e1T01OG
-        url: https://semgrep.dev/playground/r/e1T01OG/php.laravel.security.laravel-api-route-sql-injection.laravel-api-route-sql-injection
+        version_id: NdTB213
+        url: https://semgrep.dev/playground/r/NdTB213/php.laravel.security.laravel-api-route-sql-injection.laravel-api-route-sql-injection
         origin: community
 - id: php.laravel.security.laravel-sql-injection.laravel-sql-injection
   metadata:
@@ -23001,10 +23001,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16830
-        rv_id: 110071
+        rv_id: 834293
         rule_id: j2UQdp
-        version_id: 8KTQ9ZJ
-        url: https://semgrep.dev/playground/r/8KTQ9ZJ/php.laravel.security.laravel-sql-injection.laravel-sql-injection
+        version_id: ZRTlPwl
+        url: https://semgrep.dev/playground/r/ZRTlPwl/php.laravel.security.laravel-sql-injection.laravel-sql-injection
         origin: community
   severity: WARNING
   message: Detected a SQL query based on user input. This could lead to SQL injection,
@@ -23192,10 +23192,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21677
-        rv_id: 110072
+        rv_id: 834294
         rule_id: X5ULgE
-        version_id: gET3xDz
-        url: https://semgrep.dev/playground/r/gET3xDz/php.laravel.security.laravel-unsafe-validator.laravel-unsafe-validator
+        version_id: nWTy47n
+        url: https://semgrep.dev/playground/r/nWTy47n/php.laravel.security.laravel-unsafe-validator.laravel-unsafe-validator
         origin: community
 - id: problem-based-packs.insecure-transport.go-stdlib.bypass-tls-verification.bypass-tls-verification
   message: Checks for disabling of TLS/SSL certificate verification. This should only
@@ -23223,10 +23223,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9400
-        rv_id: 110087
+        rv_id: 834309
         rule_id: DbUpjg
-        version_id: qkT2xyl
-        url: https://semgrep.dev/playground/r/qkT2xyl/problem-based-packs.insecure-transport.go-stdlib.bypass-tls-verification.bypass-tls-verification
+        version_id: BjTe0EO
+        url: https://semgrep.dev/playground/r/BjTe0EO/problem-based-packs.insecure-transport.go-stdlib.bypass-tls-verification.bypass-tls-verification
         origin: community
   languages:
   - go
@@ -23265,10 +23265,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9401
-        rv_id: 110088
+        rv_id: 834310
         rule_id: WAUow9
-        version_id: l4T4vjQ
-        url: https://semgrep.dev/playground/r/l4T4vjQ/problem-based-packs.insecure-transport.go-stdlib.disallow-old-tls-versions.disallow-old-tls-versions
+        version_id: DkTG0QZ
+        url: https://semgrep.dev/playground/r/DkTG0QZ/problem-based-packs.insecure-transport.go-stdlib.disallow-old-tls-versions.disallow-old-tls-versions
         origin: community
   languages:
   - go
@@ -23312,10 +23312,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9402
-        rv_id: 110089
+        rv_id: 834311
         rule_id: 0oU5XN
-        version_id: YDTp2yp
-        url: https://semgrep.dev/playground/r/YDTp2yp/problem-based-packs.insecure-transport.go-stdlib.ftp-request.ftp-request
+        version_id: WrTdpbX
+        url: https://semgrep.dev/playground/r/WrTdpbX/problem-based-packs.insecure-transport.go-stdlib.ftp-request.ftp-request
         origin: community
   languages:
   - go
@@ -23372,10 +23372,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9403
-        rv_id: 110090
+        rv_id: 834312
         rule_id: KxUbXx
-        version_id: JdTNpW5
-        url: https://semgrep.dev/playground/r/JdTNpW5/problem-based-packs.insecure-transport.go-stdlib.gorequest-http-request.gorequest-http-request
+        version_id: 0bTwbvD
+        url: https://semgrep.dev/playground/r/0bTwbvD/problem-based-packs.insecure-transport.go-stdlib.gorequest-http-request.gorequest-http-request
         origin: community
   languages:
   - go
@@ -23424,10 +23424,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9404
-        rv_id: 110091
+        rv_id: 834313
         rule_id: qNUjy3
-        version_id: 5PTdAwP
-        url: https://semgrep.dev/playground/r/5PTdAwP/problem-based-packs.insecure-transport.go-stdlib.grequests-http-request.grequests-http-request
+        version_id: K3Trqle
+        url: https://semgrep.dev/playground/r/K3Trqle/problem-based-packs.insecure-transport.go-stdlib.grequests-http-request.grequests-http-request
         origin: community
   languages:
   - go
@@ -23469,10 +23469,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9405
-        rv_id: 110092
+        rv_id: 834314
         rule_id: lBU90n
-        version_id: GxTv6A7
-        url: https://semgrep.dev/playground/r/GxTv6A7/problem-based-packs.insecure-transport.go-stdlib.http-customized-request.http-customized-request
+        version_id: qkTQnN6
+        url: https://semgrep.dev/playground/r/qkTQnN6/problem-based-packs.insecure-transport.go-stdlib.http-customized-request.http-customized-request
         origin: community
   languages:
   - go
@@ -23510,10 +23510,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9406
-        rv_id: 110093
+        rv_id: 834315
         rule_id: YGUR70
-        version_id: RGTDkzP
-        url: https://semgrep.dev/playground/r/RGTDkzP/problem-based-packs.insecure-transport.go-stdlib.http-request.http-request
+        version_id: l4TyO5E
+        url: https://semgrep.dev/playground/r/l4TyO5E/problem-based-packs.insecure-transport.go-stdlib.http-request.http-request
         origin: community
   languages:
   - go
@@ -23568,10 +23568,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9407
-        rv_id: 110094
+        rv_id: 834316
         rule_id: 6JUjoX
-        version_id: A8T954G
-        url: https://semgrep.dev/playground/r/A8T954G/problem-based-packs.insecure-transport.go-stdlib.sling-http-request.sling-http-request
+        version_id: YDTl0od
+        url: https://semgrep.dev/playground/r/YDTl0od/problem-based-packs.insecure-transport.go-stdlib.sling-http-request.sling-http-request
         origin: community
   languages:
   - go
@@ -23640,10 +23640,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9408
-        rv_id: 110095
+        rv_id: 834317
         rule_id: oqUewD
-        version_id: BjTXrPd
-        url: https://semgrep.dev/playground/r/BjTXrPd/problem-based-packs.insecure-transport.go-stdlib.telnet-request.telnet-request
+        version_id: 6xTDgeP
+        url: https://semgrep.dev/playground/r/6xTDgeP/problem-based-packs.insecure-transport.go-stdlib.telnet-request.telnet-request
         origin: community
   languages:
   - go
@@ -23679,10 +23679,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9409
-        rv_id: 110096
+        rv_id: 834318
         rule_id: zdUkZZ
-        version_id: DkT6n5x
-        url: https://semgrep.dev/playground/r/DkT6n5x/problem-based-packs.insecure-transport.java-spring.bypass-tls-verification.bypass-tls-verification
+        version_id: o5TBEnE
+        url: https://semgrep.dev/playground/r/o5TBEnE/problem-based-packs.insecure-transport.java-spring.bypass-tls-verification.bypass-tls-verification
         origin: community
   languages:
   - java
@@ -23736,10 +23736,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9410
-        rv_id: 110097
+        rv_id: 834319
         rule_id: pKUOYW
-        version_id: WrTWQ1d
-        url: https://semgrep.dev/playground/r/WrTWQ1d/problem-based-packs.insecure-transport.java-spring.spring-ftp-request.spring-ftp-request
+        version_id: zyTWJ53
+        url: https://semgrep.dev/playground/r/zyTWJ53/problem-based-packs.insecure-transport.java-spring.spring-ftp-request.spring-ftp-request
         origin: community
   languages:
   - java
@@ -23790,10 +23790,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9411
-        rv_id: 110098
+        rv_id: 834320
         rule_id: 2ZUbjg
-        version_id: 0bTLldp
-        url: https://semgrep.dev/playground/r/0bTLldp/problem-based-packs.insecure-transport.java-spring.spring-http-request.spring-http-request
+        version_id: pZTXjr3
+        url: https://semgrep.dev/playground/r/pZTXjr3/problem-based-packs.insecure-transport.java-spring.spring-http-request.spring-http-request
         origin: community
   languages:
   - java
@@ -23850,10 +23850,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9412
-        rv_id: 110099
+        rv_id: 834321
         rule_id: X5U8qv
-        version_id: K3Tvj0J
-        url: https://semgrep.dev/playground/r/K3Tvj0J/problem-based-packs.insecure-transport.java-stdlib.bypass-tls-verification.bypass-tls-verification
+        version_id: 2KT7x1j
+        url: https://semgrep.dev/playground/r/2KT7x1j/problem-based-packs.insecure-transport.java-stdlib.bypass-tls-verification.bypass-tls-verification
         origin: community
   languages:
   - java
@@ -23912,10 +23912,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9413
-        rv_id: 250960
+        rv_id: 834322
         rule_id: j2Uv2K
-        version_id: d6TqD0o
-        url: https://semgrep.dev/playground/r/d6TqD0o/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions1.disallow-old-tls-versions1
+        version_id: X0T5NP9
+        url: https://semgrep.dev/playground/r/X0T5NP9/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions1.disallow-old-tls-versions1
         origin: community
   languages:
   - java
@@ -23971,10 +23971,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9414
-        rv_id: 110101
+        rv_id: 834323
         rule_id: 10UKvx
-        version_id: l4T4vj6
-        url: https://semgrep.dev/playground/r/l4T4vj6/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions2.disallow-old-tls-versions2
+        version_id: jQTrXKb
+        url: https://semgrep.dev/playground/r/jQTrXKb/problem-based-packs.insecure-transport.java-stdlib.disallow-old-tls-versions2.disallow-old-tls-versions2
         origin: community
   languages:
   - java
@@ -24015,10 +24015,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9415
-        rv_id: 110102
+        rv_id: 834324
         rule_id: 9AU1wD
-        version_id: YDTp2yZ
-        url: https://semgrep.dev/playground/r/YDTp2yZ/problem-based-packs.insecure-transport.java-stdlib.ftp-request.ftp-request
+        version_id: 1QTPLjD
+        url: https://semgrep.dev/playground/r/1QTPLjD/problem-based-packs.insecure-transport.java-stdlib.ftp-request.ftp-request
         origin: community
   languages:
   - java
@@ -24062,10 +24062,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9416
-        rv_id: 110103
+        rv_id: 834325
         rule_id: yyUnjk
-        version_id: 6xTvJY8
-        url: https://semgrep.dev/playground/r/6xTvJY8/problem-based-packs.insecure-transport.java-stdlib.http-components-request.http-components-request
+        version_id: 9lTJ0zz
+        url: https://semgrep.dev/playground/r/9lTJ0zz/problem-based-packs.insecure-transport.java-stdlib.http-components-request.http-components-request
         origin: community
   languages:
   - java
@@ -24111,10 +24111,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9417
-        rv_id: 110104
+        rv_id: 834326
         rule_id: r6Ur3y
-        version_id: o5TglNL
-        url: https://semgrep.dev/playground/r/o5TglNL/problem-based-packs.insecure-transport.java-stdlib.httpclient-http-request.httpclient-http-request
+        version_id: yeTN1XL
+        url: https://semgrep.dev/playground/r/yeTN1XL/problem-based-packs.insecure-transport.java-stdlib.httpclient-http-request.httpclient-http-request
         origin: community
   languages:
   - java
@@ -24195,10 +24195,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48942
-        rv_id: 110105
+        rv_id: 834327
         rule_id: 6JUOJ2
-        version_id: zyTK84N
-        url: https://semgrep.dev/playground/r/zyTK84N/problem-based-packs.insecure-transport.java-stdlib.httpget-http-request.httpget-http-request
+        version_id: rxTDzxP
+        url: https://semgrep.dev/playground/r/rxTDzxP/problem-based-packs.insecure-transport.java-stdlib.httpget-http-request.httpget-http-request
         origin: community
   languages:
   - java
@@ -24242,10 +24242,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9418
-        rv_id: 110106
+        rv_id: 834328
         rule_id: bwUwvR
-        version_id: pZT1yWA
-        url: https://semgrep.dev/playground/r/pZT1yWA/problem-based-packs.insecure-transport.java-stdlib.httpurlconnection-http-request.httpurlconnection-http-request
+        version_id: bZTBekA
+        url: https://semgrep.dev/playground/r/bZTBekA/problem-based-packs.insecure-transport.java-stdlib.httpurlconnection-http-request.httpurlconnection-http-request
         origin: community
   languages:
   - java
@@ -24296,10 +24296,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9420
-        rv_id: 110108
+        rv_id: 834330
         rule_id: kxUkXk
-        version_id: X0TQx9J
-        url: https://semgrep.dev/playground/r/X0TQx9J/problem-based-packs.insecure-transport.java-stdlib.telnet-request.telnet-request
+        version_id: kbT2lAg
+        url: https://semgrep.dev/playground/r/kbT2lAg/problem-based-packs.insecure-transport.java-stdlib.telnet-request.telnet-request
         origin: community
   languages:
   - java
@@ -24334,10 +24334,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9421
-        rv_id: 110109
+        rv_id: 834331
         rule_id: wdUJw8
-        version_id: jQTgYxL
-        url: https://semgrep.dev/playground/r/jQTgYxL/problem-based-packs.insecure-transport.java-stdlib.tls-renegotiation.tls-renegotiation
+        version_id: w8TAx2z
+        url: https://semgrep.dev/playground/r/w8TAx2z/problem-based-packs.insecure-transport.java-stdlib.tls-renegotiation.tls-renegotiation
         origin: community
   languages:
   - java
@@ -24372,10 +24372,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9422
-        rv_id: 110110
+        rv_id: 834332
         rule_id: x8Uno2
-        version_id: 1QTOYln
-        url: https://semgrep.dev/playground/r/1QTOYln/problem-based-packs.insecure-transport.java-stdlib.unirest-http-request.unirest-http-request
+        version_id: xyTNeBn
+        url: https://semgrep.dev/playground/r/xyTNeBn/problem-based-packs.insecure-transport.java-stdlib.unirest-http-request.unirest-http-request
         origin: community
   languages:
   - java
@@ -24420,10 +24420,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9423
-        rv_id: 110111
+        rv_id: 834333
         rule_id: OrU3Y6
-        version_id: 9lTdWB8
-        url: https://semgrep.dev/playground/r/9lTdWB8/problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
+        version_id: O9TJW0G
+        url: https://semgrep.dev/playground/r/O9TJW0G/problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
         origin: community
   languages:
   - javascript
@@ -24462,10 +24462,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9424
-        rv_id: 110112
+        rv_id: 834334
         rule_id: eqU8nr
-        version_id: yeTR2jb
-        url: https://semgrep.dev/playground/r/yeTR2jb/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions1.disallow-old-tls-versions1
+        version_id: e1TDkdp
+        url: https://semgrep.dev/playground/r/e1TDkdp/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions1.disallow-old-tls-versions1
         origin: community
   languages:
   - javascript
@@ -24523,10 +24523,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9425
-        rv_id: 110113
+        rv_id: 834335
         rule_id: v8UnPO
-        version_id: rxTyL3R
-        url: https://semgrep.dev/playground/r/rxTyL3R/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions2.disallow-old-tls-versions2
+        version_id: vdTOzk9
+        url: https://semgrep.dev/playground/r/vdTOzk9/problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions2.disallow-old-tls-versions2
         origin: community
   languages:
   - javascript
@@ -24599,10 +24599,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9426
-        rv_id: 110114
+        rv_id: 834336
         rule_id: d8UjZ6
-        version_id: bZTb1vg
-        url: https://semgrep.dev/playground/r/bZTb1vg/problem-based-packs.insecure-transport.js-node.ftp-request.ftp-request
+        version_id: d6TKGR4
+        url: https://semgrep.dev/playground/r/d6TKGR4/problem-based-packs.insecure-transport.js-node.ftp-request.ftp-request
         origin: community
   languages:
   - javascript
@@ -24645,10 +24645,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9427
-        rv_id: 110115
+        rv_id: 834337
         rule_id: ZqU5r3
-        version_id: NdT3dlK
-        url: https://semgrep.dev/playground/r/NdT3dlK/problem-based-packs.insecure-transport.js-node.http-request.http-request
+        version_id: ZRTlPEl
+        url: https://semgrep.dev/playground/r/ZRTlPEl/problem-based-packs.insecure-transport.js-node.http-request.http-request
         origin: community
   languages:
   - javascript
@@ -24709,10 +24709,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9428
-        rv_id: 110116
+        rv_id: 834338
         rule_id: nJUzKP
-        version_id: kbTdxXE
-        url: https://semgrep.dev/playground/r/kbTdxXE/problem-based-packs.insecure-transport.js-node.rest-http-client-support.rest-http-client-support
+        version_id: nWTy4en
+        url: https://semgrep.dev/playground/r/nWTy4en/problem-based-packs.insecure-transport.js-node.rest-http-client-support.rest-http-client-support
         origin: community
   languages:
   - javascript
@@ -24770,10 +24770,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9429
-        rv_id: 110117
+        rv_id: 834339
         rule_id: EwU2GA
-        version_id: w8T9nwr
-        url: https://semgrep.dev/playground/r/w8T9nwr/problem-based-packs.insecure-transport.js-node.telnet-request.telnet-request
+        version_id: ExTrDkg
+        url: https://semgrep.dev/playground/r/ExTrDkg/problem-based-packs.insecure-transport.js-node.telnet-request.telnet-request
         origin: community
   languages:
   - javascript
@@ -24819,10 +24819,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9431
-        rv_id: 110119
+        rv_id: 834341
         rule_id: L1UyKG
-        version_id: O9TNOY1
-        url: https://semgrep.dev/playground/r/O9TNOY1/problem-based-packs.insecure-transport.ruby-stdlib.http-client-requests.http-client-requests
+        version_id: LjTEbYA
+        url: https://semgrep.dev/playground/r/LjTEbYA/problem-based-packs.insecure-transport.ruby-stdlib.http-client-requests.http-client-requests
         origin: community
   languages:
   - ruby
@@ -24867,10 +24867,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9432
-        rv_id: 110120
+        rv_id: 834342
         rule_id: 8GUj13
-        version_id: e1T01nJ
-        url: https://semgrep.dev/playground/r/e1T01nJ/problem-based-packs.insecure-transport.ruby-stdlib.net-ftp-request.net-ftp-request
+        version_id: 8KTGk25
+        url: https://semgrep.dev/playground/r/8KTGk25/problem-based-packs.insecure-transport.ruby-stdlib.net-ftp-request.net-ftp-request
         origin: community
   languages:
   - ruby
@@ -24911,10 +24911,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9433
-        rv_id: 110121
+        rv_id: 834343
         rule_id: gxU1lE
-        version_id: vdTYNP7
-        url: https://semgrep.dev/playground/r/vdTYNP7/problem-based-packs.insecure-transport.ruby-stdlib.net-http-request.net-http-request
+        version_id: gETy24P
+        url: https://semgrep.dev/playground/r/gETy24P/problem-based-packs.insecure-transport.ruby-stdlib.net-http-request.net-http-request
         origin: community
   languages:
   - ruby
@@ -24962,10 +24962,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9434
-        rv_id: 110122
+        rv_id: 834344
         rule_id: QrUzo2
-        version_id: d6TrAZG
-        url: https://semgrep.dev/playground/r/d6TrAZG/problem-based-packs.insecure-transport.ruby-stdlib.net-telnet-request.net-telnet-request
+        version_id: QkTkryE
+        url: https://semgrep.dev/playground/r/QkTkryE/problem-based-packs.insecure-transport.ruby-stdlib.net-telnet-request.net-telnet-request
         origin: community
   languages:
   - ruby
@@ -25001,10 +25001,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9435
-        rv_id: 110123
+        rv_id: 834345
         rule_id: 3qUPNe
-        version_id: ZRTQNrd
-        url: https://semgrep.dev/playground/r/ZRTQNrd/problem-based-packs.insecure-transport.ruby-stdlib.openuri-request.openuri-request
+        version_id: 3ZT3AJW
+        url: https://semgrep.dev/playground/r/3ZT3AJW/problem-based-packs.insecure-transport.ruby-stdlib.openuri-request.openuri-request
         origin: community
   languages:
   - ruby
@@ -25084,10 +25084,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18260
-        rv_id: 110126
+        rv_id: 834348
         rule_id: EwUrX8
-        version_id: 7ZTgoAA
-        url: https://semgrep.dev/playground/r/7ZTgoAA/python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
+        version_id: JdTlrgZ
+        url: https://semgrep.dev/playground/r/JdTlrgZ/python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
         origin: community
   languages:
   - python
@@ -25148,10 +25148,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18261
-        rv_id: 110127
+        rv_id: 834349
         rule_id: 7KUxXg
-        version_id: LjTqQKw
-        url: https://semgrep.dev/playground/r/LjTqQKw/python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
+        version_id: 5PTyD5B
+        url: https://semgrep.dev/playground/r/5PTyD5B/python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
         origin: community
   languages:
   - python
@@ -25209,10 +25209,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18262
-        rv_id: 110128
+        rv_id: 834350
         rule_id: L1UEl7
-        version_id: 8KTQ91d
-        url: https://semgrep.dev/playground/r/8KTQ91d/python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
+        version_id: GxTDEwg
+        url: https://semgrep.dev/playground/r/GxTDEwg/python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
         origin: community
   languages:
   - python
@@ -25256,10 +25256,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18263
-        rv_id: 110129
+        rv_id: 834351
         rule_id: 8GUGBq
-        version_id: gET3xlq
-        url: https://semgrep.dev/playground/r/gET3xlq/python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
+        version_id: RGTKGvN
+        url: https://semgrep.dev/playground/r/RGTKGvN/python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
         origin: community
   languages:
   - python
@@ -25337,10 +25337,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18264
-        rv_id: 110130
+        rv_id: 834352
         rule_id: gxUyn1
-        version_id: QkTW0oy
-        url: https://semgrep.dev/playground/r/QkTW0oy/python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
+        version_id: A8T37YP
+        url: https://semgrep.dev/playground/r/A8T37YP/python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
         origin: community
   languages:
   - python
@@ -25397,10 +25397,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18265
-        rv_id: 110131
+        rv_id: 834353
         rule_id: QrUkg6
-        version_id: 3ZTkQN9
-        url: https://semgrep.dev/playground/r/3ZTkQN9/python.aws-lambda.security.dangerous-system-call.dangerous-system-call
+        version_id: BjTe0YO
+        url: https://semgrep.dev/playground/r/BjTe0YO/python.aws-lambda.security.dangerous-system-call.dangerous-system-call
         origin: community
   languages:
   - python
@@ -25448,10 +25448,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21321
-        rv_id: 110132
+        rv_id: 834354
         rule_id: KxUJ2B
-        version_id: 44TRlny
-        url: https://semgrep.dev/playground/r/44TRlny/python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
+        version_id: DkTG08Z
+        url: https://semgrep.dev/playground/r/DkTG08Z/python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
         origin: community
   message: Detected DynamoDB query filter that is tainted by `$EVENT` object. This
     could lead to NoSQL injection if the variable is user-controlled and not properly
@@ -25524,10 +25524,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18266
-        rv_id: 110133
+        rv_id: 834355
         rule_id: 3qU3eE
-        version_id: PkTJ1gJ
-        url: https://semgrep.dev/playground/r/PkTJ1gJ/python.aws-lambda.security.mysql-sqli.mysql-sqli
+        version_id: WrTdpxX
+        url: https://semgrep.dev/playground/r/WrTdpxX/python.aws-lambda.security.mysql-sqli.mysql-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -25589,10 +25589,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18267
-        rv_id: 110134
+        rv_id: 834356
         rule_id: 4bUQG1
-        version_id: JdTNpd5
-        url: https://semgrep.dev/playground/r/JdTNpd5/python.aws-lambda.security.psycopg-sqli.psycopg-sqli
+        version_id: 0bTwbOD
+        url: https://semgrep.dev/playground/r/0bTwbOD/python.aws-lambda.security.psycopg-sqli.psycopg-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -25648,10 +25648,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18268
-        rv_id: 110135
+        rv_id: 834357
         rule_id: PeUxO0
-        version_id: 5PTdAXP
-        url: https://semgrep.dev/playground/r/5PTdAXP/python.aws-lambda.security.pymssql-sqli.pymssql-sqli
+        version_id: K3Trqye
+        url: https://semgrep.dev/playground/r/K3Trqye/python.aws-lambda.security.pymssql-sqli.pymssql-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -25704,10 +25704,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18269
-        rv_id: 110136
+        rv_id: 834358
         rule_id: JDUlel
-        version_id: GxTv6Q7
-        url: https://semgrep.dev/playground/r/GxTv6Q7/python.aws-lambda.security.pymysql-sqli.pymysql-sqli
+        version_id: qkTQnq6
+        url: https://semgrep.dev/playground/r/qkTQnq6/python.aws-lambda.security.pymysql-sqli.pymysql-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -25764,10 +25764,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18270
-        rv_id: 110137
+        rv_id: 834359
         rule_id: 5rUy3N
-        version_id: RGTDk5P
-        url: https://semgrep.dev/playground/r/RGTDk5P/python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
+        version_id: l4TyOPE
+        url: https://semgrep.dev/playground/r/l4TyOPE/python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -25829,10 +25829,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18271
-        rv_id: 110138
+        rv_id: 834360
         rule_id: GdUDJP
-        version_id: A8T95AG
-        url: https://semgrep.dev/playground/r/A8T95AG/python.aws-lambda.security.tainted-code-exec.tainted-code-exec
+        version_id: YDTl0Pd
+        url: https://semgrep.dev/playground/r/YDTl0Pd/python.aws-lambda.security.tainted-code-exec.tainted-code-exec
         origin: community
   languages:
   - python
@@ -25883,10 +25883,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18272
-        rv_id: 110139
+        rv_id: 834361
         rule_id: ReUKrk
-        version_id: BjTXrwd
-        url: https://semgrep.dev/playground/r/BjTXrwd/python.aws-lambda.security.tainted-html-response.tainted-html-response
+        version_id: JdTlrg9
+        url: https://semgrep.dev/playground/r/JdTlrg9/python.aws-lambda.security.tainted-html-response.tainted-html-response
         origin: community
   languages:
   - python
@@ -25927,10 +25927,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18484
-        rv_id: 110140
+        rv_id: 834362
         rule_id: JDUlwy
-        version_id: DkT6nDx
-        url: https://semgrep.dev/playground/r/DkT6nDx/python.aws-lambda.security.tainted-html-string.tainted-html-string
+        version_id: 5PTyD5D
+        url: https://semgrep.dev/playground/r/5PTyD5D/python.aws-lambda.security.tainted-html-string.tainted-html-string
         origin: community
   mode: taint
   pattern-sources:
@@ -26016,10 +26016,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21602
-        rv_id: 110141
+        rv_id: 834363
         rule_id: JDUDQg
-        version_id: WrTWQvd
-        url: https://semgrep.dev/playground/r/WrTWQvd/python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
+        version_id: GxTDEwX
+        url: https://semgrep.dev/playground/r/GxTDEwX/python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
         origin: community
   languages:
   - python
@@ -26060,10 +26060,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18273
-        rv_id: 110142
+        rv_id: 834364
         rule_id: AbU3LX
-        version_id: 0bTLlAp
-        url: https://semgrep.dev/playground/r/0bTLlAp/python.aws-lambda.security.tainted-sql-string.tainted-sql-string
+        version_id: RGTKGvL
+        url: https://semgrep.dev/playground/r/RGTKGvL/python.aws-lambda.security.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sinks:
@@ -26128,10 +26128,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9439
-        rv_id: 110144
+        rv_id: 834366
         rule_id: 5rUOwK
-        version_id: qkT2xkx
-        url: https://semgrep.dev/playground/r/qkT2xkx/python.boto3.security.hardcoded-token.hardcoded-token
+        version_id: BjTe0YP
+        url: https://semgrep.dev/playground/r/BjTe0YP/python.boto3.security.hardcoded-token.hardcoded-token
         origin: community
   languages:
   - python
@@ -26197,10 +26197,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44817
-        rv_id: 251683
+        rv_id: 834370
         rule_id: OrUADK
-        version_id: A8TkYjr
-        url: https://semgrep.dev/playground/r/A8TkYjr/python.cryptography.security.empty-aes-key.empty-aes-key
+        version_id: K3Trqyy
+        url: https://semgrep.dev/playground/r/K3Trqyy/python.cryptography.security.empty-aes-key.empty-aes-key
         origin: community
 - id: python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
   message: ARC4 (Alleged RC4) is a stream cipher with serious weaknesses in its initial
@@ -26237,10 +26237,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33630
-        rv_id: 252912
+        rv_id: 834371
         rule_id: KxU8gK
-        version_id: 0bTyODx
-        url: https://semgrep.dev/playground/r/0bTyODx/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
+        version_id: qkTQnql
+        url: https://semgrep.dev/playground/r/qkTQnql/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
         origin: community
   severity: WARNING
   languages:
@@ -26289,10 +26289,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33631
-        rv_id: 252913
+        rv_id: 834372
         rule_id: qNULvO
-        version_id: K3TnyZv
-        url: https://semgrep.dev/playground/r/K3TnyZv/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
+        version_id: l4TyOBQ
+        url: https://semgrep.dev/playground/r/l4TyOBQ/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
         origin: community
   severity: WARNING
   languages:
@@ -26342,10 +26342,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9443
-        rv_id: 252914
+        rv_id: 834373
         rule_id: BYUNPg
-        version_id: qkT5qE5
-        url: https://semgrep.dev/playground/r/qkT5qE5/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
+        version_id: YDTl0Xp
+        url: https://semgrep.dev/playground/r/YDTl0Xp/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
         origin: community
   severity: WARNING
   languages:
@@ -26393,10 +26393,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33632
-        rv_id: 252916
+        rv_id: 834375
         rule_id: lBUopp
-        version_id: YDTNPBR
-        url: https://semgrep.dev/playground/r/YDTNPBR/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+        version_id: o5TBEYy
+        url: https://semgrep.dev/playground/r/o5TBEYy/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
         origin: community
   severity: WARNING
   languages:
@@ -26455,10 +26455,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9446
-        rv_id: 251689
+        rv_id: 834376
         rule_id: 0oU5dN
-        version_id: qkT5qYQ
-        url: https://semgrep.dev/playground/r/qkT5qYQ/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+        version_id: zyTWJPk
+        url: https://semgrep.dev/playground/r/zyTWJPk/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
         origin: community
   severity: WARNING
   languages:
@@ -26508,10 +26508,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9447
-        rv_id: 252917
+        rv_id: 834377
         rule_id: KxUb0x
-        version_id: 6xTZKrq
-        url: https://semgrep.dev/playground/r/6xTZKrq/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+        version_id: pZTXj9G
+        url: https://semgrep.dev/playground/r/pZTXj9G/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
         origin: community
   languages:
   - python
@@ -26557,10 +26557,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9450
-        rv_id: 110159
+        rv_id: 834381
         rule_id: YGURy0
-        version_id: NdT3d8K
-        url: https://semgrep.dev/playground/r/NdT3d8K/python.distributed.security.require-encryption
+        version_id: 1QTPLgP
+        url: https://semgrep.dev/playground/r/1QTPLgP/python.distributed.security.require-encryption
         origin: community
   languages:
   - python
@@ -26591,10 +26591,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9467
-        rv_id: 110180
+        rv_id: 834402
         rule_id: OrU3e6
-        version_id: GxTv6G7
-        url: https://semgrep.dev/playground/r/GxTv6G7/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
+        version_id: 3ZT3A9q
+        url: https://semgrep.dev/playground/r/3ZT3A9q/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
         origin: community
   message: Avoid using insecure deserialization library, backed by `pickle`, `_pickle`,
     `cpickle`, `dill`, `shelve`, or `yaml`, which are known to lead to remote code
@@ -26679,10 +26679,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9469
-        rv_id: 110182
+        rv_id: 834404
         rule_id: v8UnqO
-        version_id: A8T956G
-        url: https://semgrep.dev/playground/r/A8T956G/python.django.security.audit.csrf-exempt.no-csrf-exempt
+        version_id: PkTxrAN
+        url: https://semgrep.dev/playground/r/PkTxrAN/python.django.security.audit.csrf-exempt.no-csrf-exempt
         origin: community
   languages:
   - python
@@ -26718,10 +26718,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72426
-        rv_id: 110208
+        rv_id: 834430
         rule_id: 0oUXqy
-        version_id: 2KTzrD9
-        url: https://semgrep.dev/playground/r/2KTzrD9/python.django.security.hashids-with-django-secret.hashids-with-django-secret
+        version_id: NdTBRDz
+        url: https://semgrep.dev/playground/r/NdTBRDz/python.django.security.hashids-with-django-secret.hashids-with-django-secret
         origin: community
   pattern-either:
   - pattern: hashids.Hashids(..., salt=django.conf.settings.SECRET_KEY, ...)
@@ -26755,10 +26755,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9500
-        rv_id: 110210
+        rv_id: 834432
         rule_id: BYUNw9
-        version_id: jQTgYEX
-        url: https://semgrep.dev/playground/r/jQTgYEX/python.django.security.injection.code.user-eval-format-string.user-eval-format-string
+        version_id: w8TAb1W
+        url: https://semgrep.dev/playground/r/w8TAb1W/python.django.security.injection.code.user-eval-format-string.user-eval-format-string
         origin: community
   patterns:
   - pattern-inside: |
@@ -26894,10 +26894,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9501
-        rv_id: 110211
+        rv_id: 834433
         rule_id: DbUpDQ
-        version_id: 1QTOYDN
-        url: https://semgrep.dev/playground/r/1QTOYDN/python.django.security.injection.code.user-eval.user-eval
+        version_id: xyTNrL0
+        url: https://semgrep.dev/playground/r/xyTNrL0/python.django.security.injection.code.user-eval.user-eval
         origin: community
   patterns:
   - pattern-inside: |
@@ -26951,10 +26951,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9502
-        rv_id: 110212
+        rv_id: 834434
         rule_id: WAUovx
-        version_id: 9lTdWjb
-        url: https://semgrep.dev/playground/r/9lTdWjb/python.django.security.injection.code.user-exec-format-string.user-exec-format-string
+        version_id: O9TJ7jB
+        url: https://semgrep.dev/playground/r/O9TJ7jB/python.django.security.injection.code.user-exec-format-string.user-exec-format-string
         origin: community
   patterns:
   - pattern-inside: |
@@ -27183,10 +27183,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9503
-        rv_id: 110213
+        rv_id: 834435
         rule_id: 0oU5AW
-        version_id: yeTR26r
-        url: https://semgrep.dev/playground/r/yeTR26r/python.django.security.injection.code.user-exec.user-exec
+        version_id: e1TDKRG
+        url: https://semgrep.dev/playground/r/e1TDKRG/python.django.security.injection.code.user-exec.user-exec
         origin: community
   patterns:
   - pattern-inside: |
@@ -27263,10 +27263,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9504
-        rv_id: 110214
+        rv_id: 834436
         rule_id: KxUbp2
-        version_id: rxTyL53
-        url: https://semgrep.dev/playground/r/rxTyL53/python.django.security.injection.command.command-injection-os-system.command-injection-os-system
+        version_id: vdTOQr3
+        url: https://semgrep.dev/playground/r/vdTOQr3/python.django.security.injection.command.command-injection-os-system.command-injection-os-system
         origin: community
   languages:
   - python
@@ -27600,10 +27600,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31144
-        rv_id: 110215
+        rv_id: 834437
         rule_id: EwUepx
-        version_id: bZTb1Yq
-        url: https://semgrep.dev/playground/r/bZTb1Yq/python.django.security.injection.command.subprocess-injection.subprocess-injection
+        version_id: d6TKgwn
+        url: https://semgrep.dev/playground/r/d6TKgwn/python.django.security.injection.command.subprocess-injection.subprocess-injection
         origin: community
 - id: python.django.security.injection.csv-writer-injection.csv-writer-injection
   languages:
@@ -27642,10 +27642,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31145
-        rv_id: 110216
+        rv_id: 834438
         rule_id: 7KUK1y
-        version_id: NdT3dxx
-        url: https://semgrep.dev/playground/r/NdT3dxx/python.django.security.injection.csv-writer-injection.csv-writer-injection
+        version_id: ZRTld4J
+        url: https://semgrep.dev/playground/r/ZRTld4J/python.django.security.injection.csv-writer-injection.csv-writer-injection
         origin: community
   mode: taint
   pattern-sinks:
@@ -27700,10 +27700,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9505
-        rv_id: 110217
+        rv_id: 834439
         rule_id: qNUj02
-        version_id: kbTdxo7
-        url: https://semgrep.dev/playground/r/kbTdxo7/python.django.security.injection.email.xss-html-email-body.xss-html-email-body
+        version_id: nWTyNW5
+        url: https://semgrep.dev/playground/r/nWTyNW5/python.django.security.injection.email.xss-html-email-body.xss-html-email-body
         origin: community
   languages:
   - python
@@ -27915,10 +27915,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9506
-        rv_id: 110218
+        rv_id: 834440
         rule_id: lBU9Ll
-        version_id: w8T9ne2
-        url: https://semgrep.dev/playground/r/w8T9ne2/python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
+        version_id: ExTrW85
+        url: https://semgrep.dev/playground/r/ExTrW85/python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
         origin: community
   languages:
   - python
@@ -28174,10 +28174,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9494
-        rv_id: 110220
+        rv_id: 834442
         rule_id: PeUZgr
-        version_id: O9TNOyj
-        url: https://semgrep.dev/playground/r/O9TNOyj/python.django.security.injection.open-redirect.open-redirect
+        version_id: LjTEeNo
+        url: https://semgrep.dev/playground/r/LjTEeNo/python.django.security.injection.open-redirect.open-redirect
         origin: community
   languages:
   - python
@@ -28774,10 +28774,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9507
-        rv_id: 110221
+        rv_id: 834443
         rule_id: YGUR36
-        version_id: e1T01x0
-        url: https://semgrep.dev/playground/r/e1T01x0/python.django.security.injection.path-traversal.path-traversal-file-name.path-traversal-file-name
+        version_id: 8KTGlYJ
+        url: https://semgrep.dev/playground/r/8KTGlYJ/python.django.security.injection.path-traversal.path-traversal-file-name.path-traversal-file-name
         origin: community
   patterns:
   - pattern-inside: |
@@ -28865,10 +28865,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9509
-        rv_id: 110223
+        rv_id: 834445
         rule_id: oqUe7z
-        version_id: d6TrADQ
-        url: https://semgrep.dev/playground/r/d6TrADQ/python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
+        version_id: QkTkNvD
+        url: https://semgrep.dev/playground/r/QkTkNvD/python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
         origin: community
   languages:
   - python
@@ -29324,10 +29324,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14360
-        rv_id: 110224
+        rv_id: 834446
         rule_id: 2ZUPER
-        version_id: ZRTQNw5
-        url: https://semgrep.dev/playground/r/ZRTQNw5/python.django.security.injection.raw-html-format.raw-html-format
+        version_id: 3ZT3wYq
+        url: https://semgrep.dev/playground/r/3ZT3wYq/python.django.security.injection.raw-html-format.raw-html-format
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -29388,10 +29388,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9495
-        rv_id: 110225
+        rv_id: 834447
         rule_id: JDUydR
-        version_id: nWTxP7Y
-        url: https://semgrep.dev/playground/r/nWTxP7Y/python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
+        version_id: 44TQqyD
+        url: https://semgrep.dev/playground/r/44TQqyD/python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
         origin: community
   languages:
   - python
@@ -29666,10 +29666,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9496
-        rv_id: 110226
+        rv_id: 834448
         rule_id: 5rUOX1
-        version_id: ExTjNnQ
-        url: https://semgrep.dev/playground/r/ExTjNnQ/python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
+        version_id: PkTxG5N
+        url: https://semgrep.dev/playground/r/PkTxG5N/python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
         origin: community
   languages:
   - python
@@ -29945,10 +29945,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9497
-        rv_id: 110227
+        rv_id: 834449
         rule_id: GdU7QR
-        version_id: 7ZTgoOv
-        url: https://semgrep.dev/playground/r/7ZTgoOv/python.django.security.injection.request-data-fileresponse.request-data-fileresponse
+        version_id: JdTlR19
+        url: https://semgrep.dev/playground/r/JdTlR19/python.django.security.injection.request-data-fileresponse.request-data-fileresponse
         origin: community
   languages:
   - python
@@ -30039,10 +30039,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9498
-        rv_id: 110228
+        rv_id: 834450
         rule_id: ReUg5z
-        version_id: LjTqQ0P
-        url: https://semgrep.dev/playground/r/LjTqQ0P/python.django.security.injection.request-data-write.request-data-write
+        version_id: 5PTyGJD
+        url: https://semgrep.dev/playground/r/5PTyGJD/python.django.security.injection.request-data-write.request-data-write
         origin: community
   languages:
   - python
@@ -30252,10 +30252,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9510
-        rv_id: 110229
+        rv_id: 834451
         rule_id: zdUkx1
-        version_id: 8KTQ9bG
-        url: https://semgrep.dev/playground/r/8KTQ9bG/python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
+        version_id: GxTDXLX
+        url: https://semgrep.dev/playground/r/GxTDXLX/python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
         origin: community
   languages:
   - python
@@ -30578,10 +30578,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9511
-        rv_id: 110230
+        rv_id: 834452
         rule_id: pKUOBp
-        version_id: gET3xqk
-        url: https://semgrep.dev/playground/r/gET3xqk/python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
+        version_id: RGTKxOL
+        url: https://semgrep.dev/playground/r/RGTKxOL/python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
         origin: community
   languages:
   - python
@@ -30897,10 +30897,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9512
-        rv_id: 110231
+        rv_id: 834453
         rule_id: 2ZUbDL
-        version_id: QkTW0JZ
-        url: https://semgrep.dev/playground/r/QkTW0JZ/python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
+        version_id: A8T3lj2
+        url: https://semgrep.dev/playground/r/A8T3lj2/python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
         origin: community
   languages:
   - python
@@ -31206,10 +31206,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9513
-        rv_id: 110232
+        rv_id: 834454
         rule_id: X5U8v5
-        version_id: 3ZTkQdQ
-        url: https://semgrep.dev/playground/r/3ZTkQdQ/python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
+        version_id: BjTeLWP
+        url: https://semgrep.dev/playground/r/BjTeLWP/python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
         origin: community
   languages:
   - python
@@ -31516,10 +31516,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9514
-        rv_id: 110233
+        rv_id: 834455
         rule_id: j2UvEw
-        version_id: 44TRlo6
-        url: https://semgrep.dev/playground/r/44TRlo6/python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
+        version_id: DkTGydD
+        url: https://semgrep.dev/playground/r/DkTGydD/python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
         origin: community
   languages:
   - python
@@ -31785,10 +31785,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9515
-        rv_id: 110234
+        rv_id: 834456
         rule_id: 10UKDo
-        version_id: PkTJ1YR
-        url: https://semgrep.dev/playground/r/PkTJ1YR/python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
+        version_id: WrTdnzR
+        url: https://semgrep.dev/playground/r/WrTdnzR/python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
         origin: community
   languages:
   - python
@@ -32076,10 +32076,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18275
-        rv_id: 110238
+        rv_id: 834460
         rule_id: DbUGvk
-        version_id: RGTDkb9
-        url: https://semgrep.dev/playground/r/RGTDkb9/python.django.security.nan-injection.nan-injection
+        version_id: l4TyD4Q
+        url: https://semgrep.dev/playground/r/l4TyD4Q/python.django.security.nan-injection.nan-injection
         origin: community
 - id: python.django.security.passwords.password-empty-string.password-empty-string
   message: "'$VAR' is the empty string and is being used to set the password on '$MODEL'.
@@ -32107,10 +32107,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9516
-        rv_id: 110239
+        rv_id: 834461
         rule_id: 9AU1jW
-        version_id: A8T95RL
-        url: https://semgrep.dev/playground/r/A8T95RL/python.django.security.passwords.password-empty-string.password-empty-string
+        version_id: YDTlbpp
+        url: https://semgrep.dev/playground/r/YDTlbpp/python.django.security.passwords.password-empty-string.password-empty-string
         origin: community
   patterns:
   - pattern-either:
@@ -32157,10 +32157,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9517
-        rv_id: 250906
+        rv_id: 834462
         rule_id: yyUn6Z
-        version_id: yeT3XWe
-        url: https://semgrep.dev/playground/r/yeT3XWe/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
+        version_id: JdTlRN5
+        url: https://semgrep.dev/playground/r/JdTlRN5/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
         origin: community
   languages:
   - python
@@ -32226,10 +32226,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 112311
-        rv_id: 250907
+        rv_id: 834464
         rule_id: lBU4JQ3
-        version_id: rxT0xJG
-        url: https://semgrep.dev/playground/r/rxT0xJG/python.fastapi.security.wildcard-cors.wildcard-cors
+        version_id: GxTDXv7
+        url: https://semgrep.dev/playground/r/GxTDXv7/python.fastapi.security.wildcard-cors.wildcard-cors
         origin: community
 - id: python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
   message: Running flask app with host 0.0.0.0 could expose the server publicly.
@@ -32256,10 +32256,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9532
-        rv_id: 110248
+        rv_id: 834471
         rule_id: L1Uy1n
-        version_id: 6xTvJer
-        url: https://semgrep.dev/playground/r/6xTvJer/python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
+        version_id: K3TrLvJ
+        url: https://semgrep.dev/playground/r/K3TrLvJ/python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
         origin: community
   languages:
   - python
@@ -32301,10 +32301,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9533
-        rv_id: 110249
+        rv_id: 834472
         rule_id: 8GUjdX
-        version_id: o5Tglnv
-        url: https://semgrep.dev/playground/r/o5Tglnv/python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
+        version_id: qkTQw2x
+        url: https://semgrep.dev/playground/r/qkTQw2x/python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
         origin: community
   languages:
   - python
@@ -32340,10 +32340,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9534
-        rv_id: 110250
+        rv_id: 834473
         rule_id: gxU1bd
-        version_id: zyTK85o
-        url: https://semgrep.dev/playground/r/zyTK85o/python.flask.security.audit.debug-enabled.debug-enabled
+        version_id: l4TyD46
+        url: https://semgrep.dev/playground/r/l4TyD46/python.flask.security.audit.debug-enabled.debug-enabled
         origin: community
   severity: WARNING
   languages:
@@ -32379,10 +32379,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9535
-        rv_id: 110251
+        rv_id: 834474
         rule_id: QrUz49
-        version_id: pZT1yrE
-        url: https://semgrep.dev/playground/r/pZT1yrE/python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+        version_id: YDTlbpZ
+        url: https://semgrep.dev/playground/r/YDTlbpZ/python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
         origin: community
   languages:
   - python
@@ -32464,10 +32464,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72427
-        rv_id: 110263
+        rv_id: 834486
         rule_id: KxUX3z
-        version_id: xyTKZ4J
-        url: https://semgrep.dev/playground/r/xyTKZ4J/python.flask.security.hashids-with-flask-secret.hashids-with-flask-secret
+        version_id: bZTBobg
+        url: https://semgrep.dev/playground/r/bZTBobg/python.flask.security.hashids-with-flask-secret.hashids-with-flask-secret
         origin: community
   pattern-either:
   - pattern: hashids.Hashids(..., salt=flask.current_app.config['SECRET_KEY'], ...)
@@ -32517,10 +32517,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31146
-        rv_id: 110264
+        rv_id: 834487
         rule_id: L1UR2K
-        version_id: O9TNO0j
-        url: https://semgrep.dev/playground/r/O9TNO0j/python.flask.security.injection.csv-writer-injection.csv-writer-injection
+        version_id: NdTBR3K
+        url: https://semgrep.dev/playground/r/NdTBR3K/python.flask.security.injection.csv-writer-injection.csv-writer-injection
         origin: community
   mode: taint
   pattern-sinks:
@@ -32615,10 +32615,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18276
-        rv_id: 110265
+        rv_id: 834488
         rule_id: WAUdj7
-        version_id: e1T01d0
-        url: https://semgrep.dev/playground/r/e1T01d0/python.flask.security.injection.nan-injection.nan-injection
+        version_id: kbT2PdE
+        url: https://semgrep.dev/playground/r/kbT2PdE/python.flask.security.injection.nan-injection.nan-injection
         origin: community
 - id: python.flask.security.injection.raw-html-concat.raw-html-format
   languages:
@@ -32657,10 +32657,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14389
-        rv_id: 789459
+        rv_id: 834491
         rule_id: GdUrJv
-        version_id: PkTxQrQ
-        url: https://semgrep.dev/playground/r/PkTxQrQ/python.flask.security.injection.raw-html-concat.raw-html-format
+        version_id: O9TJ7N1
+        url: https://semgrep.dev/playground/r/O9TJ7N1/python.flask.security.injection.raw-html-concat.raw-html-format
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -32736,10 +32736,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9546
-        rv_id: 110269
+        rv_id: 834492
         rule_id: WAUoRx
-        version_id: nWTxPeY
-        url: https://semgrep.dev/playground/r/nWTxPeY/python.flask.security.injection.ssrf-requests.ssrf-requests
+        version_id: e1TDK0J
+        url: https://semgrep.dev/playground/r/e1TDK0J/python.flask.security.injection.ssrf-requests.ssrf-requests
         origin: community
   pattern-either:
   - patterns:
@@ -32881,10 +32881,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31147
-        rv_id: 110270
+        rv_id: 834493
         rule_id: 8GU3qp
-        version_id: ExTjNkQ
-        url: https://semgrep.dev/playground/r/ExTjNkQ/python.flask.security.injection.subprocess-injection.subprocess-injection
+        version_id: vdTOQY7
+        url: https://semgrep.dev/playground/r/vdTOQY7/python.flask.security.injection.subprocess-injection.subprocess-injection
         origin: community
 - id: python.flask.security.injection.tainted-sql-string.tainted-sql-string
   message: Detected user input used to manually construct a SQL string. This is usually
@@ -32920,10 +32920,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14702
-        rv_id: 110271
+        rv_id: 834494
         rule_id: YGUDKQ
-        version_id: 7ZTgo7v
-        url: https://semgrep.dev/playground/r/7ZTgo7v/python.flask.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: d6TKgrG
+        url: https://semgrep.dev/playground/r/d6TKgrG/python.flask.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   severity: ERROR
   languages:
@@ -32992,10 +32992,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14649
-        rv_id: 762649
+        rv_id: 834495
         rule_id: ReU3Wb
-        version_id: l4TW5L5
-        url: https://semgrep.dev/playground/r/l4TW5L5/python.flask.security.injection.tainted-url-host.tainted-url-host
+        version_id: ZRTldQd
+        url: https://semgrep.dev/playground/r/ZRTldQd/python.flask.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sinks:
@@ -33075,10 +33075,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9547
-        rv_id: 110273
+        rv_id: 834496
         rule_id: 0oU54W
-        version_id: 8KTQ92G
-        url: https://semgrep.dev/playground/r/8KTQ92G/python.flask.security.injection.user-eval.eval-injection
+        version_id: nWTyNxL
+        url: https://semgrep.dev/playground/r/nWTyNxL/python.flask.security.injection.user-eval.eval-injection
         origin: community
   pattern-either:
   - patterns:
@@ -33154,10 +33154,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9548
-        rv_id: 110274
+        rv_id: 834497
         rule_id: KxUbl2
-        version_id: gET3x4k
-        url: https://semgrep.dev/playground/r/gET3x4k/python.flask.security.injection.user-exec.exec-injection
+        version_id: ExTrWjw
+        url: https://semgrep.dev/playground/r/ExTrWjw/python.flask.security.injection.user-exec.exec-injection
         origin: community
   pattern-either:
   - patterns:
@@ -33242,10 +33242,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20039
-        rv_id: 110286
+        rv_id: 834509
         rule_id: QrU1Xg
-        version_id: WrTWQxg
-        url: https://semgrep.dev/playground/r/WrTWQxg/python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
+        version_id: RGTKxeP
+        url: https://semgrep.dev/playground/r/RGTKxeP/python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
         origin: community
   languages:
   - python
@@ -33286,10 +33286,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20040
-        rv_id: 110287
+        rv_id: 834510
         rule_id: 3qULRx
-        version_id: 0bTLlO0
-        url: https://semgrep.dev/playground/r/0bTLlO0/python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
+        version_id: A8T3lkG
+        url: https://semgrep.dev/playground/r/A8T3lkG/python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
         origin: community
   languages:
   - python
@@ -33324,10 +33324,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9557
-        rv_id: 110290
+        rv_id: 834513
         rule_id: X5U8P5
-        version_id: l4T4vPA
-        url: https://semgrep.dev/playground/r/l4T4vPA/python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
+        version_id: WrTdnOd
+        url: https://semgrep.dev/playground/r/WrTdnOd/python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
         origin: community
   patterns:
   - pattern: 'jwt.encode($X, $SECRET, ...)
@@ -33370,10 +33370,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9558
-        rv_id: 110291
+        rv_id: 834514
         rule_id: j2UvKw
-        version_id: YDTp2P1
-        url: https://semgrep.dev/playground/r/YDTp2P1/python.jwt.security.jwt-none-alg.jwt-python-none-alg
+        version_id: 0bTw3yp
+        url: https://semgrep.dev/playground/r/0bTw3yp/python.jwt.security.jwt-none-alg.jwt-python-none-alg
         origin: community
   languages:
   - python
@@ -33483,10 +33483,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27250
-        rv_id: 110367
+        rv_id: 834590
         rule_id: 7KUE1E
-        version_id: vdTY8rX
-        url: https://semgrep.dev/playground/r/vdTY8rX/python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
+        version_id: w8TAbz2
+        url: https://semgrep.dev/playground/r/w8TAbz2/python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
         origin: community
   languages:
   - python
@@ -33588,10 +33588,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27252
-        rv_id: 110369
+        rv_id: 834592
         rule_id: 8GU5q3
-        version_id: ZRTQp4x
-        url: https://semgrep.dev/playground/r/ZRTQp4x/python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
+        version_id: O9TJ73j
+        url: https://semgrep.dev/playground/r/O9TJ73j/python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
         origin: community
   languages:
   - python
@@ -33702,10 +33702,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27254
-        rv_id: 110371
+        rv_id: 834594
         rule_id: QrUG72
-        version_id: ExTjA8X
-        url: https://semgrep.dev/playground/r/ExTjA8X/python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
+        version_id: vdTOQn1
+        url: https://semgrep.dev/playground/r/vdTOQn1/python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
         origin: community
   severity: WARNING
   languages:
@@ -33821,10 +33821,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27256
-        rv_id: 110373
+        rv_id: 834596
         rule_id: 4bUEAY
-        version_id: LjTqANx
-        url: https://semgrep.dev/playground/r/LjTqANx/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
+        version_id: ZRTld55
+        url: https://semgrep.dev/playground/r/ZRTld55/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
         origin: community
   languages:
   - python
@@ -33942,10 +33942,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27258
-        rv_id: 110375
+        rv_id: 834598
         rule_id: JDUz34
-        version_id: gET3OZv
-        url: https://semgrep.dev/playground/r/gET3OZv/python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
+        version_id: ExTrW2Q
+        url: https://semgrep.dev/playground/r/ExTrW2Q/python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
         origin: community
   languages:
   - python
@@ -34034,10 +34034,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27260
-        rv_id: 110377
+        rv_id: 834600
         rule_id: GdUkxO
-        version_id: 3ZTkrYD
-        url: https://semgrep.dev/playground/r/3ZTkrYD/python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
+        version_id: LjTEeyP
+        url: https://semgrep.dev/playground/r/LjTEeyP/python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
         origin: community
   severity: WARNING
   languages:
@@ -34159,10 +34159,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27262
-        rv_id: 110379
+        rv_id: 834602
         rule_id: AbUgrZ
-        version_id: PkTJd5l
-        url: https://semgrep.dev/playground/r/PkTJd5l/python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+        version_id: gETyX1k
+        url: https://semgrep.dev/playground/r/gETyX1k/python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
         origin: community
   languages:
   - python
@@ -34278,10 +34278,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27264
-        rv_id: 110382
+        rv_id: 834604
         rule_id: DbUR9g
-        version_id: GxTv8LN
-        url: https://semgrep.dev/playground/r/GxTv8LN/python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
+        version_id: 3ZT3wPQ
+        url: https://semgrep.dev/playground/r/3ZT3wPQ/python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
         origin: community
   languages:
   - python
@@ -34376,10 +34376,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27266
-        rv_id: 110384
+        rv_id: 834606
         rule_id: 0oUK7N
-        version_id: A8T9Xjw
-        url: https://semgrep.dev/playground/r/A8T9Xjw/python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
+        version_id: PkTxGZR
+        url: https://semgrep.dev/playground/r/PkTxGZR/python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
         origin: community
   severity: WARNING
   languages:
@@ -34413,10 +34413,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13594
-        rv_id: 110392
+        rv_id: 834614
         rule_id: zdUYqR
-        version_id: YDTpnq3
-        url: https://semgrep.dev/playground/r/YDTpnq3/python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        version_id: WrTdnog
+        url: https://semgrep.dev/playground/r/WrTdnog/python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
         origin: community
   message: These permissions `$BITS` are widely permissive and grant access to more
     people than may be necessary. A good default is `0o644` which gives read and write
@@ -34499,10 +34499,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9668
-        rv_id: 110411
+        rv_id: 834633
         rule_id: x8UnJk
-        version_id: X0TQ2Q4
-        url: https://semgrep.dev/playground/r/X0TQ2Q4/python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+        version_id: kbT2Pk7
+        url: https://semgrep.dev/playground/r/kbT2Pk7/python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         origin: community
 - id: python.lang.security.audit.md5-used-as-password.md5-used-as-password
   severity: WARNING
@@ -34542,10 +34542,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14703
-        rv_id: 110414
+        rv_id: 834636
         rule_id: 6JU1w1
-        version_id: 9lTd5d6
-        url: https://semgrep.dev/playground/r/9lTd5d6/python.lang.security.audit.md5-used-as-password.md5-used-as-password
+        version_id: O9TJ7Gj
+        url: https://semgrep.dev/playground/r/O9TJ7Gj/python.lang.security.audit.md5-used-as-password.md5-used-as-password
         origin: community
   mode: taint
   pattern-sources:
@@ -34590,10 +34590,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9669
-        rv_id: 110415
+        rv_id: 834637
         rule_id: OrU3og
-        version_id: yeTRZR5
-        url: https://semgrep.dev/playground/r/yeTRZR5/python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
+        version_id: e1TDKv0
+        url: https://semgrep.dev/playground/r/e1TDKv0/python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
         origin: community
   languages:
   - python
@@ -34650,10 +34650,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9670
-        rv_id: 110416
+        rv_id: 834638
         rule_id: eqU87k
-        version_id: rxTy4y8
-        url: https://semgrep.dev/playground/r/rxTy4y8/python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
+        version_id: vdTOQ51
+        url: https://semgrep.dev/playground/r/vdTOQ51/python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
         origin: community
   languages:
   - python
@@ -34688,62 +34688,14 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9645
-        rv_id: 110427
+        rv_id: 834649
         rule_id: BYUN2e
-        version_id: nWTxox3
-        url: https://semgrep.dev/playground/r/nWTxox3/python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
+        version_id: 44TQqz6
+        url: https://semgrep.dev/playground/r/44TQqz6/python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
         origin: community
   languages:
   - python
   severity: WARNING
-- id: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
-  patterns:
-  - pattern: subprocess.$FUNC(..., shell=True, ...)
-  - pattern-not: subprocess.$FUNC("...", shell=True, ...)
-  message: Found 'subprocess' function '$FUNC' with 'shell=True'. This is dangerous
-    because this call will spawn the command using a shell process. Doing so propagates
-    current shell settings and variables, which makes it much easier for a malicious
-    actor to execute commands. Use 'shell=False' instead.
-  fix-regex:
-    regex: "(shell\\s*=\\s*)True"
-    replacement: "\\1False"
-  metadata:
-    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
-    owasp:
-    - A01:2017 - Injection
-    - A03:2021 - Injection
-    cwe:
-    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
-      Command Injection'')'
-    references:
-    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
-    - https://docs.python.org/3/library/subprocess.html
-    category: security
-    technology:
-    - python
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - vuln
-    likelihood: HIGH
-    impact: LOW
-    confidence: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Command Injection
-    source: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
-    shortlink: https://sg.run/J92w
-    semgrep.dev:
-      rule:
-        r_id: 9646
-        rv_id: 110428
-        rule_id: DbUpz2
-        version_id: ExTjAjz
-        url: https://semgrep.dev/playground/r/ExTjAjz/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
-        origin: community
-  languages:
-  - python
-  severity: ERROR
 - id: python.lang.security.dangerous-code-run.dangerous-interactive-code-run
   mode: taint
   options:
@@ -34902,10 +34854,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27267
-        rv_id: 110432
+        rv_id: 834654
         rule_id: KxUKzx
-        version_id: gET3O37
-        url: https://semgrep.dev/playground/r/gET3O37/python.lang.security.dangerous-code-run.dangerous-interactive-code-run
+        version_id: RGTKxP9
+        url: https://semgrep.dev/playground/r/RGTKxP9/python.lang.security.dangerous-code-run.dangerous-interactive-code-run
         origin: community
   severity: WARNING
   languages:
@@ -35073,10 +35025,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27268
-        rv_id: 110434
+        rv_id: 834656
         rule_id: qNUR13
-        version_id: 3ZTkrkN
-        url: https://semgrep.dev/playground/r/3ZTkrkN/python.lang.security.dangerous-os-exec.dangerous-os-exec
+        version_id: BjTeLBG
+        url: https://semgrep.dev/playground/r/BjTeLBG/python.lang.security.dangerous-os-exec.dangerous-os-exec
         origin: community
   languages:
   - python
@@ -35287,10 +35239,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27269
-        rv_id: 110435
+        rv_id: 834657
         rule_id: lBUJrn
-        version_id: 44TR6Rn
-        url: https://semgrep.dev/playground/r/44TR6Rn/python.lang.security.dangerous-spawn-process.dangerous-spawn-process
+        version_id: DkTGyW3
+        url: https://semgrep.dev/playground/r/DkTGyW3/python.lang.security.dangerous-spawn-process.dangerous-spawn-process
         origin: community
   languages:
   - python
@@ -35431,10 +35383,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27270
-        rv_id: 110436
+        rv_id: 834658
         rule_id: PeURWr
-        version_id: PkTJdJp
-        url: https://semgrep.dev/playground/r/PkTJdJp/python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
+        version_id: WrTdnZg
+        url: https://semgrep.dev/playground/r/WrTdnZg/python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
         origin: community
   severity: WARNING
   languages:
@@ -35608,10 +35560,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27271
-        rv_id: 110437
+        rv_id: 834659
         rule_id: JDUz3R
-        version_id: JdTNvNq
-        url: https://semgrep.dev/playground/r/JdTNvNq/python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
+        version_id: 0bTw3E0
+        url: https://semgrep.dev/playground/r/0bTw3E0/python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
         origin: community
   languages:
   - python
@@ -35782,10 +35734,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27272
-        rv_id: 110438
+        rv_id: 834660
         rule_id: 5rUoP1
-        version_id: 5PTded5
-        url: https://semgrep.dev/playground/r/5PTded5/python.lang.security.dangerous-system-call.dangerous-system-call
+        version_id: K3TrL49
+        url: https://semgrep.dev/playground/r/K3TrL49/python.lang.security.dangerous-system-call.dangerous-system-call
         origin: community
   languages:
   - python
@@ -35932,10 +35884,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 27273
-        rv_id: 110439
+        rv_id: 834661
         rule_id: GdUkxR
-        version_id: GxTv8v9
-        url: https://semgrep.dev/playground/r/GxTv8v9/python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
+        version_id: qkTQwoz
+        url: https://semgrep.dev/playground/r/qkTQwoz/python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
         origin: community
   severity: WARNING
   languages:
@@ -35981,10 +35933,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33633
-        rv_id: 110447
+        rv_id: 834669
         rule_id: PeU2e2
-        version_id: qkT2B5X
-        url: https://semgrep.dev/playground/r/qkT2B5X/python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+        version_id: BjTeLB3
+        url: https://semgrep.dev/playground/r/BjTeLB3/python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
         origin: community
   severity: WARNING
   languages:
@@ -36031,10 +35983,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9624
-        rv_id: 110448
+        rv_id: 834670
         rule_id: x8UnBk
-        version_id: l4T46lW
-        url: https://semgrep.dev/playground/r/l4T46lW/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+        version_id: DkTGyW0
+        url: https://semgrep.dev/playground/r/DkTGyW0/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
         origin: community
   severity: WARNING
   languages:
@@ -36068,10 +36020,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 72436
-        rv_id: 110452
+        rv_id: 834673
         rule_id: X5Uqnx
-        version_id: zyTKDj8
-        url: https://semgrep.dev/playground/r/zyTKDj8/python.lang.security.use-defused-xml-parse.use-defused-xml-parse
+        version_id: K3TrL4X
+        url: https://semgrep.dev/playground/r/K3TrL4X/python.lang.security.use-defused-xml-parse.use-defused-xml-parse
         origin: community
   message: The native Python `xml` library is vulnerable to XML External Entity (XXE)
     attacks.  These attacks can leak confidential data and "XML bombs" can cause denial
@@ -36086,7 +36038,10 @@ rules:
   fix: defusedxml.etree.ElementTree.parse($...ARGS)
 - id: python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
   message: Detected Blowfish cipher algorithm which is considered insecure. This algorithm
-    is not cryptographically secure and can be reversed easily. Use AES instead.
+    is not cryptographically secure and can be reversed easily. Use secure stream
+    ciphers such as ChaCha20, XChaCha20 and Salsa20, or a block cipher such as AES
+    with a block size of 128 bits. When using a block cipher, use a modern mode of
+    operation that also provides authentication, such as GCM.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
     cwe:
@@ -36097,6 +36052,7 @@ rules:
     bandit-code: B304
     references:
     - https://stackoverflow.com/questions/1135186/whats-wrong-with-xor-encryption
+    - https://www.pycryptodome.org/src/cipher/cipher
     category: security
     technology:
     - pycryptodome
@@ -36104,7 +36060,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::symmetric-algorithm::pycryptodome
+    - crypto::search::symmetric-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36113,11 +36072,13 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33634
-        rv_id: 110456
+        rv_id: 834677
         rule_id: JDUGnK
-        version_id: jQTgyl1
-        url: https://semgrep.dev/playground/r/jQTgyl1/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
+        version_id: 6xTDXqe
+        url: https://semgrep.dev/playground/r/6xTDXqe/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
@@ -36125,8 +36086,12 @@ rules:
   - pattern: Cryptodome.Cipher.Blowfish.new(...)
   - pattern: Crypto.Cipher.Blowfish.new(...)
 - id: python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
-  message: Detected DES cipher algorithm which is considered insecure. This algorithm
-    is not cryptographically secure and can be reversed easily. Use AES instead.
+  message: Detected DES cipher or Triple DES algorithm which is considered insecure.
+    This algorithm is not cryptographically secure and can be reversed easily. Use
+    a secure symmetric cipher from the cryptodome package instead. Use secure stream
+    ciphers such as ChaCha20, XChaCha20 and Salsa20, or a block cipher such as AES
+    with a block size of 128 bits. When using a block cipher, use a modern mode of
+    operation that also provides authentication, such as GCM.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
     cwe:
@@ -36137,6 +36102,7 @@ rules:
     bandit-code: B304
     references:
     - https://cwe.mitre.org/data/definitions/326.html
+    - https://www.pycryptodome.org/src/cipher/cipher
     category: security
     technology:
     - pycryptodome
@@ -36144,7 +36110,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::symmetric-algorithm::pycryptodome
+    - crypto::search::symmetric-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36153,20 +36122,27 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33635
-        rv_id: 110457
+        rv_id: 834678
         rule_id: 5rUr73
-        version_id: 1QTO7z3
-        url: https://semgrep.dev/playground/r/1QTO7z3/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
+        version_id: o5TB1zx
+        url: https://semgrep.dev/playground/r/o5TB1zx/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
   pattern-either:
   - pattern: Cryptodome.Cipher.DES.new(...)
   - pattern: Crypto.Cipher.DES.new(...)
+  - pattern: Cryptodome.Cipher.DES3.new(...)
+  - pattern: Crypto.Cipher.DES3.new(...)
 - id: python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
   message: Detected RC2 cipher algorithm which is considered insecure. This algorithm
-    is not cryptographically secure and can be reversed easily. Use AES instead.
+    is not cryptographically secure and can be reversed easily. Use secure stream
+    ciphers such as ChaCha20, XChaCha20 and Salsa20, or a block cipher such as AES
+    with a block size of 128 bits. When using a block cipher, use a modern mode of
+    operation that also provides authentication, such as GCM.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
     cwe:
@@ -36177,6 +36153,7 @@ rules:
     bandit-code: B304
     references:
     - https://cwe.mitre.org/data/definitions/326.html
+    - https://www.pycryptodome.org/src/cipher/cipher
     category: security
     technology:
     - pycryptodome
@@ -36184,7 +36161,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::symmetric-algorithm::pycryptodome
+    - crypto::search::symmetric-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36193,11 +36173,13 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33636
-        rv_id: 110458
+        rv_id: 834679
         rule_id: GdUYlW
-        version_id: 9lTd5e6
-        url: https://semgrep.dev/playground/r/9lTd5e6/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
+        version_id: zyTW3yP
+        url: https://semgrep.dev/playground/r/zyTW3yP/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
@@ -36206,7 +36188,10 @@ rules:
   - pattern: Crypto.Cipher.ARC2.new(...)
 - id: python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
   message: Detected ARC4 cipher algorithm which is considered insecure. This algorithm
-    is not cryptographically secure and can be reversed easily. Use AES instead.
+    is not cryptographically secure and can be reversed easily. Use secure stream
+    ciphers such as ChaCha20, XChaCha20 and Salsa20, or a block cipher such as AES
+    with a block size of 128 bits. When using a block cipher, use a modern mode of
+    operation that also provides authentication, such as GCM.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
     cwe:
@@ -36217,6 +36202,7 @@ rules:
     bandit-code: B304
     references:
     - https://cwe.mitre.org/data/definitions/326.html
+    - https://www.pycryptodome.org/src/cipher/cipher
     category: security
     technology:
     - pycryptodome
@@ -36224,7 +36210,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::symmetric-algorithm::pycryptodome
+    - crypto::search::symmetric-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36233,10 +36222,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33637
-        rv_id: 110459
+        rv_id: 834680
         rule_id: ReUnEB
-        version_id: yeTRZ35
-        url: https://semgrep.dev/playground/r/yeTRZ35/python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
+        version_id: pZTXDwP
+        url: https://semgrep.dev/playground/r/pZTXDwP/python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
         origin: community
   severity: WARNING
   languages:
@@ -36273,10 +36262,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9683
-        rv_id: 110460
+        rv_id: 834681
         rule_id: PeUk5W
-        version_id: rxTy408
-        url: https://semgrep.dev/playground/r/rxTy408/python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
+        version_id: 2KT7OKz
+        url: https://semgrep.dev/playground/r/2KT7OKz/python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
         origin: community
   severity: WARNING
   languages:
@@ -36286,8 +36275,8 @@ rules:
   - pattern: Crypto.Cipher.XOR.new(...)
 - id: python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
   message: Detected MD2 hash algorithm which is considered insecure. MD2 is not collision
-    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
-    or SHA3 instead.
+    resistant and is therefore not suitable as a cryptographic signature.  Use a modern
+    hash algorithm from the SHA-2, SHA-3, or BLAKE2 family instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
     cwe:
@@ -36296,6 +36285,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     references:
+    - https://www.pycryptodome.org/src/hash/hash#modern-hash-algorithms
     - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
     - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
     - http://2012.sharcs.org/slides/stevens.pdf
@@ -36307,7 +36297,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::hash-algorithm::pycryptodome
+    - crypto::search::hash-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36316,11 +36309,13 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33638
-        rv_id: 110461
+        rv_id: 834682
         rule_id: AbU0Ex
-        version_id: bZTb9Rx
-        url: https://semgrep.dev/playground/r/bZTb9Rx/python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
+        version_id: X0T5K7O
+        url: https://semgrep.dev/playground/r/X0T5K7O/python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
@@ -36329,8 +36324,8 @@ rules:
   - pattern: Cryptodome.Hash.MD2.new (...)
 - id: python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
   message: Detected MD4 hash algorithm which is considered insecure. MD4 is not collision
-    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
-    or SHA3 instead.
+    resistant and is therefore not suitable as a cryptographic signature. Use a modern
+    hash algorithm from the SHA-2, SHA-3, or BLAKE2 family instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
     cwe:
@@ -36339,6 +36334,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     references:
+    - https://www.pycryptodome.org/src/hash/hash#modern-hash-algorithms
     - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
     - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
     - http://2012.sharcs.org/slides/stevens.pdf
@@ -36350,7 +36346,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::hash-algorithm::pycryptodome
+    - crypto::search::hash-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36359,11 +36358,13 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33639
-        rv_id: 110462
+        rv_id: 834683
         rule_id: BYUJy4
-        version_id: NdT3ogE
-        url: https://semgrep.dev/playground/r/NdT3ogE/python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
+        version_id: jQTrjR6
+        url: https://semgrep.dev/playground/r/jQTrjR6/python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
@@ -36372,8 +36373,8 @@ rules:
   - pattern: Cryptodome.Hash.MD4.new (...)
 - id: python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
   message: Detected MD5 hash algorithm which is considered insecure. MD5 is not collision
-    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
-    or SHA3 instead.
+    resistant and is therefore not suitable as a cryptographic signature.  Use a modern
+    hash algorithm from the SHA-2, SHA-3, or BLAKE2 family instead.
   metadata:
     source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
     cwe:
@@ -36382,6 +36383,7 @@ rules:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
     references:
+    - https://www.pycryptodome.org/src/hash/hash#modern-hash-algorithms
     - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
     - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
     - http://2012.sharcs.org/slides/stevens.pdf
@@ -36393,7 +36395,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::hash-algorithm::pycryptodome
+    - crypto::search::hash-algorithm::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36402,11 +36407,13 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33640
-        rv_id: 110463
+        rv_id: 834684
         rule_id: DbUXwo
-        version_id: kbTdLgQ
-        url: https://semgrep.dev/playground/r/kbTdLgQ/python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
+        version_id: 1QTPNeK
+        url: https://semgrep.dev/playground/r/1QTPNeK/python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
         origin: community
+  options:
+    symbolic_propagation: true
   severity: WARNING
   languages:
   - python
@@ -36445,10 +36452,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9687
-        rv_id: 110464
+        rv_id: 834685
         rule_id: ReUPO3
-        version_id: w8T9D6g
-        url: https://semgrep.dev/playground/r/w8T9D6g/python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
+        version_id: 9lTJ7kO
+        url: https://semgrep.dev/playground/r/9lTJ7kO/python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
         origin: community
   severity: WARNING
   languages:
@@ -36457,15 +36464,6 @@ rules:
   - pattern: Crypto.Hash.SHA.new(...)
   - pattern: Cryptodome.Hash.SHA.new (...)
 - id: python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
-  patterns:
-  - pattern-either:
-    - pattern: Crypto.PublicKey.DSA.generate(..., bits=$SIZE, ...)
-    - pattern: Crypto.PublicKey.DSA.generate($SIZE, ...)
-    - pattern: Cryptodome.PublicKey.DSA.generate(..., bits=$SIZE, ...)
-    - pattern: Cryptodome.PublicKey.DSA.generate($SIZE, ...)
-  - metavariable-comparison:
-      metavariable: "$SIZE"
-      comparison: "$SIZE < 2048"
   message: Detected an insufficient key size for DSA. NIST recommends a key size of
     2048 or higher.
   metadata:
@@ -36476,7 +36474,8 @@ rules:
     - A02:2021 - Cryptographic Failures
     source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
     references:
-    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    - https://www.pycryptodome.org/src/public_key/dsa
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf
     category: security
     technology:
     - pycryptodome
@@ -36484,7 +36483,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::key-length::pycryptodome
+    - crypto::search::key-length::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36493,26 +36495,28 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9688
-        rv_id: 110465
+        rv_id: 834686
         rule_id: AbUWje
-        version_id: xyTKpvy
-        url: https://semgrep.dev/playground/r/xyTKpvy/python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+        version_id: yeTNgyy
+        url: https://semgrep.dev/playground/r/yeTNgyy/python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
         origin: community
+  options:
+    symbolic_propagation: true
   languages:
   - python
   severity: WARNING
-- id: python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
   patterns:
   - pattern-either:
-    - pattern: Crypto.PublicKey.RSA.generate(..., bits=$SIZE, ...)
-    - pattern: Crypto.PublicKey.RSA.generate($SIZE, ...)
-    - pattern: Cryptodome.PublicKey.RSA.generate(..., bits=$SIZE, ...)
-    - pattern: Cryptodome.PublicKey.RSA.generate($SIZE, ...)
+    - pattern: Crypto.PublicKey.DSA.generate(..., bits=$SIZE, ...)
+    - pattern: Crypto.PublicKey.DSA.generate($SIZE, ...)
+    - pattern: Cryptodome.PublicKey.DSA.generate(..., bits=$SIZE, ...)
+    - pattern: Cryptodome.PublicKey.DSA.generate($SIZE, ...)
   - metavariable-comparison:
       metavariable: "$SIZE"
       comparison: "$SIZE < 2048"
+- id: python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
   message: Detected an insufficient key size for RSA. NIST recommends a key size of
-    2048 or higher.
+    3072 or higher.
   metadata:
     cwe:
     - 'CWE-326: Inadequate Encryption Strength'
@@ -36521,7 +36525,8 @@ rules:
     - A02:2021 - Cryptographic Failures
     source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
     references:
-    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    - https://www.pycryptodome.org/src/public_key/rsa#rsa
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf
     category: security
     technology:
     - pycryptodome
@@ -36529,7 +36534,10 @@ rules:
     - vuln
     likelihood: LOW
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
+    functional-categories:
+    - crypto::search::key-length::pycryptodome
+    - crypto::search::key-length::pycryptodomex
     license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     vulnerability_class:
     - Cryptographic Issues
@@ -36538,14 +36546,25 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9689
-        rv_id: 110466
+        rv_id: 834687
         rule_id: BYUBWe
-        version_id: O9TNdk2
-        url: https://semgrep.dev/playground/r/O9TNdk2/python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+        version_id: rxTDv9w
+        url: https://semgrep.dev/playground/r/rxTDv9w/python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
         origin: community
+  options:
+    symbolic_propagation: true
   languages:
   - python
   severity: WARNING
+  patterns:
+  - pattern-either:
+    - pattern: Crypto.PublicKey.RSA.generate(..., bits=$SIZE, ...)
+    - pattern: Crypto.PublicKey.RSA.generate($SIZE, ...)
+    - pattern: Cryptodome.PublicKey.RSA.generate(..., bits=$SIZE, ...)
+    - pattern: Cryptodome.PublicKey.RSA.generate($SIZE, ...)
+  - metavariable-comparison:
+      metavariable: "$SIZE"
+      comparison: "$SIZE < 3072"
 - id: python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
   message: 'An encryption mode of operation is being used without proper message authentication.
     This can potentially result in the encrypted content to be decrypted by an attacker.
@@ -36577,10 +36596,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31872
-        rv_id: 110467
+        rv_id: 834688
         rule_id: YGUw8w
-        version_id: e1T03go
-        url: https://semgrep.dev/playground/r/e1T03go/python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
+        version_id: bZTBoNz
+        url: https://semgrep.dev/playground/r/bZTBoNz/python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
         origin: community
   patterns:
   - pattern-either:
@@ -36635,10 +36654,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 12658
-        rv_id: 110468
+        rv_id: 834689
         rule_id: d8UlOX
-        version_id: vdTY81E
-        url: https://semgrep.dev/playground/r/vdTY81E/python.pymongo.security.mongodb.mongo-client-bad-auth
+        version_id: NdTBRYB
+        url: https://semgrep.dev/playground/r/NdTBRYB/python.pymongo.security.mongodb.mongo-client-bad-auth
         origin: community
 - id: python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
   patterns:
@@ -36679,10 +36698,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21437
-        rv_id: 110469
+        rv_id: 834690
         rule_id: bwUXKB
-        version_id: d6Trvq1
-        url: https://semgrep.dev/playground/r/d6Trvq1/python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
+        version_id: kbT2P8O
+        url: https://semgrep.dev/playground/r/kbT2P8O/python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
         origin: community
   languages:
   - python
@@ -36734,10 +36753,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21438
-        rv_id: 110470
+        rv_id: 834691
         rule_id: NbUq9e
-        version_id: ZRTQp60
-        url: https://semgrep.dev/playground/r/ZRTQp60/python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
+        version_id: w8TAbGK
+        url: https://semgrep.dev/playground/r/w8TAbGK/python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
         origin: community
   languages:
   - python
@@ -36781,10 +36800,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21439
-        rv_id: 110471
+        rv_id: 834692
         rule_id: kxUYjY
-        version_id: nWTxoO3
-        url: https://semgrep.dev/playground/r/nWTxoO3/python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
+        version_id: xyTNr2Z
+        url: https://semgrep.dev/playground/r/xyTNr2Z/python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
         origin: community
   languages:
   - python
@@ -36832,10 +36851,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21440
-        rv_id: 110472
+        rv_id: 834693
         rule_id: wdUKzn
-        version_id: ExTjARz
-        url: https://semgrep.dev/playground/r/ExTjARz/python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
+        version_id: O9TJ7Dd
+        url: https://semgrep.dev/playground/r/O9TJ7Dd/python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
         origin: community
   languages:
   - python
@@ -36886,10 +36905,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21441
-        rv_id: 110473
+        rv_id: 834694
         rule_id: x8UqAp
-        version_id: 7ZTgnD4
-        url: https://semgrep.dev/playground/r/7ZTgnD4/python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
+        version_id: e1TDKpy
+        url: https://semgrep.dev/playground/r/e1TDKpy/python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
         origin: community
   languages:
   - python
@@ -36937,10 +36956,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21443
-        rv_id: 110475
+        rv_id: 834696
         rule_id: eqU9Le
-        version_id: 8KTQy4l
-        url: https://semgrep.dev/playground/r/8KTQy4l/python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
+        version_id: d6TKgl8
+        url: https://semgrep.dev/playground/r/d6TKgl8/python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
         origin: community
 - id: python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
   message: Origin check for the CSRF token is disabled for this view. This might represent
@@ -36975,10 +36994,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21444
-        rv_id: 110476
+        rv_id: 834697
         rule_id: v8UGpL
-        version_id: gET3O67
-        url: https://semgrep.dev/playground/r/gET3O67/python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
+        version_id: ZRTldgx
+        url: https://semgrep.dev/playground/r/ZRTldgx/python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
         origin: community
   severity: WARNING
   languages:
@@ -37044,10 +37063,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21445
-        rv_id: 110477
+        rv_id: 834698
         rule_id: d8UPQ7
-        version_id: QkTWw8O
-        url: https://semgrep.dev/playground/r/QkTWw8O/python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
+        version_id: nWTyNrk
+        url: https://semgrep.dev/playground/r/nWTyNrk/python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
         origin: community
   languages:
   - python
@@ -37106,10 +37125,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21446
-        rv_id: 110478
+        rv_id: 834699
         rule_id: ZqU37W
-        version_id: 3ZTkrlN
-        url: https://semgrep.dev/playground/r/3ZTkrlN/python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
+        version_id: ExTrWQX
+        url: https://semgrep.dev/playground/r/ExTrWQX/python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
         origin: community
   languages:
   - python
@@ -37161,10 +37180,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21447
-        rv_id: 110479
+        rv_id: 834700
         rule_id: nJUp80
-        version_id: 44TR67n
-        url: https://semgrep.dev/playground/r/44TR67n/python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
+        version_id: 7ZTxRpY
+        url: https://semgrep.dev/playground/r/7ZTxRpY/python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
         origin: community
   languages:
   - python
@@ -37217,10 +37236,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21448
-        rv_id: 110480
+        rv_id: 834701
         rule_id: EwUgpY
-        version_id: PkTJdDp
-        url: https://semgrep.dev/playground/r/PkTJdDp/python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
+        version_id: LjTEerx
+        url: https://semgrep.dev/playground/r/LjTEerx/python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
         origin: community
   languages:
   - python
@@ -37272,10 +37291,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21449
-        rv_id: 110481
+        rv_id: 834702
         rule_id: 7KUr15
-        version_id: JdTNv5q
-        url: https://semgrep.dev/playground/r/JdTNv5q/python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
+        version_id: 8KTGlx0
+        url: https://semgrep.dev/playground/r/8KTGlx0/python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
         origin: community
   languages:
   - python
@@ -37332,10 +37351,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21450
-        rv_id: 110482
+        rv_id: 834703
         rule_id: L1UX2J
-        version_id: 5PTdek5
-        url: https://semgrep.dev/playground/r/5PTdek5/python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
+        version_id: gETyXYv
+        url: https://semgrep.dev/playground/r/gETyXYv/python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
         origin: community
   languages:
   - python
@@ -37382,10 +37401,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21451
-        rv_id: 110483
+        rv_id: 834704
         rule_id: 8GUKqP
-        version_id: GxTv8j9
-        url: https://semgrep.dev/playground/r/GxTv8j9/python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
+        version_id: QkTkNp3
+        url: https://semgrep.dev/playground/r/QkTkNp3/python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
         origin: community
 - id: python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
   message: Detected data rendered directly to the end user via 'Response'. This bypasses
@@ -37418,10 +37437,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21452
-        rv_id: 110484
+        rv_id: 834705
         rule_id: gxUeA8
-        version_id: RGTDRQO
-        url: https://semgrep.dev/playground/r/RGTDRQO/python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
+        version_id: 3ZT3wED
+        url: https://semgrep.dev/playground/r/3ZT3wED/python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
         origin: community
   languages:
   - python
@@ -37486,10 +37505,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 21453
-        rv_id: 110485
+        rv_id: 834706
         rule_id: QrUZ7l
-        version_id: A8T9Xr9
-        url: https://semgrep.dev/playground/r/A8T9Xr9/python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
+        version_id: 44TQq2w
+        url: https://semgrep.dev/playground/r/44TQq2w/python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
         origin: community
   mode: taint
   pattern-sources:
@@ -37588,10 +37607,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9702
-        rv_id: 110499
+        rv_id: 834720
         rule_id: BYUBWo
-        version_id: BjTXpDb
-        url: https://semgrep.dev/playground/r/BjTXpDb/python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
+        version_id: YDTlbQ3
+        url: https://semgrep.dev/playground/r/YDTlbQ3/python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
         origin: community
 - id: python.twilio.security.twiml-injection.twiml-injection
   languages:
@@ -37623,10 +37642,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 134692
-        rv_id: 756860
+        rv_id: 834721
         rule_id: oqUgjj2
-        version_id: rxT23xn
-        url: https://semgrep.dev/playground/r/rxT23xn/python.twilio.security.twiml-injection.twiml-injection
+        version_id: 6xTDX6e
+        url: https://semgrep.dev/playground/r/6xTDX6e/python.twilio.security.twiml-injection.twiml-injection
         origin: community
   mode: taint
   pattern-sources:
@@ -37688,10 +37707,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18277
-        rv_id: 110500
+        rv_id: 834722
         rule_id: 0oUw9g
-        version_id: DkT6Y9w
-        url: https://semgrep.dev/playground/r/DkT6Y9w/ruby.aws-lambda.security.activerecord-sqli.activerecord-sqli
+        version_id: o5TB1rx
+        url: https://semgrep.dev/playground/r/o5TB1rx/ruby.aws-lambda.security.activerecord-sqli.activerecord-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -37747,10 +37766,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18278
-        rv_id: 110501
+        rv_id: 834723
         rule_id: KxUrQ3
-        version_id: WrTW3lG
-        url: https://semgrep.dev/playground/r/WrTW3lG/ruby.aws-lambda.security.mysql2-sqli.mysql2-sqli
+        version_id: zyTW31P
+        url: https://semgrep.dev/playground/r/zyTW31P/ruby.aws-lambda.security.mysql2-sqli.mysql2-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -37809,10 +37828,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18279
-        rv_id: 110502
+        rv_id: 834724
         rule_id: qNUQee
-        version_id: 0bTLe7q
-        url: https://semgrep.dev/playground/r/0bTLe7q/ruby.aws-lambda.security.pg-sqli.pg-sqli
+        version_id: pZTXDpP
+        url: https://semgrep.dev/playground/r/pZTXDpP/ruby.aws-lambda.security.pg-sqli.pg-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -37872,10 +37891,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18280
-        rv_id: 110503
+        rv_id: 834725
         rule_id: lBUy2N
-        version_id: K3TvGzQ
-        url: https://semgrep.dev/playground/r/K3TvGzQ/ruby.aws-lambda.security.sequel-sqli.sequel-sqli
+        version_id: 2KT7OPz
+        url: https://semgrep.dev/playground/r/2KT7OPz/ruby.aws-lambda.security.sequel-sqli.sequel-sqli
         origin: community
   pattern-sinks:
   - patterns:
@@ -37933,10 +37952,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22078
-        rv_id: 110504
+        rv_id: 834726
         rule_id: zdUlNJ
-        version_id: qkT2B1K
-        url: https://semgrep.dev/playground/r/qkT2B1K/ruby.aws-lambda.security.tainted-deserialization.tainted-deserialization
+        version_id: X0T5KdO
+        url: https://semgrep.dev/playground/r/X0T5KdO/ruby.aws-lambda.security.tainted-deserialization.tainted-deserialization
         origin: community
   pattern-sinks:
   - patterns:
@@ -37999,10 +38018,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18281
-        rv_id: 110505
+        rv_id: 834727
         rule_id: PeUxOE
-        version_id: l4T46re
-        url: https://semgrep.dev/playground/r/l4T46re/ruby.aws-lambda.security.tainted-sql-string.tainted-sql-string
+        version_id: jQTrj36
+        url: https://semgrep.dev/playground/r/jQTrj36/ruby.aws-lambda.security.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sources:
@@ -38089,10 +38108,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9708
-        rv_id: 110513
+        rv_id: 834735
         rule_id: lBUdQg
-        version_id: jQTgy6W
-        url: https://semgrep.dev/playground/r/jQTgy6W/ruby.lang.security.bad-deserialization.bad-deserialization
+        version_id: w8TAbjK
+        url: https://semgrep.dev/playground/r/w8TAbjK/ruby.lang.security.bad-deserialization.bad-deserialization
         origin: community
   languages:
   - ruby
@@ -38155,10 +38174,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9805
-        rv_id: 110516
+        rv_id: 834738
         rule_id: WAUZOw
-        version_id: yeTRZBK
-        url: https://semgrep.dev/playground/r/yeTRZBK/ruby.lang.security.dangerous-exec.dangerous-exec
+        version_id: e1TDKzy
+        url: https://semgrep.dev/playground/r/e1TDKzy/ruby.lang.security.dangerous-exec.dangerous-exec
         origin: community
   severity: WARNING
   languages:
@@ -38186,10 +38205,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9711
-        rv_id: 110521
+        rv_id: 834743
         rule_id: oqUzXA
-        version_id: w8T9DzL
-        url: https://semgrep.dev/playground/r/w8T9DzL/ruby.lang.security.divide-by-zero.divide-by-zero
+        version_id: ExTrWKX
+        url: https://semgrep.dev/playground/r/ExTrWKX/ruby.lang.security.divide-by-zero.divide-by-zero
         origin: community
   languages:
   - ruby
@@ -38233,10 +38252,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9714
-        rv_id: 110524
+        rv_id: 834746
         rule_id: 2ZU4lx
-        version_id: e1T03L6
-        url: https://semgrep.dev/playground/r/e1T03L6/ruby.lang.security.force-ssl-false.force-ssl-false
+        version_id: 8KTGlz0
+        url: https://semgrep.dev/playground/r/8KTGlz0/ruby.lang.security.force-ssl-false.force-ssl-false
         origin: community
   languages:
   - ruby
@@ -38279,10 +38298,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20730
-        rv_id: 110526
+        rv_id: 834748
         rule_id: bwULyN
-        version_id: d6TrvQR
-        url: https://semgrep.dev/playground/r/d6TrvQR/ruby.lang.security.hardcoded-secret-rsa-passphrase.hardcoded-secret-rsa-passphrase
+        version_id: QkTkNd3
+        url: https://semgrep.dev/playground/r/QkTkNd3/ruby.lang.security.hardcoded-secret-rsa-passphrase.hardcoded-secret-rsa-passphrase
         origin: community
   patterns:
   - pattern-either:
@@ -38387,10 +38406,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20731
-        rv_id: 110527
+        rv_id: 834749
         rule_id: NbUe4N
-        version_id: ZRTQp7j
-        url: https://semgrep.dev/playground/r/ZRTQp7j/ruby.lang.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+        version_id: 3ZT3wjD
+        url: https://semgrep.dev/playground/r/3ZT3wjD/ruby.lang.security.insufficient-rsa-key-size.insufficient-rsa-key-size
         origin: community
   patterns:
   - pattern-either:
@@ -38453,10 +38472,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14704
-        rv_id: 110532
+        rv_id: 834752
         rule_id: oqU4p2
-        version_id: 8KTQyjj
-        url: https://semgrep.dev/playground/r/8KTQyjj/ruby.lang.security.md5-used-as-password.md5-used-as-password
+        version_id: JdTlRLE
+        url: https://semgrep.dev/playground/r/JdTlRLE/ruby.lang.security.md5-used-as-password.md5-used-as-password
         origin: community
   mode: taint
   pattern-sources:
@@ -38499,10 +38518,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9726
-        rv_id: 110539
+        rv_id: 834756
         rule_id: OrUGNk
-        version_id: 5PTdeO9
-        url: https://semgrep.dev/playground/r/5PTdeO9/ruby.lang.security.no-eval.ruby-eval
+        version_id: A8T3lQw
+        url: https://semgrep.dev/playground/r/A8T3lQw/ruby.lang.security.no-eval.ruby-eval
         origin: community
   languages:
   - ruby
@@ -38569,10 +38588,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9728
-        rv_id: 110541
+        rv_id: 834758
         rule_id: v8U5Yn
-        version_id: RGTDRgR
-        url: https://semgrep.dev/playground/r/RGTDRgR/ruby.lang.security.ssl-mode-no-verify.ssl-mode-no-verify
+        version_id: DkTGy10
+        url: https://semgrep.dev/playground/r/DkTGy10/ruby.lang.security.ssl-mode-no-verify.ssl-mode-no-verify
         origin: community
 - id: ruby.lang.security.weak-hashes-md5.weak-hashes-md5
   message: Should not use md5 to generate hashes. md5 is proven to be vulnerable through
@@ -38602,10 +38621,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9731
-        rv_id: 110544
+        rv_id: 834760
         rule_id: nJUYxZ
-        version_id: DkT6Ypw
-        url: https://semgrep.dev/playground/r/DkT6Ypw/ruby.lang.security.weak-hashes-md5.weak-hashes-md5
+        version_id: 0bTw32z
+        url: https://semgrep.dev/playground/r/0bTw32z/ruby.lang.security.weak-hashes-md5.weak-hashes-md5
         origin: community
   languages:
   - ruby
@@ -38648,10 +38667,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9732
-        rv_id: 110545
+        rv_id: 834761
         rule_id: EwU4jq
-        version_id: WrTW3oG
-        url: https://semgrep.dev/playground/r/WrTW3oG/ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
+        version_id: K3TrL7X
+        url: https://semgrep.dev/playground/r/K3TrL7X/ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
         origin: community
   languages:
   - ruby
@@ -38696,10 +38715,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13584
-        rv_id: 110549
+        rv_id: 834764
         rule_id: BYUdW6
-        version_id: l4T469e
-        url: https://semgrep.dev/playground/r/l4T469e/ruby.rails.security.audit.avoid-session-manipulation.avoid-session-manipulation
+        version_id: YDTlbD3
+        url: https://semgrep.dev/playground/r/YDTlbD3/ruby.rails.security.audit.avoid-session-manipulation.avoid-session-manipulation
         origin: community
   message: This gets data from session using user inputs. A malicious user may be
     able to retrieve information from your session that you didn't intend them to.
@@ -38742,10 +38761,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13585
-        rv_id: 110550
+        rv_id: 834765
         rule_id: DbU1dr
-        version_id: YDTpnRx
-        url: https://semgrep.dev/playground/r/YDTpnRx/ruby.rails.security.audit.avoid-tainted-file-access.avoid-tainted-file-access
+        version_id: JdTlRLq
+        url: https://semgrep.dev/playground/r/JdTlRLq/ruby.rails.security.audit.avoid-tainted-file-access.avoid-tainted-file-access
         origin: community
   message: Using user input when accessing files is potentially dangerous. A malicious
     actor could use this to modify or access files they have no right to.
@@ -38824,10 +38843,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13586
-        rv_id: 110551
+        rv_id: 834766
         rule_id: WAUyzp
-        version_id: 6xTvQj4
-        url: https://semgrep.dev/playground/r/6xTvQj4/ruby.rails.security.audit.avoid-tainted-ftp-call.avoid-tainted-ftp-call
+        version_id: 5PTyGL5
+        url: https://semgrep.dev/playground/r/5PTyGL5/ruby.rails.security.audit.avoid-tainted-ftp-call.avoid-tainted-ftp-call
         origin: community
   message: Using user input when accessing files is potentially dangerous. A malicious
     actor could use this to modify or access files they have no right to.
@@ -38874,10 +38893,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13587
-        rv_id: 110552
+        rv_id: 834767
         rule_id: 0oU2x3
-        version_id: o5Tg9eQ
-        url: https://semgrep.dev/playground/r/o5Tg9eQ/ruby.rails.security.audit.avoid-tainted-http-request.avoid-tainted-http-request
+        version_id: GxTDXr9
+        url: https://semgrep.dev/playground/r/GxTDXr9/ruby.rails.security.audit.avoid-tainted-http-request.avoid-tainted-http-request
         origin: community
   message: Using user input when accessing files is potentially dangerous. A malicious
     actor could use this to modify or access files they have no right to.
@@ -38965,10 +38984,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13588
-        rv_id: 110553
+        rv_id: 834768
         rule_id: KxU72k
-        version_id: zyTKDkv
-        url: https://semgrep.dev/playground/r/zyTKDkv/ruby.rails.security.audit.avoid-tainted-shell-call.avoid-tainted-shell-call
+        version_id: RGTKxqO
+        url: https://semgrep.dev/playground/r/RGTKxqO/ruby.rails.security.audit.avoid-tainted-shell-call.avoid-tainted-shell-call
         origin: community
   message: Using user input when accessing files is potentially dangerous. A malicious
     actor could use this to modify or access files they have no right to.
@@ -39096,10 +39115,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10328
-        rv_id: 110569
+        rv_id: 834771
         rule_id: NbUAz7
-        version_id: vdTY8n2
-        url: https://semgrep.dev/playground/r/vdTY8n2/ruby.rails.security.audit.sqli.ruby-pg-sqli.ruby-pg-sqli
+        version_id: DkTGyx9
+        url: https://semgrep.dev/playground/r/DkTGyx9/ruby.rails.security.audit.sqli.ruby-pg-sqli.ruby-pg-sqli
         origin: community
   severity: WARNING
 - id: ruby.rails.security.audit.xss.avoid-link-to.avoid-link-to
@@ -39132,10 +39151,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13590
-        rv_id: 110573
+        rv_id: 834775
         rule_id: lBU8Qj
-        version_id: ExTjA4j
-        url: https://semgrep.dev/playground/r/ExTjA4j/ruby.rails.security.audit.xss.avoid-link-to.avoid-link-to
+        version_id: qkTQwWX
+        url: https://semgrep.dev/playground/r/qkTQwWX/ruby.rails.security.audit.xss.avoid-link-to.avoid-link-to
         origin: community
   message: This code includes user input in `link_to`. In Rails 2.x, the body of `link_to`
     is not escaped. This means that user input which reaches the body will be executed
@@ -39190,10 +39209,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13591
-        rv_id: 110575
+        rv_id: 834777
         rule_id: YGUDqJ
-        version_id: LjTqA42
-        url: https://semgrep.dev/playground/r/LjTqA42/ruby.rails.security.audit.xss.avoid-redirect.avoid-redirect
+        version_id: YDTlbAl
+        url: https://semgrep.dev/playground/r/YDTlbAl/ruby.rails.security.audit.xss.avoid-redirect.avoid-redirect
         origin: community
   message: When a redirect uses user input, a malicious user can spoof a website under
     a trusted URL or access restricted parts of a site. When using user-supplied values,
@@ -39265,10 +39284,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13592
-        rv_id: 110576
+        rv_id: 834778
         rule_id: 6JU1bL
-        version_id: 8KTQyEj
-        url: https://semgrep.dev/playground/r/8KTQyEj/ruby.rails.security.audit.xss.avoid-render-dynamic-path.avoid-render-dynamic-path
+        version_id: 6xTDXEy
+        url: https://semgrep.dev/playground/r/6xTDXEy/ruby.rails.security.audit.xss.avoid-render-dynamic-path.avoid-render-dynamic-path
         origin: community
   message: Avoid rendering user input. It may be possible for a malicious user to
     input a path that lets them access a template they shouldn't. To prevent this,
@@ -39338,10 +39357,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20531
-        rv_id: 760823
+        rv_id: 834792
         rule_id: wdUkBP
-        version_id: RGTqX1r
-        url: https://semgrep.dev/playground/r/RGTqX1r/ruby.rails.security.brakeman.check-before-filter.check-before-filter
+        version_id: w8TAblg
+        url: https://semgrep.dev/playground/r/w8TAblg/ruby.rails.security.brakeman.check-before-filter.check-before-filter
         origin: community
 - id: ruby.rails.security.brakeman.check-dynamic-render-local-file-include.check-dynamic-render-local-file-include
   mode: search
@@ -39391,10 +39410,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20043
-        rv_id: 110592
+        rv_id: 834794
         rule_id: JDUokO
-        version_id: qkT2BoK
-        url: https://semgrep.dev/playground/r/qkT2BoK/ruby.rails.security.brakeman.check-dynamic-render-local-file-include.check-dynamic-render-local-file-include
+        version_id: O9TJ7l2
+        url: https://semgrep.dev/playground/r/O9TJ7l2/ruby.rails.security.brakeman.check-dynamic-render-local-file-include.check-dynamic-render-local-file-include
         origin: community
 - id: ruby.rails.security.brakeman.check-http-verb-confusion.check-http-verb-confusion
   mode: search
@@ -39441,10 +39460,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20532
-        rv_id: 110593
+        rv_id: 834795
         rule_id: x8UdDE
-        version_id: l4T46de
-        url: https://semgrep.dev/playground/r/l4T46de/ruby.rails.security.brakeman.check-http-verb-confusion.check-http-verb-confusion
+        version_id: e1TDKro
+        url: https://semgrep.dev/playground/r/e1TDKro/ruby.rails.security.brakeman.check-http-verb-confusion.check-http-verb-confusion
         origin: community
 - id: ruby.rails.security.brakeman.check-rails-session-secret-handling.check-rails-session-secret-handling
   patterns:
@@ -39499,10 +39518,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20155
-        rv_id: 110597
+        rv_id: 834799
         rule_id: lBUX1r
-        version_id: GxTv805
-        url: https://semgrep.dev/playground/r/GxTv805/ruby.rails.security.brakeman.check-rails-session-secret-handling.check-rails-session-secret-handling
+        version_id: nWTyNG3
+        url: https://semgrep.dev/playground/r/nWTyNG3/ruby.rails.security.brakeman.check-rails-session-secret-handling.check-rails-session-secret-handling
         origin: community
 - id: ruby.rails.security.brakeman.check-redirect-to.check-redirect-to
   mode: taint
@@ -39591,10 +39610,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20732
-        rv_id: 110598
+        rv_id: 834800
         rule_id: kxUOJ6
-        version_id: RGTDRPZ
-        url: https://semgrep.dev/playground/r/RGTDRPZ/ruby.rails.security.brakeman.check-redirect-to.check-redirect-to
+        version_id: ExTrWqz
+        url: https://semgrep.dev/playground/r/ExTrWqz/ruby.rails.security.brakeman.check-redirect-to.check-redirect-to
         origin: community
 - id: ruby.rails.security.brakeman.check-regex-dos.check-regex-dos
   mode: taint
@@ -39670,10 +39689,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20156
-        rv_id: 110599
+        rv_id: 834801
         rule_id: YGUY4R
-        version_id: A8T9XWO
-        url: https://semgrep.dev/playground/r/A8T9XWO/ruby.rails.security.brakeman.check-regex-dos.check-regex-dos
+        version_id: 7ZTxRW4
+        url: https://semgrep.dev/playground/r/7ZTxRW4/ruby.rails.security.brakeman.check-regex-dos.check-regex-dos
         origin: community
 - id: ruby.rails.security.brakeman.check-render-local-file-include.check-render-local-file-include
   mode: taint
@@ -39745,10 +39764,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20046
-        rv_id: 253875
+        rv_id: 834802
         rule_id: ReU2pZ
-        version_id: X0TOBZb
-        url: https://semgrep.dev/playground/r/X0TOBZb/ruby.rails.security.brakeman.check-render-local-file-include.check-render-local-file-include
+        version_id: LjTEePb
+        url: https://semgrep.dev/playground/r/LjTEePb/ruby.rails.security.brakeman.check-render-local-file-include.check-render-local-file-include
         origin: community
 - id: ruby.rails.security.brakeman.check-reverse-tabnabbing.check-reverse-tabnabbing
   mode: search
@@ -39824,10 +39843,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22069
-        rv_id: 110601
+        rv_id: 834803
         rule_id: DbUNX4
-        version_id: DkT6YWJ
-        url: https://semgrep.dev/playground/r/DkT6YWJ/ruby.rails.security.brakeman.check-reverse-tabnabbing.check-reverse-tabnabbing
+        version_id: 8KTGlAl
+        url: https://semgrep.dev/playground/r/8KTGlAl/ruby.rails.security.brakeman.check-reverse-tabnabbing.check-reverse-tabnabbing
         origin: community
 - id: ruby.rails.security.brakeman.check-secrets.check-secrets
   patterns:
@@ -39870,10 +39889,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20047
-        rv_id: 110602
+        rv_id: 834804
         rule_id: AbUNqO
-        version_id: WrTW3ZB
-        url: https://semgrep.dev/playground/r/WrTW3ZB/ruby.rails.security.brakeman.check-secrets.check-secrets
+        version_id: gETyXJ7
+        url: https://semgrep.dev/playground/r/gETyXJ7/ruby.rails.security.brakeman.check-secrets.check-secrets
         origin: community
 - id: ruby.rails.security.brakeman.check-send-file.check-send-file
   mode: taint
@@ -39932,10 +39951,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20048
-        rv_id: 110603
+        rv_id: 834805
         rule_id: BYUKbl
-        version_id: 0bTLeEn
-        url: https://semgrep.dev/playground/r/0bTLeEn/ruby.rails.security.brakeman.check-send-file.check-send-file
+        version_id: QkTkNnO
+        url: https://semgrep.dev/playground/r/QkTkNnO/ruby.rails.security.brakeman.check-send-file.check-send-file
         origin: community
 - id: ruby.rails.security.brakeman.check-sql.check-sql
   mode: taint
@@ -40043,10 +40062,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20533
-        rv_id: 110604
+        rv_id: 875837
         rule_id: OrUv2z
-        version_id: K3TvG41
-        url: https://semgrep.dev/playground/r/K3TvG41/ruby.rails.security.brakeman.check-sql.check-sql
+        version_id: yeTD2GG
+        url: https://semgrep.dev/playground/r/yeTD2GG/ruby.rails.security.brakeman.check-sql.check-sql
         origin: community
 - id: ruby.rails.security.brakeman.check-unsafe-reflection-methods.check-unsafe-reflection-methods
   mode: taint
@@ -40115,10 +40134,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20534
-        rv_id: 252884
+        rv_id: 834807
         rule_id: eqUZ2Q
-        version_id: LjT7YWR
-        url: https://semgrep.dev/playground/r/LjT7YWR/ruby.rails.security.brakeman.check-unsafe-reflection-methods.check-unsafe-reflection-methods
+        version_id: 44TQqgn
+        url: https://semgrep.dev/playground/r/44TQqgn/ruby.rails.security.brakeman.check-unsafe-reflection-methods.check-unsafe-reflection-methods
         origin: community
 - id: ruby.rails.security.brakeman.check-unsafe-reflection.check-unsafe-reflection
   mode: taint
@@ -40185,10 +40204,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20733
-        rv_id: 110606
+        rv_id: 834808
         rule_id: wdUkYA
-        version_id: l4T46dO
-        url: https://semgrep.dev/playground/r/l4T46dO/ruby.rails.security.brakeman.check-unsafe-reflection.check-unsafe-reflection
+        version_id: PkTxG0p
+        url: https://semgrep.dev/playground/r/PkTxG0p/ruby.rails.security.brakeman.check-unsafe-reflection.check-unsafe-reflection
         origin: community
 - id: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
   mode: taint
@@ -40253,10 +40272,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20734
-        rv_id: 110607
+        rv_id: 834809
         rule_id: x8Ud6d
-        version_id: YDTpnrb
-        url: https://semgrep.dev/playground/r/YDTpnrb/ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
+        version_id: JdTlR6q
+        url: https://semgrep.dev/playground/r/JdTlR6q/ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
         origin: community
 - id: ruby.rails.security.brakeman.check-validation-regex.check-validation-regex
   mode: search
@@ -40306,10 +40325,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20735
-        rv_id: 110608
+        rv_id: 834810
         rule_id: OrUv1X
-        version_id: 6xTvQq9
-        url: https://semgrep.dev/playground/r/6xTvQq9/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex
+        version_id: 5PTyGp5
+        url: https://semgrep.dev/playground/r/5PTyGp5/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex
         origin: community
 - id: ruby.rails.security.injection.raw-html-format.raw-html-format
   languages:
@@ -40349,10 +40368,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14470
-        rv_id: 110610
+        rv_id: 834811
         rule_id: kxUwZX
-        version_id: zyTKDy4
-        url: https://semgrep.dev/playground/r/zyTKDy4/ruby.rails.security.injection.raw-html-format.raw-html-format
+        version_id: GxTDXz9
+        url: https://semgrep.dev/playground/r/GxTDXz9/ruby.rails.security.injection.raw-html-format.raw-html-format
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -40420,10 +40439,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14714
-        rv_id: 113536
+        rv_id: 834812
         rule_id: bwU8gl
-        version_id: YDTpZBw
-        url: https://semgrep.dev/playground/r/YDTpZBw/ruby.rails.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: RGTKxKO
+        url: https://semgrep.dev/playground/r/RGTKxKO/ruby.rails.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   mode: taint
   pattern-sources:
@@ -40506,10 +40525,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14705
-        rv_id: 762650
+        rv_id: 834813
         rule_id: zdUY0W
-        version_id: YDTAo3P
-        url: https://semgrep.dev/playground/r/YDTAo3P/ruby.rails.security.injection.tainted-url-host.tainted-url-host
+        version_id: A8T3l39
+        url: https://semgrep.dev/playground/r/A8T3l39/ruby.rails.security.injection.tainted-url-host.tainted-url-host
         origin: community
   mode: taint
   pattern-sanitizers:
@@ -40563,10 +40582,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40108
-        rv_id: 110617
+        rv_id: 834818
         rule_id: qNUKDg
-        version_id: yeTRZyR
-        url: https://semgrep.dev/playground/r/yeTRZyR/rust.lang.security.reqwest-accept-invalid.reqwest-accept-invalid
+        version_id: K3TrLrY
+        url: https://semgrep.dev/playground/r/K3TrLrY/rust.lang.security.reqwest-accept-invalid.reqwest-accept-invalid
         origin: community
   languages:
   - rust
@@ -40600,10 +40619,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40110
-        rv_id: 110619
+        rv_id: 834820
         rule_id: YGU8LK
-        version_id: bZTb9NK
-        url: https://semgrep.dev/playground/r/bZTb9NK/rust.lang.security.rustls-dangerous.rustls-dangerous
+        version_id: l4TyDyW
+        url: https://semgrep.dev/playground/r/l4TyDyW/rust.lang.security.rustls-dangerous.rustls-dangerous
         origin: community
   languages:
   - rust
@@ -40630,10 +40649,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40111
-        rv_id: 110620
+        rv_id: 834821
         rule_id: 6JU0Bl
-        version_id: NdT3oYk
-        url: https://semgrep.dev/playground/r/NdT3oYk/rust.lang.security.ssl-verify-none.ssl-verify-none
+        version_id: YDTlbll
+        url: https://semgrep.dev/playground/r/YDTlbll/rust.lang.security.ssl-verify-none.ssl-verify-none
         origin: community
   languages:
   - rust
@@ -40728,10 +40747,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19040
-        rv_id: 110623
+        rv_id: 834824
         rule_id: WAUdK0
-        version_id: xyTKp2x
-        url: https://semgrep.dev/playground/r/xyTKp2x/scala.jwt-scala.security.jwt-scala-hardcode.jwt-scala-hardcode
+        version_id: zyTW3W8
+        url: https://semgrep.dev/playground/r/zyTW3W8/scala.jwt-scala.security.jwt-scala-hardcode.jwt-scala-hardcode
         origin: community
 - id: scala.lang.security.audit.documentbuilder-dtd-enabled.documentbuilder-dtd-enabled
   patterns:
@@ -40825,10 +40844,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19041
-        rv_id: 110628
+        rv_id: 834829
         rule_id: 0oUwzP
-        version_id: ZRTQpgN
-        url: https://semgrep.dev/playground/r/ZRTQpgN/scala.lang.security.audit.documentbuilder-dtd-enabled.documentbuilder-dtd-enabled
+        version_id: 1QTPNP3
+        url: https://semgrep.dev/playground/r/1QTPNP3/scala.lang.security.audit.documentbuilder-dtd-enabled.documentbuilder-dtd-enabled
         origin: community
 - id: scala.lang.security.audit.tainted-sql-string.tainted-sql-string
   languages:
@@ -40867,10 +40886,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20050
-        rv_id: 110638
+        rv_id: 834839
         rule_id: WAUY8B
-        version_id: PkTJdBK
-        url: https://semgrep.dev/playground/r/PkTJdBK/scala.lang.security.audit.tainted-sql-string.tainted-sql-string
+        version_id: e1TDKDo
+        url: https://semgrep.dev/playground/r/e1TDKDo/scala.lang.security.audit.tainted-sql-string.tainted-sql-string
         origin: community
   pattern-sources:
   - patterns:
@@ -41014,10 +41033,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19044
-        rv_id: 110640
+        rv_id: 834841
         rule_id: lBUyRR
-        version_id: 5PTde8l
-        url: https://semgrep.dev/playground/r/5PTde8l/scala.play.security.conf-csrf-headers-bypass.conf-csrf-headers-bypass
+        version_id: d6TKgK1
+        url: https://semgrep.dev/playground/r/d6TKgK1/scala.play.security.conf-csrf-headers-bypass.conf-csrf-headers-bypass
         origin: community
 - id: scala.play.security.conf-insecure-cookie-settings.conf-insecure-cookie-settings
   patterns:
@@ -41061,10 +41080,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18284
-        rv_id: 110641
+        rv_id: 834842
         rule_id: GdUDJO
-        version_id: GxTv8Z5
-        url: https://semgrep.dev/playground/r/GxTv8Z5/scala.play.security.conf-insecure-cookie-settings.conf-insecure-cookie-settings
+        version_id: ZRTldl0
+        url: https://semgrep.dev/playground/r/ZRTldl0/scala.play.security.conf-insecure-cookie-settings.conf-insecure-cookie-settings
         origin: community
 - id: scala.play.security.tainted-html-response.tainted-html-response
   mode: taint
@@ -41096,10 +41115,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18795
-        rv_id: 110642
+        rv_id: 834843
         rule_id: 0oUwn2
-        version_id: RGTDRoZ
-        url: https://semgrep.dev/playground/r/RGTDRoZ/scala.play.security.tainted-html-response.tainted-html-response
+        version_id: nWTyNy3
+        url: https://semgrep.dev/playground/r/nWTyNy3/scala.play.security.tainted-html-response.tainted-html-response
         origin: community
   message: Detected a request with potential user-input going into an `Ok()` response.
     This bypasses any view or template environments, including HTML escaping, which
@@ -41195,10 +41214,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18328
-        rv_id: 110643
+        rv_id: 834844
         rule_id: GdUDWO
-        version_id: A8T9XGO
-        url: https://semgrep.dev/playground/r/A8T9XGO/scala.play.security.tainted-slick-sqli.tainted-slick-sqli
+        version_id: ExTrWrz
+        url: https://semgrep.dev/playground/r/ExTrWrz/scala.play.security.tainted-slick-sqli.tainted-slick-sqli
         origin: community
   message: Detected a tainted SQL statement. This could lead to SQL injection if variables
     in the SQL statement are not properly sanitized. Avoid using using user input
@@ -41281,10 +41300,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20051
-        rv_id: 110644
+        rv_id: 834845
         rule_id: 0oUpon
-        version_id: BjTXp7l
-        url: https://semgrep.dev/playground/r/BjTXp7l/scala.play.security.tainted-sql-from-http-request.tainted-sql-from-http-request
+        version_id: 7ZTxRx4
+        url: https://semgrep.dev/playground/r/7ZTxRx4/scala.play.security.tainted-sql-from-http-request.tainted-sql-from-http-request
         origin: community
   pattern-sources:
   - patterns:
@@ -41367,10 +41386,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67640
-        rv_id: 110668
+        rv_id: 834869
         rule_id: kxUl7x
-        version_id: O9TNd6l
-        url: https://semgrep.dev/playground/r/O9TNd6l/solidity.security.balancer-readonly-reentrancy-getpooltokens.balancer-readonly-reentrancy-getpooltokens
+        version_id: RGTKx2R
+        url: https://semgrep.dev/playground/r/RGTKx2R/solidity.security.balancer-readonly-reentrancy-getpooltokens.balancer-readonly-reentrancy-getpooltokens
         origin: community
   patterns:
   - pattern-either:
@@ -41517,10 +41536,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67641
-        rv_id: 110669
+        rv_id: 834870
         rule_id: wdUx3D
-        version_id: e1T03zD
-        url: https://semgrep.dev/playground/r/e1T03zD/solidity.security.balancer-readonly-reentrancy-getrate.balancer-readonly-reentrancy-getrate
+        version_id: A8T3lNg
+        url: https://semgrep.dev/playground/r/A8T3lNg/solidity.security.balancer-readonly-reentrancy-getrate.balancer-readonly-reentrancy-getrate
         origin: community
   patterns:
   - pattern: |
@@ -41658,10 +41677,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67644
-        rv_id: 110672
+        rv_id: 834873
         rule_id: eqUkx4
-        version_id: ZRTQpON
-        url: https://semgrep.dev/playground/r/ZRTQpON/solidity.security.compound-borrowfresh-reentrancy.compound-borrowfresh-reentrancy
+        version_id: WrTdnYG
+        url: https://semgrep.dev/playground/r/WrTdnYG/solidity.security.compound-borrowfresh-reentrancy.compound-borrowfresh-reentrancy
         origin: community
   patterns:
   - pattern-inside: |
@@ -41700,10 +41719,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67645
-        rv_id: 110673
+        rv_id: 834874
         rule_id: v8Uz2o
-        version_id: nWTxoZo
-        url: https://semgrep.dev/playground/r/nWTxoZo/solidity.security.compound-sweeptoken-not-restricted.compound-sweeptoken-not-restricted
+        version_id: 0bTw3pq
+        url: https://semgrep.dev/playground/r/0bTw3pq/solidity.security.compound-sweeptoken-not-restricted.compound-sweeptoken-not-restricted
         origin: community
   patterns:
   - pattern-inside: |
@@ -41748,10 +41767,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67646
-        rv_id: 110674
+        rv_id: 834875
         rule_id: d8UGDL
-        version_id: ExTjAKE
-        url: https://semgrep.dev/playground/r/ExTjAKE/solidity.security.curve-readonly-reentrancy.curve-readonly-reentrancy
+        version_id: K3TrLwQ
+        url: https://semgrep.dev/playground/r/K3TrLwQ/solidity.security.curve-readonly-reentrancy.curve-readonly-reentrancy
         origin: community
   patterns:
   - pattern: "$POOL.get_virtual_price()\n"
@@ -41828,10 +41847,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67648
-        rv_id: 110676
+        rv_id: 834877
         rule_id: nJU47w
-        version_id: LjTqA5R
-        url: https://semgrep.dev/playground/r/LjTqA5R/solidity.security.encode-packed-collision.encode-packed-collision
+        version_id: l4TyDXe
+        url: https://semgrep.dev/playground/r/l4TyDXe/solidity.security.encode-packed-collision.encode-packed-collision
         origin: community
   patterns:
   - pattern-either:
@@ -41919,10 +41938,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67651
-        rv_id: 110679
+        rv_id: 834880
         rule_id: L1Ub0L
-        version_id: QkTWwdg
-        url: https://semgrep.dev/playground/r/QkTWwdg/solidity.security.erc677-reentrancy.erc677-reentrancy
+        version_id: o5TB1KQ
+        url: https://semgrep.dev/playground/r/o5TB1KQ/solidity.security.erc677-reentrancy.erc677-reentrancy
         origin: community
   patterns:
   - pattern-inside: |
@@ -41956,10 +41975,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67652
-        rv_id: 110680
+        rv_id: 834881
         rule_id: 8GUkbo
-        version_id: 3ZTkrjx
-        url: https://semgrep.dev/playground/r/3ZTkrjx/solidity.security.erc721-arbitrary-transferfrom.erc721-arbitrary-transferfrom
+        version_id: zyTW3Gv
+        url: https://semgrep.dev/playground/r/zyTW3Gv/solidity.security.erc721-arbitrary-transferfrom.erc721-arbitrary-transferfrom
         origin: community
   patterns:
   - pattern-inside: |
@@ -42008,10 +42027,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67653
-        rv_id: 110681
+        rv_id: 834882
         rule_id: gxU2qG
-        version_id: 44TR61x
-        url: https://semgrep.dev/playground/r/44TR61x/solidity.security.erc721-reentrancy.erc721-reentrancy
+        version_id: pZTXDb4
+        url: https://semgrep.dev/playground/r/pZTXDb4/solidity.security.erc721-reentrancy.erc721-reentrancy
         origin: community
   patterns:
   - pattern: _checkOnERC721Received(...)
@@ -42041,10 +42060,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67654
-        rv_id: 110682
+        rv_id: 834883
         rule_id: QrUrJj
-        version_id: PkTJdoK
-        url: https://semgrep.dev/playground/r/PkTJdoK/solidity.security.erc777-reentrancy.erc777-reentrancy
+        version_id: 2KT7Odk
+        url: https://semgrep.dev/playground/r/2KT7Odk/solidity.security.erc777-reentrancy.erc777-reentrancy
         origin: community
   patterns:
   - pattern: "$X.tokensReceived(...);"
@@ -42074,10 +42093,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67656
-        rv_id: 110684
+        rv_id: 834885
         rule_id: 4bUPoB
-        version_id: 5PTdeLl
-        url: https://semgrep.dev/playground/r/5PTdeLl/solidity.security.incorrect-use-of-blockhash.incorrect-use-of-blockhash
+        version_id: jQTrjwW
+        url: https://semgrep.dev/playground/r/jQTrjwW/solidity.security.incorrect-use-of-blockhash.incorrect-use-of-blockhash
         origin: community
   patterns:
   - pattern-either:
@@ -42117,10 +42136,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67657
-        rv_id: 110685
+        rv_id: 834886
         rule_id: PeUrYv
-        version_id: GxTv8r5
-        url: https://semgrep.dev/playground/r/GxTv8r5/solidity.security.keeper-network-oracle-manipulation.keeper-network-oracle-manipulation
+        version_id: 1QTPN46
+        url: https://semgrep.dev/playground/r/1QTPN46/solidity.security.keeper-network-oracle-manipulation.keeper-network-oracle-manipulation
         origin: community
   patterns:
   - pattern: "$KEEPER.current($TOKENIN, $AMOUNTIN, $TOKENOUT);"
@@ -42159,10 +42178,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 133075
-        rv_id: 751093
+        rv_id: 834887
         rule_id: 6JUv7Nz
-        version_id: 6xTEXKQ
-        url: https://semgrep.dev/playground/r/6xTEXKQ/solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
+        version_id: 9lTJ7Ap
+        url: https://semgrep.dev/playground/r/9lTJ7Ap/solidity.security.missing-self-transfer-check-ercx.missing-self-transfer-check-ercx
         origin: community
   patterns:
   - pattern-either:
@@ -42206,10 +42225,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67660
-        rv_id: 110688
+        rv_id: 834890
         rule_id: GdUE2p
-        version_id: BjTXpdl
-        url: https://semgrep.dev/playground/r/BjTXpdl/solidity.security.no-slippage-check.no-slippage-check
+        version_id: bZTBoLe
+        url: https://semgrep.dev/playground/r/bZTBoLe/solidity.security.no-slippage-check.no-slippage-check
         origin: community
   patterns:
   - pattern-either:
@@ -42296,10 +42315,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67663
-        rv_id: 110691
+        rv_id: 834893
         rule_id: BYU0EL
-        version_id: 0bTLe2n
-        url: https://semgrep.dev/playground/r/0bTLe2n/solidity.security.proxy-storage-collision.proxy-storage-collision
+        version_id: w8TAbkL
+        url: https://semgrep.dev/playground/r/w8TAbkL/solidity.security.proxy-storage-collision.proxy-storage-collision
         origin: community
   patterns:
   - pattern-either:
@@ -42383,10 +42402,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67664
-        rv_id: 110692
+        rv_id: 834894
         rule_id: DbU0Qb
-        version_id: K3TvG71
-        url: https://semgrep.dev/playground/r/K3TvG71/solidity.security.redacted-cartel-custom-approval-bug.redacted-cartel-custom-approval-bug
+        version_id: xyTNrdo
+        url: https://semgrep.dev/playground/r/xyTNrdo/solidity.security.redacted-cartel-custom-approval-bug.redacted-cartel-custom-approval-bug
         origin: community
   patterns:
   - pattern-inside: |
@@ -42421,10 +42440,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67665
-        rv_id: 110693
+        rv_id: 834895
         rule_id: WAUpbw
-        version_id: qkT2BX8
-        url: https://semgrep.dev/playground/r/qkT2BX8/solidity.security.rigoblock-missing-access-control.rigoblock-missing-access-control
+        version_id: O9TJ7ve
+        url: https://semgrep.dev/playground/r/O9TJ7ve/solidity.security.rigoblock-missing-access-control.rigoblock-missing-access-control
         origin: community
   patterns:
   - pattern: function setMultipleAllowances(...) {...}
@@ -42455,10 +42474,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67666
-        rv_id: 110694
+        rv_id: 834896
         rule_id: 0oUbvd
-        version_id: l4T468O
-        url: https://semgrep.dev/playground/r/l4T468O/solidity.security.sense-missing-oracle-access-control.sense-missing-oracle-access-control
+        version_id: e1TDKZ6
+        url: https://semgrep.dev/playground/r/e1TDKZ6/solidity.security.sense-missing-oracle-access-control.sense-missing-oracle-access-control
         origin: community
   patterns:
   - pattern-either:
@@ -42519,10 +42538,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67667
-        rv_id: 110695
+        rv_id: 834897
         rule_id: KxUqld
-        version_id: YDTpnDb
-        url: https://semgrep.dev/playground/r/YDTpnDb/solidity.security.superfluid-ctx-injection.superfluid-ctx-injection
+        version_id: vdTOQv2
+        url: https://semgrep.dev/playground/r/vdTOQv2/solidity.security.superfluid-ctx-injection.superfluid-ctx-injection
         origin: community
   patterns:
   - pattern: "$T.decodeCtx(ctx);"
@@ -42555,10 +42574,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 67668
-        rv_id: 110696
+        rv_id: 834898
         rule_id: qNUnN0
-        version_id: JdTNvLx
-        url: https://semgrep.dev/playground/r/JdTNvLx/solidity.security.tecra-coin-burnfrom-bug.tecra-coin-burnfrom-bug
+        version_id: d6TKg6R
+        url: https://semgrep.dev/playground/r/d6TKg6R/solidity.security.tecra-coin-burnfrom-bug.tecra-coin-burnfrom-bug
         origin: community
   patterns:
   - pattern-inside: |
@@ -42606,10 +42625,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 66512
-        rv_id: 110700
+        rv_id: 834902
         rule_id: KxUqoZ
-        version_id: A8T9XQ6
-        url: https://semgrep.dev/playground/r/A8T9XQ6/swift.lang.storage.sensitive-storage-userdefaults.swift-user-defaults
+        version_id: 7ZTxRrD
+        url: https://semgrep.dev/playground/r/7ZTxRrD/swift.lang.storage.sensitive-storage-userdefaults.swift-user-defaults
         origin: community
   languages:
   - swift
@@ -42830,10 +42849,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17342
-        rv_id: 253876
+        rv_id: 834930
         rule_id: kxU6A8
-        version_id: jQTlOqE
-        url: https://semgrep.dev/playground/r/jQTlOqE/terraform.aws.security.aws-cloudfront-insecure-tls.aws-insecure-cloudfront-distribution-tls-version
+        version_id: 1QTPNo6
+        url: https://semgrep.dev/playground/r/1QTPNo6/terraform.aws.security.aws-cloudfront-insecure-tls.aws-insecure-cloudfront-distribution-tls-version
         origin: community
   languages:
   - hcl
@@ -42879,10 +42898,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17344
-        rv_id: 110730
+        rv_id: 834932
         rule_id: x8UGBG
-        version_id: nWTxoG1
-        url: https://semgrep.dev/playground/r/nWTxoG1/terraform.aws.security.aws-cloudwatch-log-group-no-retention.aws-cloudwatch-log-group-no-retention
+        version_id: yeTNg0K
+        url: https://semgrep.dev/playground/r/yeTNg0K/terraform.aws.security.aws-cloudwatch-log-group-no-retention.aws-cloudwatch-log-group-no-retention
         origin: community
 - id: terraform.aws.security.aws-codebuild-project-unencrypted.aws-codebuild-project-unencrypted
   patterns:
@@ -42926,10 +42945,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17347
-        rv_id: 110734
+        rv_id: 834936
         rule_id: v8U4kG
-        version_id: 8KTQyAR
-        url: https://semgrep.dev/playground/r/8KTQyAR/terraform.aws.security.aws-codebuild-project-unencrypted.aws-codebuild-project-unencrypted
+        version_id: kbT2PYG
+        url: https://semgrep.dev/playground/r/kbT2PYG/terraform.aws.security.aws-codebuild-project-unencrypted.aws-codebuild-project-unencrypted
         origin: community
 - id: terraform.aws.security.aws-db-instance-no-logging.aws-db-instance-no-logging
   patterns:
@@ -42973,10 +42992,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17348
-        rv_id: 110736
+        rv_id: 834938
         rule_id: d8U4RA
-        version_id: QkTWwnx
-        url: https://semgrep.dev/playground/r/QkTWwnx/terraform.aws.security.aws-db-instance-no-logging.aws-db-instance-no-logging
+        version_id: xyTNrqo
+        url: https://semgrep.dev/playground/r/xyTNrqo/terraform.aws.security.aws-db-instance-no-logging.aws-db-instance-no-logging
         origin: community
 - id: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
   patterns:
@@ -43025,10 +43044,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17350
-        rv_id: 110741
+        rv_id: 834943
         rule_id: nJUGe2
-        version_id: 5PTdepz
-        url: https://semgrep.dev/playground/r/5PTdepz/terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
+        version_id: ZRTld3j
+        url: https://semgrep.dev/playground/r/ZRTld3j/terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
         origin: community
 - id: terraform.aws.security.aws-ebs-snapshot-encrypted-with-cmk.aws-ebs-snapshot-encrypted-with-cmk
   patterns:
@@ -43071,10 +43090,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17351
-        rv_id: 110742
+        rv_id: 834944
         rule_id: EwUqko
-        version_id: GxTv8zA
-        url: https://semgrep.dev/playground/r/GxTv8zA/terraform.aws.security.aws-ebs-snapshot-encrypted-with-cmk.aws-ebs-snapshot-encrypted-with-cmk
+        version_id: nWTyNPW
+        url: https://semgrep.dev/playground/r/nWTyNPW/terraform.aws.security.aws-ebs-snapshot-encrypted-with-cmk.aws-ebs-snapshot-encrypted-with-cmk
         origin: community
   languages:
   - hcl
@@ -43116,10 +43135,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17352
-        rv_id: 110743
+        rv_id: 834945
         rule_id: 7KUW7K
-        version_id: RGTDRq5
-        url: https://semgrep.dev/playground/r/RGTDRq5/terraform.aws.security.aws-ebs-unencrypted.aws-ebs-unencrypted
+        version_id: ExTrWNj
+        url: https://semgrep.dev/playground/r/ExTrWNj/terraform.aws.security.aws-ebs-unencrypted.aws-ebs-unencrypted
         origin: community
 - id: terraform.aws.security.aws-ec2-has-public-ip.aws-ec2-has-public-ip
   patterns:
@@ -43168,10 +43187,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17354
-        rv_id: 110746
+        rv_id: 834948
         rule_id: 8GUA2n
-        version_id: DkT6Yx8
-        url: https://semgrep.dev/playground/r/DkT6Yx8/terraform.aws.security.aws-ec2-has-public-ip.aws-ec2-has-public-ip
+        version_id: 8KTGl9j
+        url: https://semgrep.dev/playground/r/8KTGl9j/terraform.aws.security.aws-ec2-has-public-ip.aws-ec2-has-public-ip
         origin: community
   languages:
   - hcl
@@ -43254,10 +43273,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 48636
-        rv_id: 110754
+        rv_id: 834956
         rule_id: qNUzov
-        version_id: o5Tg9Br
-        url: https://semgrep.dev/playground/r/o5Tg9Br/terraform.aws.security.aws-ecr-repository-wildcard-principal.aws-ecr-repository-wildcard-principal
+        version_id: GxTDX66
+        url: https://semgrep.dev/playground/r/GxTDX66/terraform.aws.security.aws-ecr-repository-wildcard-principal.aws-ecr-repository-wildcard-principal
         origin: community
   languages:
   - hcl
@@ -43304,10 +43323,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 19045
-        rv_id: 110757
+        rv_id: 834958
         rule_id: YGUle7
-        version_id: 2KTz377
-        url: https://semgrep.dev/playground/r/2KTz377/terraform.aws.security.aws-elasticsearch-insecure-tls-version.aws-elasticsearch-insecure-tls-version
+        version_id: A8T3l5g
+        url: https://semgrep.dev/playground/r/A8T3l5g/terraform.aws.security.aws-elasticsearch-insecure-tls-version.aws-elasticsearch-insecure-tls-version
         origin: community
 - id: terraform.aws.security.aws-elasticsearch-nodetonode-encryption.aws-elasticsearch-nodetonode-encryption-not-enabled
   patterns:
@@ -43374,10 +43393,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17357
-        rv_id: 110758
+        rv_id: 834959
         rule_id: 3qU6J7
-        version_id: X0TQ25A
-        url: https://semgrep.dev/playground/r/X0TQ25A/terraform.aws.security.aws-elasticsearch-nodetonode-encryption.aws-elasticsearch-nodetonode-encryption-not-enabled
+        version_id: BjTeLrb
+        url: https://semgrep.dev/playground/r/BjTeLrb/terraform.aws.security.aws-elasticsearch-nodetonode-encryption.aws-elasticsearch-nodetonode-encryption-not-enabled
         origin: community
   languages:
   - hcl
@@ -43436,10 +43455,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17364
-        rv_id: 110765
+        rv_id: 834966
         rule_id: AbUeYK
-        version_id: NdT3oBG
-        url: https://semgrep.dev/playground/r/NdT3oBG/terraform.aws.security.aws-glacier-vault-any-principal.aws-glacier-vault-any-principal
+        version_id: YDTlb2x
+        url: https://semgrep.dev/playground/r/YDTlb2x/terraform.aws.security.aws-glacier-vault-any-principal.aws-glacier-vault-any-principal
         origin: community
   languages:
   - hcl
@@ -43499,10 +43518,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17365
-        rv_id: 110766
+        rv_id: 834967
         rule_id: BYUzY5
-        version_id: kbTdL25
-        url: https://semgrep.dev/playground/r/kbTdL25/terraform.aws.security.aws-iam-admin-policy-ssoadmin.aws-iam-admin-policy-ssoadmin
+        version_id: JdTlRpO
+        url: https://semgrep.dev/playground/r/JdTlRpO/terraform.aws.security.aws-iam-admin-policy-ssoadmin.aws-iam-admin-policy-ssoadmin
         origin: community
   languages:
   - hcl
@@ -43563,10 +43582,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17366
-        rv_id: 110767
+        rv_id: 834968
         rule_id: DbUx8l
-        version_id: w8T9DAy
-        url: https://semgrep.dev/playground/r/w8T9DAy/terraform.aws.security.aws-iam-admin-policy.aws-iam-admin-policy
+        version_id: 5PTyGAl
+        url: https://semgrep.dev/playground/r/5PTyGAl/terraform.aws.security.aws-iam-admin-policy.aws-iam-admin-policy
         origin: community
   languages:
   - hcl
@@ -43631,10 +43650,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 18818
-        rv_id: 110769
+        rv_id: 834970
         rule_id: v8UOle
-        version_id: O9TNdJ4
-        url: https://semgrep.dev/playground/r/O9TNdJ4/terraform.aws.security.aws-insecure-api-gateway-tls-version.aws-insecure-api-gateway-tls-version
+        version_id: RGTKxkZ
+        url: https://semgrep.dev/playground/r/RGTKxkZ/terraform.aws.security.aws-insecure-api-gateway-tls-version.aws-insecure-api-gateway-tls-version
         origin: community
 - id: terraform.aws.security.aws-insecure-redshift-ssl-configuration.aws-insecure-redshift-ssl-configuration
   patterns:
@@ -43687,10 +43706,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17368
-        rv_id: 110770
+        rv_id: 834971
         rule_id: 0oUrOj
-        version_id: e1T03Dw
-        url: https://semgrep.dev/playground/r/e1T03Dw/terraform.aws.security.aws-insecure-redshift-ssl-configuration.aws-insecure-redshift-ssl-configuration
+        version_id: A8T3l5O
+        url: https://semgrep.dev/playground/r/A8T3l5O/terraform.aws.security.aws-insecure-redshift-ssl-configuration.aws-insecure-redshift-ssl-configuration
         origin: community
   languages:
   - hcl
@@ -43753,10 +43772,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17371
-        rv_id: 110774
+        rv_id: 834975
         rule_id: lBUWPD
-        version_id: nWTxoy1
-        url: https://semgrep.dev/playground/r/nWTxoy1/terraform.aws.security.aws-kms-key-wildcard-principal.aws-kms-key-wildcard-principal
+        version_id: 0bTw3ln
+        url: https://semgrep.dev/playground/r/0bTw3ln/terraform.aws.security.aws-kms-key-wildcard-principal.aws-kms-key-wildcard-principal
         origin: community
   languages:
   - hcl
@@ -43823,10 +43842,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17372
-        rv_id: 110775
+        rv_id: 834976
         rule_id: PeU0L3
-        version_id: ExTjArL
-        url: https://semgrep.dev/playground/r/ExTjArL/terraform.aws.security.aws-kms-no-rotation.aws-kms-no-rotation
+        version_id: K3TrLj1
+        url: https://semgrep.dev/playground/r/K3TrLj1/terraform.aws.security.aws-kms-no-rotation.aws-kms-no-rotation
         origin: community
 - id: terraform.aws.security.aws-lambda-environment-credentials.aws-lambda-environment-credentials
   patterns:
@@ -43881,10 +43900,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17373
-        rv_id: 110776
+        rv_id: 834977
         rule_id: JDU6gj
-        version_id: 7ZTgnxG
-        url: https://semgrep.dev/playground/r/7ZTgnxG/terraform.aws.security.aws-lambda-environment-credentials.aws-lambda-environment-credentials
+        version_id: qkTQwx8
+        url: https://semgrep.dev/playground/r/qkTQwx8/terraform.aws.security.aws-lambda-environment-credentials.aws-lambda-environment-credentials
         origin: community
   languages:
   - hcl
@@ -43941,10 +43960,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 54772
-        rv_id: 110778
+        rv_id: 834979
         rule_id: OrU9Ox
-        version_id: 8KTQyGR
-        url: https://semgrep.dev/playground/r/8KTQyGR/terraform.aws.security.aws-lambda-permission-unrestricted-source-arn.aws-lambda-permission-unrestricted-source-arn
+        version_id: YDTlb2b
+        url: https://semgrep.dev/playground/r/YDTlb2b/terraform.aws.security.aws-lambda-permission-unrestricted-source-arn.aws-lambda-permission-unrestricted-source-arn
         origin: community
 - id: terraform.aws.security.aws-provider-static-credentials.aws-provider-static-credentials
   patterns:
@@ -43989,10 +44008,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 16439
-        rv_id: 110783
+        rv_id: 834984
         rule_id: d8U4n0
-        version_id: PkTJdxG
-        url: https://semgrep.dev/playground/r/PkTJdxG/terraform.aws.security.aws-provider-static-credentials.aws-provider-static-credentials
+        version_id: 2KT7OrD
+        url: https://semgrep.dev/playground/r/2KT7OrD/terraform.aws.security.aws-provider-static-credentials.aws-provider-static-credentials
         origin: community
 - id: terraform.aws.security.aws-rds-backup-no-retention.aws-rds-backup-no-retention
   patterns:
@@ -44038,10 +44057,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17375
-        rv_id: 110785
+        rv_id: 834986
         rule_id: GdUzwQ
-        version_id: 5PTdeyz
-        url: https://semgrep.dev/playground/r/5PTdeyz/terraform.aws.security.aws-rds-backup-no-retention.aws-rds-backup-no-retention
+        version_id: jQTrjYZ
+        url: https://semgrep.dev/playground/r/jQTrjYZ/terraform.aws.security.aws-rds-backup-no-retention.aws-rds-backup-no-retention
         origin: community
 - id: terraform.aws.security.aws-sqs-queue-policy-wildcard-principal.aws-sqs-queue-policy-wildcard-principal
   patterns:
@@ -44128,10 +44147,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 53517
-        rv_id: 110793
+        rv_id: 834994
         rule_id: PeUl9d
-        version_id: K3TvGwv
-        url: https://semgrep.dev/playground/r/K3TvGwv/terraform.aws.security.aws-sqs-queue-policy-wildcard-principal.aws-sqs-queue-policy-wildcard-principal
+        version_id: w8TAbDG
+        url: https://semgrep.dev/playground/r/w8TAbDG/terraform.aws.security.aws-sqs-queue-policy-wildcard-principal.aws-sqs-queue-policy-wildcard-principal
         origin: community
   languages:
   - hcl
@@ -44202,10 +44221,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14966
-        rv_id: 110801
+        rv_id: 835002
         rule_id: 2ZUP9K
-        version_id: A8T9XN3
-        url: https://semgrep.dev/playground/r/A8T9XN3/terraform.aws.security.insecure-load-balancer-tls-version.insecure-load-balancer-tls-version
+        version_id: ExTrWAE
+        url: https://semgrep.dev/playground/r/ExTrWAE/terraform.aws.security.insecure-load-balancer-tls-version.insecure-load-balancer-tls-version
         origin: community
   languages:
   - hcl
@@ -44255,10 +44274,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15139
-        rv_id: 110804
+        rv_id: 835005
         rule_id: 5rUL1P
-        version_id: WrTW3YQ
-        url: https://semgrep.dev/playground/r/WrTW3YQ/terraform.aws.security.wildcard-assume-role.wildcard-assume-role
+        version_id: 8KTGlyg
+        url: https://semgrep.dev/playground/r/8KTGlyg/terraform.aws.security.wildcard-assume-role.wildcard-assume-role
         origin: community
   languages:
   - hcl
@@ -44321,10 +44340,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15102
-        rv_id: 110865
+        rv_id: 835066
         rule_id: 0oU23p
-        version_id: bZTb9Xr
-        url: https://semgrep.dev/playground/r/bZTb9Xr/terraform.azure.security.appservice.appservice-authentication-enabled.appservice-authentication-enabled
+        version_id: l4TyDJO
+        url: https://semgrep.dev/playground/r/l4TyDJO/terraform.azure.security.appservice.appservice-authentication-enabled.appservice-authentication-enabled
         origin: community
   languages:
   - hcl
@@ -44384,10 +44403,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15103
-        rv_id: 110866
+        rv_id: 835067
         rule_id: KxU7LJ
-        version_id: NdT3oqP
-        url: https://semgrep.dev/playground/r/NdT3oqP/terraform.azure.security.appservice.appservice-enable-http2.appservice-enable-http2
+        version_id: YDTlbZb
+        url: https://semgrep.dev/playground/r/YDTlbZb/terraform.azure.security.appservice.appservice-enable-http2.appservice-enable-http2
         origin: community
   languages:
   - hcl
@@ -44440,10 +44459,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15104
-        rv_id: 110867
+        rv_id: 835068
         rule_id: qNUXwx
-        version_id: kbTdLYJ
-        url: https://semgrep.dev/playground/r/kbTdLYJ/terraform.azure.security.appservice.appservice-enable-https-only.appservice-enable-https-only
+        version_id: JdTlRzx
+        url: https://semgrep.dev/playground/r/JdTlRzx/terraform.azure.security.appservice.appservice-enable-https-only.appservice-enable-https-only
         origin: community
   languages:
   - hcl
@@ -44495,10 +44514,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15105
-        rv_id: 110868
+        rv_id: 835069
         rule_id: lBU8D6
-        version_id: w8T9DKO
-        url: https://semgrep.dev/playground/r/w8T9DKO/terraform.azure.security.appservice.appservice-require-client-cert.appservice-require-client-cert
+        version_id: 5PTyGoz
+        url: https://semgrep.dev/playground/r/5PTyGoz/terraform.azure.security.appservice.appservice-require-client-cert.appservice-require-client-cert
         origin: community
   languages:
   - hcl
@@ -44538,10 +44557,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15106
-        rv_id: 110869
+        rv_id: 835070
         rule_id: YGUDbZ
-        version_id: xyTKpq7
-        url: https://semgrep.dev/playground/r/xyTKpq7/terraform.azure.security.appservice.appservice-use-secure-tls-policy.appservice-use-secure-tls-policy
+        version_id: GxTDXkA
+        url: https://semgrep.dev/playground/r/GxTDXkA/terraform.azure.security.appservice.appservice-use-secure-tls-policy.appservice-use-secure-tls-policy
         origin: community
   languages:
   - hcl
@@ -44589,10 +44608,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23962
-        rv_id: 110872
+        rv_id: 835073
         rule_id: bwU1Eg
-        version_id: vdTY8G6
-        url: https://semgrep.dev/playground/r/vdTY8G6/terraform.azure.security.appservice.azure-appservice-detailed-errormessages-enabled.azure-appservice-detailed-errormessages-enabled
+        version_id: BjTeLkE
+        url: https://semgrep.dev/playground/r/BjTeLkE/terraform.azure.security.appservice.azure-appservice-detailed-errormessages-enabled.azure-appservice-detailed-errormessages-enabled
         origin: community
   languages:
   - hcl
@@ -44637,10 +44656,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23966
-        rv_id: 110876
+        rv_id: 835077
         rule_id: x8UZRP
-        version_id: ExTjAg9
-        url: https://semgrep.dev/playground/r/ExTjAg9/terraform.azure.security.appservice.azure-appservice-https-only.azure-appservice-https-only
+        version_id: K3TrLov
+        url: https://semgrep.dev/playground/r/K3TrLov/terraform.azure.security.appservice.azure-appservice-https-only.azure-appservice-https-only
         origin: community
   languages:
   - hcl
@@ -44683,10 +44702,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23990
-        rv_id: 110900
+        rv_id: 835101
         rule_id: 0oUlgp
-        version_id: GxTv86W
-        url: https://semgrep.dev/playground/r/GxTv86W/terraform.azure.security.azure-key-no-expiration-date.azure-key-no-expiration-date
+        version_id: ZRTld21
+        url: https://semgrep.dev/playground/r/ZRTld21/terraform.azure.security.azure-key-no-expiration-date.azure-key-no-expiration-date
         origin: community
   languages:
   - hcl
@@ -44731,10 +44750,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23995
-        rv_id: 110905
+        rv_id: 835106
         rule_id: 6JUJG8
-        version_id: WrTW3Q2
-        url: https://semgrep.dev/playground/r/WrTW3Q2/terraform.azure.security.azure-mssql-service-mintls-version.azure-mssql-service-mintls-version
+        version_id: 8KTGlNR
+        url: https://semgrep.dev/playground/r/8KTGlNR/terraform.azure.security.azure-mssql-service-mintls-version.azure-mssql-service-mintls-version
         origin: community
   languages:
   - hcl
@@ -44777,10 +44796,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23996
-        rv_id: 110906
+        rv_id: 835107
         rule_id: oqUloL
-        version_id: 0bTLelY
-        url: https://semgrep.dev/playground/r/0bTLelY/terraform.azure.security.azure-mysql-encryption-enabled.azure-mysql-encryption-enabled
+        version_id: gETyXPK
+        url: https://semgrep.dev/playground/r/gETyXPK/terraform.azure.security.azure-mysql-encryption-enabled.azure-mysql-encryption-enabled
         origin: community
   languages:
   - hcl
@@ -44825,10 +44844,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 23997
-        rv_id: 110907
+        rv_id: 835108
         rule_id: zdU8NN
-        version_id: K3TvGjD
-        url: https://semgrep.dev/playground/r/K3TvGjD/terraform.azure.security.azure-mysql-mintls-version.azure-mysql-mintls-version
+        version_id: QkTkNXx
+        url: https://semgrep.dev/playground/r/QkTkNXx/terraform.azure.security.azure-mysql-mintls-version.azure-mysql-mintls-version
         origin: community
   languages:
   - hcl
@@ -44870,10 +44889,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15133
-        rv_id: 110929
+        rv_id: 835130
         rule_id: gxUgXq
-        version_id: vdTY885
-        url: https://semgrep.dev/playground/r/vdTY885/terraform.azure.security.keyvault.keyvault-ensure-key-expires.keyvault-ensure-key-expires
+        version_id: X0T5KYA
+        url: https://semgrep.dev/playground/r/X0T5KYA/terraform.azure.security.keyvault.keyvault-ensure-key-expires.keyvault-ensure-key-expires
         origin: community
   languages:
   - hcl
@@ -44915,10 +44934,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15134
-        rv_id: 110930
+        rv_id: 835131
         rule_id: QrUdNy
-        version_id: d6Trvvl
-        url: https://semgrep.dev/playground/r/d6Trvvl/terraform.azure.security.keyvault.keyvault-ensure-secret-expires.keyvault-ensure-secret-expires
+        version_id: jQTrj1z
+        url: https://semgrep.dev/playground/r/jQTrj1z/terraform.azure.security.keyvault.keyvault-ensure-secret-expires.keyvault-ensure-secret-expires
         origin: community
   languages:
   - hcl
@@ -44967,10 +44986,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15135
-        rv_id: 110931
+        rv_id: 835132
         rule_id: 3qUjw9
-        version_id: ZRTQppO
-        url: https://semgrep.dev/playground/r/ZRTQppO/terraform.azure.security.keyvault.keyvault-purge-enabled.keyvault-purge-enabled
+        version_id: 1QTPNEY
+        url: https://semgrep.dev/playground/r/1QTPNEY/terraform.azure.security.keyvault.keyvault-purge-enabled.keyvault-purge-enabled
         origin: community
   languages:
   - hcl
@@ -45017,10 +45036,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15110
-        rv_id: 110935
+        rv_id: 835136
         rule_id: pKUpDA
-        version_id: LjTqAAX
-        url: https://semgrep.dev/playground/r/LjTqAAX/terraform.azure.security.storage.storage-enforce-https.storage-enforce-https
+        version_id: bZTBoEE
+        url: https://semgrep.dev/playground/r/bZTBoEE/terraform.azure.security.storage.storage-enforce-https.storage-enforce-https
         origin: community
   languages:
   - hcl
@@ -45074,10 +45093,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15155
-        rv_id: 110937
+        rv_id: 835138
         rule_id: AbUQdL
-        version_id: gET3OOO
-        url: https://semgrep.dev/playground/r/gET3OOO/terraform.azure.security.storage.storage-use-secure-tls-policy.storage-use-secure-tls-policy
+        version_id: kbT2PW5
+        url: https://semgrep.dev/playground/r/kbT2PW5/terraform.azure.security.storage.storage-use-secure-tls-policy.storage-use-secure-tls-policy
         origin: community
   languages:
   - hcl
@@ -45119,10 +45138,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 32303
-        rv_id: 110971
+        rv_id: 835172
         rule_id: gxUrdg
-        version_id: O9TNdpn
-        url: https://semgrep.dev/playground/r/O9TNdpn/terraform.gcp.security.gcp-cloud-storage-logging.gcp-cloud-storage-logging
+        version_id: RGTKxnq
+        url: https://semgrep.dev/playground/r/RGTKxnq/terraform.gcp.security.gcp-cloud-storage-logging.gcp-cloud-storage-logging
         origin: community
 - id: terraform.gcp.security.gcp-dns-key-specs-rsasha1.gcp-dns-key-specs-rsasha1
   patterns:
@@ -45184,10 +45203,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33670
-        rv_id: 110997
+        rv_id: 835198
         rule_id: 7KUZZb
-        version_id: l4T46Jb
-        url: https://semgrep.dev/playground/r/l4T46Jb/terraform.gcp.security.gcp-dns-key-specs-rsasha1.gcp-dns-key-specs-rsasha1
+        version_id: O9TJ7EW
+        url: https://semgrep.dev/playground/r/O9TJ7EW/terraform.gcp.security.gcp-dns-key-specs-rsasha1.gcp-dns-key-specs-rsasha1
         origin: community
   languages:
   - hcl
@@ -45236,10 +45255,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33709
-        rv_id: 111037
+        rv_id: 835238
         rule_id: v8Uod5
-        version_id: 8KTQyNO
-        url: https://semgrep.dev/playground/r/8KTQyNO/terraform.gcp.security.gcp-sql-database-require-ssl.gcp-sql-database-require-ssl
+        version_id: NdTBRJP
+        url: https://semgrep.dev/playground/r/NdTBRJP/terraform.gcp.security.gcp-sql-database-require-ssl.gcp-sql-database-require-ssl
         origin: community
   languages:
   - hcl
@@ -45306,10 +45325,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33710
-        rv_id: 111038
+        rv_id: 835239
         rule_id: d8U7Ll
-        version_id: gET3OPo
-        url: https://semgrep.dev/playground/r/gET3OPo/terraform.gcp.security.gcp-sql-public-database.gcp-sql-public-database
+        version_id: kbT2P5J
+        url: https://semgrep.dev/playground/r/kbT2P5J/terraform.gcp.security.gcp-sql-public-database.gcp-sql-public-database
         origin: community
   languages:
   - hcl
@@ -45345,10 +45364,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11302
-        rv_id: 111049
+        rv_id: 835249
         rule_id: GdU0eA
-        version_id: DkT6Ykj
-        url: https://semgrep.dev/playground/r/DkT6Ykj/terraform.lang.security.ec2-imdsv1-optional.ec2-imdsv1-optional
+        version_id: 7ZTxRPO
+        url: https://semgrep.dev/playground/r/7ZTxRPO/terraform.lang.security.ec2-imdsv1-optional.ec2-imdsv1-optional
         origin: community
   pattern-either:
   - patterns:
@@ -45441,10 +45460,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15830
-        rv_id: 111062
+        rv_id: 835262
         rule_id: OrUl6W
-        version_id: jQTgy1R
-        url: https://semgrep.dev/playground/r/jQTgy1R/terraform.lang.security.rds-insecure-password-storage-in-source-code.rds-insecure-password-storage-in-source-code
+        version_id: BjTeL8K
+        url: https://semgrep.dev/playground/r/BjTeL8K/terraform.lang.security.rds-insecure-password-storage-in-source-code.rds-insecure-password-storage-in-source-code
         origin: community
 - id: terraform.lang.security.s3-public-rw-bucket.s3-public-rw-bucket
   pattern: acl = "public-read-write"
@@ -45478,10 +45497,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9754
-        rv_id: 111066
+        rv_id: 835266
         rule_id: 6JUqvn
-        version_id: rxTy4nj
-        url: https://semgrep.dev/playground/r/rxTy4nj/terraform.lang.security.s3-public-rw-bucket.s3-public-rw-bucket
+        version_id: K3TrLQK
+        url: https://semgrep.dev/playground/r/K3TrLQK/terraform.lang.security.s3-public-rw-bucket.s3-public-rw-bucket
         origin: community
 - id: typescript.angular.security.audit.angular-domsanitizer.angular-bypasssecuritytrust
   message: Detected the use of `$TRUST`. This can introduce a Cross-Site-Scripting
@@ -45517,10 +45536,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9755
-        rv_id: 111068
+        rv_id: 835268
         rule_id: oqUzgA
-        version_id: NdT3o6d
-        url: https://semgrep.dev/playground/r/NdT3o6d/typescript.angular.security.audit.angular-domsanitizer.angular-bypasssecuritytrust
+        version_id: l4TyD2p
+        url: https://semgrep.dev/playground/r/l4TyD2p/typescript.angular.security.audit.angular-domsanitizer.angular-bypasssecuritytrust
         origin: community
   languages:
   - typescript
@@ -45655,10 +45674,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15276
-        rv_id: 111069
+        rv_id: 835269
         rule_id: bwU8qz
-        version_id: kbTdLWL
-        url: https://semgrep.dev/playground/r/kbTdLWL/typescript.aws-cdk.security.audit.awscdk-bucket-encryption.awscdk-bucket-encryption
+        version_id: YDTlbOk
+        url: https://semgrep.dev/playground/r/YDTlbOk/typescript.aws-cdk.security.audit.awscdk-bucket-encryption.awscdk-bucket-encryption
         origin: community
   languages:
   - typescript
@@ -45726,10 +45745,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15277
-        rv_id: 111070
+        rv_id: 835270
         rule_id: NbUN8B
-        version_id: w8T9DWR
-        url: https://semgrep.dev/playground/r/w8T9DWR/typescript.aws-cdk.security.audit.awscdk-bucket-enforcessl.aws-cdk-bucket-enforcessl
+        version_id: JdTlReK
+        url: https://semgrep.dev/playground/r/JdTlReK/typescript.aws-cdk.security.audit.awscdk-bucket-enforcessl.aws-cdk-bucket-enforcessl
         origin: community
   languages:
   - ts
@@ -45779,10 +45798,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15278
-        rv_id: 111071
+        rv_id: 835271
         rule_id: kxUwqO
-        version_id: xyTKpR8
-        url: https://semgrep.dev/playground/r/xyTKpR8/typescript.aws-cdk.security.audit.awscdk-sqs-unencryptedqueue.awscdk-sqs-unencryptedqueue
+        version_id: 5PTyG33
+        url: https://semgrep.dev/playground/r/5PTyG33/typescript.aws-cdk.security.audit.awscdk-sqs-unencryptedqueue.awscdk-sqs-unencryptedqueue
         origin: community
   languages:
   - ts
@@ -45842,10 +45861,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15279
-        rv_id: 111072
+        rv_id: 835272
         rule_id: wdUjZK
-        version_id: O9TNdQQ
-        url: https://semgrep.dev/playground/r/O9TNdQQ/typescript.aws-cdk.security.awscdk-bucket-grantpublicaccessmethod.awscdk-bucket-grantpublicaccessmethod
+        version_id: GxTDXJW
+        url: https://semgrep.dev/playground/r/GxTDXJW/typescript.aws-cdk.security.awscdk-bucket-grantpublicaccessmethod.awscdk-bucket-grantpublicaccessmethod
         origin: community
   languages:
   - ts
@@ -45896,10 +45915,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 15280
-        rv_id: 111073
+        rv_id: 835273
         rule_id: x8UxXZ
-        version_id: e1T034b
-        url: https://semgrep.dev/playground/r/e1T034b/typescript.aws-cdk.security.awscdk-codebuild-project-public.awscdk-codebuild-project-public
+        version_id: RGTKxrB
+        url: https://semgrep.dev/playground/r/RGTKxrB/typescript.aws-cdk.security.awscdk-codebuild-project-public.awscdk-codebuild-project-public
         origin: community
   languages:
   - ts
@@ -45951,10 +45970,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9769
-        rv_id: 111091
+        rv_id: 835290
         rule_id: x8UWvK
-        version_id: A8T9XEl
-        url: https://semgrep.dev/playground/r/A8T9XEl/typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml
+        version_id: 1QTPNkl
+        url: https://semgrep.dev/playground/r/1QTPNkl/typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml
         origin: community
   languages:
   - typescript
@@ -46109,10 +46128,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9781
-        rv_id: 111103
+        rv_id: 835294
         rule_id: QrU68w
-        version_id: RGTDRnQ
-        url: https://semgrep.dev/playground/r/RGTDRnQ/typescript.react.security.audit.react-unsanitized-method.react-unsanitized-method
+        version_id: bZTBo6k
+        url: https://semgrep.dev/playground/r/bZTBo6k/typescript.react.security.audit.react-unsanitized-method.react-unsanitized-method
         origin: community
   languages:
   - typescript
@@ -46264,10 +46283,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9782
-        rv_id: 111104
+        rv_id: 835295
         rule_id: 3qUBl4
-        version_id: A8T9X0z
-        url: https://semgrep.dev/playground/r/A8T9X0z/typescript.react.security.audit.react-unsanitized-property.react-unsanitized-property
+        version_id: NdTBRrn
+        url: https://semgrep.dev/playground/r/NdTBRrn/typescript.react.security.audit.react-unsanitized-property.react-unsanitized-property
         origin: community
   languages:
   - typescript
@@ -46432,10 +46451,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9766
-        rv_id: 111106
+        rv_id: 835296
         rule_id: NbUA3O
-        version_id: DkT6YXK
-        url: https://semgrep.dev/playground/r/DkT6YXK/typescript.react.security.react-insecure-request.react-insecure-request
+        version_id: kbT2PZK
+        url: https://semgrep.dev/playground/r/kbT2PZK/typescript.react.security.react-insecure-request.react-insecure-request
         origin: community
   languages:
   - typescript
@@ -46510,10 +46529,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40768
-        rv_id: 111108
+        rv_id: 835299
         rule_id: 10U0zW
-        version_id: 0bTLegr
-        url: https://semgrep.dev/playground/r/0bTLegr/yaml.argo.security.argo-workflow-parameter-command-injection.argo-workflow-parameter-command-injection
+        version_id: O9TJ7Zn
+        url: https://semgrep.dev/playground/r/O9TJ7Zn/yaml.argo.security.argo-workflow-parameter-command-injection.argo-workflow-parameter-command-injection
         origin: community
   severity: ERROR
   patterns:
@@ -46615,10 +46634,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10006
-        rv_id: 111111
+        rv_id: 835302
         rule_id: DbUW17
-        version_id: l4T46ox
-        url: https://semgrep.dev/playground/r/l4T46ox/yaml.docker-compose.security.privileged-service.privileged-service
+        version_id: d6TKgbl
+        url: https://semgrep.dev/playground/r/d6TKgbl/yaml.docker-compose.security.privileged-service.privileged-service
         origin: community
   languages:
   - yaml
@@ -46660,10 +46679,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13412
-        rv_id: 111115
+        rv_id: 835306
         rule_id: EwUQ9x
-        version_id: zyTKDNL
-        url: https://semgrep.dev/playground/r/zyTKDNL/yaml.github-actions.security.allowed-unsecure-commands.allowed-unsecure-commands
+        version_id: 7ZTxRYb
+        url: https://semgrep.dev/playground/r/7ZTxRYb/yaml.github-actions.security.allowed-unsecure-commands.allowed-unsecure-commands
         origin: community
   patterns:
   - pattern-either:
@@ -46706,10 +46725,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 31441
-        rv_id: 111117
+        rv_id: 835309
         rule_id: OrUQvK
-        version_id: 2KTz355
-        url: https://semgrep.dev/playground/r/2KTz355/yaml.github-actions.security.github-script-injection.github-script-injection
+        version_id: gETyX5O
+        url: https://semgrep.dev/playground/r/gETyX5O/yaml.github-actions.security.github-script-injection.github-script-injection
         origin: community
   patterns:
   - pattern-inside: 'steps: [...]'
@@ -46787,10 +46806,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13162
-        rv_id: 111119
+        rv_id: 835311
         rule_id: v8UjQj
-        version_id: jQTgyDN
-        url: https://semgrep.dev/playground/r/jQTgyDN/yaml.github-actions.security.run-shell-injection.run-shell-injection
+        version_id: 3ZT3wxR
+        url: https://semgrep.dev/playground/r/3ZT3wxR/yaml.github-actions.security.run-shell-injection.run-shell-injection
         origin: community
   patterns:
   - pattern-inside: 'steps: [...]'
@@ -46860,10 +46879,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 35494
-        rv_id: 111121
+        rv_id: 835313
         rule_id: 4bU8E4
-        version_id: 9lTd5qE
-        url: https://semgrep.dev/playground/r/9lTd5qE/yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
+        version_id: PkTxGn2
+        url: https://semgrep.dev/playground/r/PkTxGn2/yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
         origin: community
   patterns:
   - pattern-inside: |
@@ -46955,10 +46974,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 47276
-        rv_id: 255675
+        rv_id: 835317
         rule_id: WAU5J6
-        version_id: JdT315R
-        url: https://semgrep.dev/playground/r/JdT315R/yaml.kubernetes.security.allow-privilege-escalation-no-securitycontext.allow-privilege-escalation-no-securitycontext
+        version_id: RGTKxwB
+        url: https://semgrep.dev/playground/r/RGTKxwB/yaml.kubernetes.security.allow-privilege-escalation-no-securitycontext.allow-privilege-escalation-no-securitycontext
         origin: community
   languages:
   - yaml
@@ -47026,10 +47045,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 47277
-        rv_id: 111126
+        rv_id: 835318
         rule_id: 0oUkqQ
-        version_id: kbTdL3y
-        url: https://semgrep.dev/playground/r/kbTdL3y/yaml.kubernetes.security.allow-privilege-escalation-true.allow-privilege-escalation-true
+        version_id: A8T3lnx
+        url: https://semgrep.dev/playground/r/A8T3lnx/yaml.kubernetes.security.allow-privilege-escalation-true.allow-privilege-escalation-true
         origin: community
   languages:
   - yaml
@@ -47100,10 +47119,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10057
-        rv_id: 255676
+        rv_id: 835319
         rule_id: 6JUqEO
-        version_id: 5PTPJk1
-        url: https://semgrep.dev/playground/r/5PTPJk1/yaml.kubernetes.security.allow-privilege-escalation.allow-privilege-escalation
+        version_id: BjTeLG4
+        url: https://semgrep.dev/playground/r/BjTeLG4/yaml.kubernetes.security.allow-privilege-escalation.allow-privilege-escalation
         origin: community
   languages:
   - yaml
@@ -47144,10 +47163,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10133
-        rv_id: 111129
+        rv_id: 835321
         rule_id: d8Uz6v
-        version_id: O9TNdEz
-        url: https://semgrep.dev/playground/r/O9TNdEz/yaml.kubernetes.security.exposing-docker-socket-hostpath.exposing-docker-socket-hostpath
+        version_id: WrTdn62
+        url: https://semgrep.dev/playground/r/WrTdn62/yaml.kubernetes.security.exposing-docker-socket-hostpath.exposing-docker-socket-hostpath
         origin: community
   languages:
   - yaml
@@ -47207,10 +47226,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 73474
-        rv_id: 113538
+        rv_id: 835325
         rule_id: GdUR2A
-        version_id: o5TgbOJ
-        url: https://semgrep.dev/playground/r/o5TgbOJ/yaml.kubernetes.security.legacy-api-clusterrole-excessive-permissions.legacy-api-clusterrole-excessive-permissions
+        version_id: l4TyDNb
+        url: https://semgrep.dev/playground/r/l4TyDNb/yaml.kubernetes.security.legacy-api-clusterrole-excessive-permissions.legacy-api-clusterrole-excessive-permissions
         origin: community
 - id: yaml.kubernetes.security.privileged-container.privileged-container
   pattern-either:
@@ -47261,10 +47280,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10058
-        rv_id: 111133
+        rv_id: 835326
         rule_id: oqUz2p
-        version_id: ZRTQpxY
-        url: https://semgrep.dev/playground/r/ZRTQpxY/yaml.kubernetes.security.privileged-container.privileged-container
+        version_id: YDTlb8W
+        url: https://semgrep.dev/playground/r/YDTlb8W/yaml.kubernetes.security.privileged-container.privileged-container
         origin: community
   languages:
   - yaml
@@ -47307,10 +47326,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10059
-        rv_id: 111139
+        rv_id: 835332
         rule_id: zdUynw
-        version_id: gET3OEw
-        url: https://semgrep.dev/playground/r/gET3OEw/yaml.kubernetes.security.seccomp-confinement-disabled.seccomp-confinement-disabled
+        version_id: X0T5KJy
+        url: https://semgrep.dev/playground/r/X0T5KJy/yaml.kubernetes.security.seccomp-confinement-disabled.seccomp-confinement-disabled
         origin: community
   languages:
   - yaml
@@ -47364,10 +47383,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 20055
-        rv_id: 111140
+        rv_id: 835333
         rule_id: YGUYEb
-        version_id: QkTWwA4
-        url: https://semgrep.dev/playground/r/QkTWwA4/yaml.kubernetes.security.secrets-in-config-file.secrets-in-config-file
+        version_id: jQTrj92
+        url: https://semgrep.dev/playground/r/jQTrj92/yaml.kubernetes.security.secrets-in-config-file.secrets-in-config-file
         origin: community
   languages:
   - yaml
@@ -47404,10 +47423,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10116
-        rv_id: 111141
+        rv_id: 835334
         rule_id: zdUyWx
-        version_id: 3ZTkrWd
-        url: https://semgrep.dev/playground/r/3ZTkrWd/yaml.kubernetes.security.skip-tls-verify-cluster.skip-tls-verify-cluster
+        version_id: 1QTPNXl
+        url: https://semgrep.dev/playground/r/1QTPNXl/yaml.kubernetes.security.skip-tls-verify-cluster.skip-tls-verify-cluster
         origin: community
   languages:
   - yaml
@@ -47444,10 +47463,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10117
-        rv_id: 111142
+        rv_id: 835335
         rule_id: pKUGXr
-        version_id: 44TR653
-        url: https://semgrep.dev/playground/r/44TR653/yaml.kubernetes.security.skip-tls-verify-service.skip-tls-verify-service
+        version_id: 9lTJ7ng
+        url: https://semgrep.dev/playground/r/9lTJ7ng/yaml.kubernetes.security.skip-tls-verify-service.skip-tls-verify-service
         origin: community
   languages:
   - yaml
@@ -47500,8 +47519,8 @@ rules:
     semgrep.dev:
       rule:
         r_id: 133077
-        rv_id: 751095
+        rv_id: 835338
         rule_id: zdUKgEX
-        version_id: zyTn3RL
-        url: https://semgrep.dev/playground/r/zyTn3RL/yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+        version_id: bZTBo4k
+        url: https://semgrep.dev/playground/r/bZTBo4k/yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
         origin: community

--- a/assets/semgrep_rules/generated/oss/audit.yaml
+++ b/assets/semgrep_rules/generated/oss/audit.yaml
@@ -2268,10 +2268,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113212
-        rv_id: 723874
+        rv_id: 833251
         rule_id: ReUD0BO
-        version_id: WrTNkvB
-        url: https://semgrep.dev/playground/r/WrTNkvB/trailofbits.generic.container-privileged.container-privileged
+        version_id: 5PTyDrK
+        url: https://semgrep.dev/playground/r/5PTyDrK/trailofbits.generic.container-privileged.container-privileged
         origin: community
   pattern-either:
   - pattern: docker ... --privileged
@@ -2319,10 +2319,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113213
-        rv_id: 253283
+        rv_id: 833252
         rule_id: AbU9gy9
-        version_id: d6TqRxp
-        url: https://semgrep.dev/playground/r/d6TqRxp/trailofbits.generic.container-user-root.container-user-root
+        version_id: GxTDEYO
+        url: https://semgrep.dev/playground/r/GxTDEYO/trailofbits.generic.container-user-root.container-user-root
         origin: community
   pattern-either:
   - pattern: docker ... -u root
@@ -2358,10 +2358,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113214
-        rv_id: 253284
+        rv_id: 833253
         rule_id: BYUXkQx
-        version_id: ZRT6EAy
-        url: https://semgrep.dev/playground/r/ZRT6EAy/trailofbits.generic.curl-insecure.curl-insecure
+        version_id: RGTKGnY
+        url: https://semgrep.dev/playground/r/RGTKGnY/trailofbits.generic.curl-insecure.curl-insecure
         origin: community
   pattern-either:
   - pattern: 'curl ... -k '
@@ -2391,10 +2391,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113215
-        rv_id: 723875
+        rv_id: 833254
         rule_id: DbU6R39
-        version_id: 0bTrQAn
-        url: https://semgrep.dev/playground/r/0bTrQAn/trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url
+        version_id: A8T370Z
+        url: https://semgrep.dev/playground/r/A8T370Z/trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url
         origin: community
   patterns:
   - pattern-either:
@@ -2427,10 +2427,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113216
-        rv_id: 253286
+        rv_id: 833255
         rule_id: WAUWqko
-        version_id: ExTRkxb
-        url: https://semgrep.dev/playground/r/ExTRkxb/trailofbits.generic.gpg-insecure-flags.gpg-insecure-flags
+        version_id: BjTe0Jg
+        url: https://semgrep.dev/playground/r/BjTe0Jg/trailofbits.generic.gpg-insecure-flags.gpg-insecure-flags
         origin: community
   pattern-either:
   - pattern: gpg ... --allow-non-selfsigned-uid
@@ -2469,10 +2469,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113217
-        rv_id: 253287
+        rv_id: 833256
         rule_id: 0oULKQE
-        version_id: 7ZTD73J
-        url: https://semgrep.dev/playground/r/7ZTD73J/trailofbits.generic.installer-allow-untrusted.installer-allow-untrusted
+        version_id: DkTG0Xg
+        url: https://semgrep.dev/playground/r/DkTG0Xg/trailofbits.generic.installer-allow-untrusted.installer-allow-untrusted
         origin: community
   pattern: installer ... -allowUntrusted
 - id: trailofbits.generic.openssl-insecure-flags.openssl-insecure-flags
@@ -2500,10 +2500,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113218
-        rv_id: 253288
+        rv_id: 833257
         rule_id: KxUvKPY
-        version_id: LjT7Ygd
-        url: https://semgrep.dev/playground/r/LjT7Ygd/trailofbits.generic.openssl-insecure-flags.openssl-insecure-flags
+        version_id: WrTdpG9
+        url: https://semgrep.dev/playground/r/WrTdpG9/trailofbits.generic.openssl-insecure-flags.openssl-insecure-flags
         origin: community
   pattern-either:
   - pattern: 'openssl ... -pass pass:'
@@ -2537,10 +2537,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113219
-        rv_id: 253289
+        rv_id: 833258
         rule_id: qNU2R9X
-        version_id: 8KT42rO
-        url: https://semgrep.dev/playground/r/8KT42rO/trailofbits.generic.ssh-disable-host-key-checking.ssh-disable-host-key-checking
+        version_id: 0bTwbgN
+        url: https://semgrep.dev/playground/r/0bTwbgN/trailofbits.generic.ssh-disable-host-key-checking.ssh-disable-host-key-checking
         origin: community
   pattern: ssh ... StrictHostKeyChecking=no
 - id: trailofbits.generic.tar-insecure-flags.tar-insecure-flags
@@ -2568,10 +2568,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113220
-        rv_id: 258314
+        rv_id: 833259
         rule_id: lBU4JeW
-        version_id: 6xT5vWg
-        url: https://semgrep.dev/playground/r/6xT5vWg/trailofbits.generic.tar-insecure-flags.tar-insecure-flags
+        version_id: K3Trq8x
+        url: https://semgrep.dev/playground/r/K3Trq8x/trailofbits.generic.tar-insecure-flags.tar-insecure-flags
         origin: community
   options:
     generic_ellipsis_max_span: 0
@@ -2605,10 +2605,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113221
-        rv_id: 253291
+        rv_id: 833260
         rule_id: PeUJREx
-        version_id: QkT8yqY
-        url: https://semgrep.dev/playground/r/QkT8yqY/trailofbits.generic.wget-no-check-certificate.wget-no-check-certificate
+        version_id: qkTQnL3
+        url: https://semgrep.dev/playground/r/qkTQnL3/trailofbits.generic.wget-no-check-certificate.wget-no-check-certificate
         origin: community
   pattern-either:
   - pattern: wget ... --no-check-certificate
@@ -2638,10 +2638,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113222
-        rv_id: 253292
+        rv_id: 833261
         rule_id: JDUNz2o
-        version_id: 3ZTlJXZ
-        url: https://semgrep.dev/playground/r/3ZTlJXZ/trailofbits.generic.wget-unencrypted-url.wget-unencrypted-url
+        version_id: l4TyOon
+        url: https://semgrep.dev/playground/r/l4TyOon/trailofbits.generic.wget-unencrypted-url.wget-unencrypted-url
         origin: community
   pattern-either:
   - pattern: wget ... http://
@@ -2681,10 +2681,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 137469
-        rv_id: 763094
+        rv_id: 833262
         rule_id: WAUWXz3
-        version_id: gETJ4g6
-        url: https://semgrep.dev/playground/r/gETJ4g6/trailofbits.go.eth-rpc-tracetransaction.eth-rpc-tracetransaction
+        version_id: YDTl0k0
+        url: https://semgrep.dev/playground/r/YDTl0k0/trailofbits.go.eth-rpc-tracetransaction.eth-rpc-tracetransaction
         origin: community
   pattern-either:
   - pattern: "$RECEIVER.TraceTransaction($CTX, $FILTER, $TRACECONF)"
@@ -2738,10 +2738,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 137470
-        rv_id: 763095
+        rv_id: 833263
         rule_id: 0oUL8xK
-        version_id: QkTnyd7
-        url: https://semgrep.dev/playground/r/QkTnyd7/trailofbits.go.eth-txreceipt-status.eth-txreceipt-status
+        version_id: 6xTDgGX
+        url: https://semgrep.dev/playground/r/6xTDgGX/trailofbits.go.eth-txreceipt-status.eth-txreceipt-status
         origin: community
   patterns:
   - pattern-inside: |
@@ -2775,10 +2775,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17197
-        rv_id: 258507
+        rv_id: 833265
         rule_id: kxU6Xb
-        version_id: A8Tr9vQ
-        url: https://semgrep.dev/playground/r/A8Tr9vQ/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
+        version_id: zyTWJNZ
+        url: https://semgrep.dev/playground/r/zyTWJNZ/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
         origin: community
   patterns:
   - pattern: |
@@ -2848,10 +2848,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17198
-        rv_id: 759634
+        rv_id: 833266
         rule_id: wdUlww
-        version_id: 6xTELRW
-        url: https://semgrep.dev/playground/r/6xTELRW/trailofbits.go.iterate-over-empty-map.iterate-over-empty-map
+        version_id: pZTXjeW
+        url: https://semgrep.dev/playground/r/pZTXjeW/trailofbits.go.iterate-over-empty-map.iterate-over-empty-map
         origin: community
   patterns:
   - pattern: |
@@ -2908,10 +2908,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11759
-        rv_id: 95088
+        rv_id: 833273
         rule_id: 4bU2AZ
-        version_id: RGTDPPg
-        url: https://semgrep.dev/playground/r/RGTDPPg/trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
+        version_id: rxTDzNy
+        url: https://semgrep.dev/playground/r/rxTDzNy/trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
         origin: community
   pattern-either:
   - patterns:
@@ -3037,10 +3037,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60575
-        rv_id: 95095
+        rv_id: 833280
         rule_id: v8UlNl
-        version_id: qkT2oo4
-        url: https://semgrep.dev/playground/r/qkT2oo4/trailofbits.javascript.apollo-graphql.v3-cors-audit.v3-potentially-bad-cors
+        version_id: e1TDkqr
+        url: https://semgrep.dev/playground/r/e1TDkqr/trailofbits.javascript.apollo-graphql.v3-cors-audit.v3-potentially-bad-cors
         origin: community
   mode: taint
   pattern-sources:
@@ -3086,10 +3086,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113224
-        rv_id: 253295
+        rv_id: 833288
         rule_id: GdUvk46
-        version_id: JdT5gxX
-        url: https://semgrep.dev/playground/r/JdT5gxX/trailofbits.jvm.mongo-hostname-verification-disabled.mongo-hostname-verification-disabled
+        version_id: 8KTGkn3
+        url: https://semgrep.dev/playground/r/8KTGkn3/trailofbits.jvm.mongo-hostname-verification-disabled.mongo-hostname-verification-disabled
         origin: community
   pattern: "$SETTINGS.invalidHostNameAllowed(true)"
 - id: trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
@@ -3119,10 +3119,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17165
-        rv_id: 250821
+        rv_id: 833289
         rule_id: WAUN1Z
-        version_id: 8KT4boW
-        url: https://semgrep.dev/playground/r/8KT4boW/trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
+        version_id: gETy20E
+        url: https://semgrep.dev/playground/r/gETy20E/trailofbits.python.automatic-memory-pinning.automatic-memory-pinning
         origin: community
   pattern-either:
   - patterns:
@@ -3155,10 +3155,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43925
-        rv_id: 95104
+        rv_id: 833292
         rule_id: GdUgN8
-        version_id: jQTgqq9
-        url: https://semgrep.dev/playground/r/jQTgqq9/trailofbits.python.numpy-distutils.numpy-distutils
+        version_id: 44TQP8Y
+        url: https://semgrep.dev/playground/r/44TQP8Y/trailofbits.python.numpy-distutils.numpy-distutils
         origin: community
   patterns:
   - pattern: 'import numpy.distutils
@@ -3191,10 +3191,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43926
-        rv_id: 95105
+        rv_id: 833293
         rule_id: ReUdJ0
-        version_id: 1QTOZZ0
-        url: https://semgrep.dev/playground/r/1QTOZZ0/trailofbits.python.numpy-f2py-compile.numpy-f2py-compile
+        version_id: PkTxrbE
+        url: https://semgrep.dev/playground/r/PkTxrbE/trailofbits.python.numpy-f2py-compile.numpy-f2py-compile
         origin: community
   patterns:
   - pattern: numpy.f2py.compile(...)
@@ -3228,10 +3228,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44134
-        rv_id: 250822
+        rv_id: 833294
         rule_id: KxURLn
-        version_id: gET6q8p
-        url: https://semgrep.dev/playground/r/gET6q8p/trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
+        version_id: JdTlrK4
+        url: https://semgrep.dev/playground/r/JdTlrK4/trailofbits.python.numpy-in-pytorch-datasets.numpy-in-pytorch-datasets
         origin: community
   patterns:
   - pattern: |
@@ -3267,10 +3267,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43927
-        rv_id: 95108
+        rv_id: 833296
         rule_id: AbUxDq
-        version_id: rxTykkg
-        url: https://semgrep.dev/playground/r/rxTykkg/trailofbits.python.numpy-load-library.numpy-load-library
+        version_id: GxTDEBO
+        url: https://semgrep.dev/playground/r/GxTDEBO/trailofbits.python.numpy-load-library.numpy-load-library
         origin: community
   patterns:
   - pattern: numpy.ctypeslib.load_library(...)
@@ -3301,10 +3301,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43928
-        rv_id: 95109
+        rv_id: 833297
         rule_id: BYUoqy
-        version_id: bZTbOOD
-        url: https://semgrep.dev/playground/r/bZTbOOD/trailofbits.python.onnx-session-options.onnx-session-options
+        version_id: RGTKG9Y
+        url: https://semgrep.dev/playground/r/RGTKG9Y/trailofbits.python.onnx-session-options.onnx-session-options
         origin: community
   patterns:
   - pattern-inside: |
@@ -3343,10 +3343,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 124726
-        rv_id: 733075
+        rv_id: 833298
         rule_id: ReUDw9J
-        version_id: 2KTLoZO
-        url: https://semgrep.dev/playground/r/2KTLoZO/trailofbits.python.pandas-eval.pandas-eval
+        version_id: A8T37pZ
+        url: https://semgrep.dev/playground/r/A8T37pZ/trailofbits.python.pandas-eval.pandas-eval
         origin: community
   patterns:
   - pattern-inside: |
@@ -3397,10 +3397,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44136
-        rv_id: 95114
+        rv_id: 833306
         rule_id: lBUYD9
-        version_id: O9TNGGw
-        url: https://semgrep.dev/playground/r/O9TNGGw/trailofbits.python.pytorch-classes-load-library.pytorch-classes-load-library
+        version_id: YDTl040
+        url: https://semgrep.dev/playground/r/YDTl040/trailofbits.python.pytorch-classes-load-library.pytorch-classes-load-library
         origin: community
   patterns:
   - pattern: torch.classes.load_library(...)
@@ -3433,10 +3433,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44137
-        rv_id: 95115
+        rv_id: 833307
         rule_id: PeUKGk
-        version_id: e1T0vvB
-        url: https://semgrep.dev/playground/r/e1T0vvB/trailofbits.python.pytorch-package.pytorch-package
+        version_id: 6xTDgWX
+        url: https://semgrep.dev/playground/r/6xTDgWX/trailofbits.python.pytorch-package.pytorch-package
         origin: community
   pattern: import torch.package
 - id: trailofbits.python.tensorflow-load-library.tensorflow-load-library
@@ -3466,10 +3466,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43930
-        rv_id: 95119
+        rv_id: 833311
         rule_id: WAUgBJ
-        version_id: nWTxYYN
-        url: https://semgrep.dev/playground/r/nWTxYYN/trailofbits.python.tensorflow-load-library.tensorflow-load-library
+        version_id: 2KT7xEg
+        url: https://semgrep.dev/playground/r/2KT7xEg/trailofbits.python.tensorflow-load-library.tensorflow-load-library
         origin: community
   patterns:
   - pattern-either:
@@ -3503,10 +3503,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 13697
-        rv_id: 95121
+        rv_id: 833313
         rule_id: 2ZUPQ3
-        version_id: 7ZTgeey
-        url: https://semgrep.dev/playground/r/7ZTgeey/trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result
+        version_id: jQTrXJK
+        url: https://semgrep.dev/playground/r/jQTrXJK/trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result
         origin: community
   patterns:
   - pattern-either:
@@ -3565,10 +3565,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113225
-        rv_id: 253296
+        rv_id: 833314
         rule_id: ReUD0BR
-        version_id: 5PTk51b
-        url: https://semgrep.dev/playground/r/5PTk51b/trailofbits.yaml.ansible.apt-key-unencrypted-url.apt-key-unencrypted-url
+        version_id: 1QTPLQx
+        url: https://semgrep.dev/playground/r/1QTPLQx/trailofbits.yaml.ansible.apt-key-unencrypted-url.apt-key-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -3613,10 +3613,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113226
-        rv_id: 253297
+        rv_id: 833315
         rule_id: AbU9gyg
-        version_id: GxTjwed
-        url: https://semgrep.dev/playground/r/GxTjwed/trailofbits.yaml.ansible.apt-key-validate-certs-disabled.apt-key-validate-certs-disabled
+        version_id: 9lTJ06D
+        url: https://semgrep.dev/playground/r/9lTJ06D/trailofbits.yaml.ansible.apt-key-validate-certs-disabled.apt-key-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -3664,10 +3664,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113227
-        rv_id: 253298
+        rv_id: 833316
         rule_id: BYUXkQb
-        version_id: RGTevLG
-        url: https://semgrep.dev/playground/r/RGTevLG/trailofbits.yaml.ansible.apt-unencrypted-url.apt-unencrypted-url
+        version_id: yeTN15k
+        url: https://semgrep.dev/playground/r/yeTN15k/trailofbits.yaml.ansible.apt-unencrypted-url.apt-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -3713,10 +3713,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113228
-        rv_id: 253299
+        rv_id: 833317
         rule_id: DbU6R3w
-        version_id: A8TkYdl
-        url: https://semgrep.dev/playground/r/A8TkYdl/trailofbits.yaml.ansible.dnf-unencrypted-url.dnf-unencrypted-url
+        version_id: rxTDzGy
+        url: https://semgrep.dev/playground/r/rxTDzGy/trailofbits.yaml.ansible.dnf-unencrypted-url.dnf-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -3765,10 +3765,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113229
-        rv_id: 253300
+        rv_id: 833318
         rule_id: WAUWqkG
-        version_id: BjTxYZZ
-        url: https://semgrep.dev/playground/r/BjTxYZZ/trailofbits.yaml.ansible.dnf-validate-certs-disabled.dnf-validate-certs-disabled
+        version_id: bZTBe6R
+        url: https://semgrep.dev/playground/r/bZTBe6R/trailofbits.yaml.ansible.dnf-validate-certs-disabled.dnf-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -3816,10 +3816,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113230
-        rv_id: 253301
+        rv_id: 833319
         rule_id: 0oULKQq
-        version_id: DkTq8bj
-        url: https://semgrep.dev/playground/r/DkTq8bj/trailofbits.yaml.ansible.get-url-unencrypted-url.get-url-unencrypted-url
+        version_id: NdTB2r9
+        url: https://semgrep.dev/playground/r/NdTB2r9/trailofbits.yaml.ansible.get-url-unencrypted-url.get-url-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -3871,10 +3871,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113231
-        rv_id: 253302
+        rv_id: 833320
         rule_id: KxUvKPQ
-        version_id: WrTOxK1
-        url: https://semgrep.dev/playground/r/WrTOxK1/trailofbits.yaml.ansible.get-url-validate-certs-disabled.get-url-validate-certs-disabled
+        version_id: kbT2lek
+        url: https://semgrep.dev/playground/r/kbT2lek/trailofbits.yaml.ansible.get-url-validate-certs-disabled.get-url-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -3929,10 +3929,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113232
-        rv_id: 253303
+        rv_id: 833321
         rule_id: qNU2R9K
-        version_id: 0bTyOzA
-        url: https://semgrep.dev/playground/r/0bTyOzA/trailofbits.yaml.ansible.rpm-key-unencrypted-url.rpm-key-unencrypted-url
+        version_id: w8TAxy8
+        url: https://semgrep.dev/playground/r/w8TAxy8/trailofbits.yaml.ansible.rpm-key-unencrypted-url.rpm-key-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -3977,10 +3977,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113233
-        rv_id: 253304
+        rv_id: 833322
         rule_id: lBU4Jee
-        version_id: K3Tnykp
-        url: https://semgrep.dev/playground/r/K3Tnykp/trailofbits.yaml.ansible.rpm-key-validate-certs-disabled.rpm-key-validate-certs-disabled
+        version_id: xyTNeQ2
+        url: https://semgrep.dev/playground/r/xyTNeQ2/trailofbits.yaml.ansible.rpm-key-validate-certs-disabled.rpm-key-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -4027,10 +4027,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113234
-        rv_id: 253305
+        rv_id: 833323
         rule_id: YGUpZzx
-        version_id: qkT5q7N
-        url: https://semgrep.dev/playground/r/qkT5q7N/trailofbits.yaml.ansible.unarchive-unencrypted-url.unarchive-unencrypted-url
+        version_id: O9TJWR6
+        url: https://semgrep.dev/playground/r/O9TJWR6/trailofbits.yaml.ansible.unarchive-unencrypted-url.unarchive-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -4074,10 +4074,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113235
-        rv_id: 253306
+        rv_id: 833324
         rule_id: 6JUv2A4
-        version_id: l4TlPRP
-        url: https://semgrep.dev/playground/r/l4TlPRP/trailofbits.yaml.ansible.unarchive-validate-certs-disabled.unarchive-validate-certs-disabled
+        version_id: e1TDkGr
+        url: https://semgrep.dev/playground/r/e1TDkGr/trailofbits.yaml.ansible.unarchive-validate-certs-disabled.unarchive-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -4123,10 +4123,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113236
-        rv_id: 253307
+        rv_id: 833325
         rule_id: oqUgbWQ
-        version_id: YDTNPeX
-        url: https://semgrep.dev/playground/r/YDTNPeX/trailofbits.yaml.ansible.wrm-cert-validation-ignore.wrm-cert-validation-ignore
+        version_id: vdTOzBO
+        url: https://semgrep.dev/playground/r/vdTOzBO/trailofbits.yaml.ansible.wrm-cert-validation-ignore.wrm-cert-validation-ignore
         origin: community
   pattern: 'ansible_winrm_server_cert_validation: ignore'
 - id: trailofbits.yaml.ansible.yum-unencrypted-url.yum-unencrypted-url
@@ -4155,10 +4155,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113237
-        rv_id: 253308
+        rv_id: 833326
         rule_id: zdUKbXv
-        version_id: JdT5gj1
-        url: https://semgrep.dev/playground/r/JdT5gj1/trailofbits.yaml.ansible.yum-unencrypted-url.yum-unencrypted-url
+        version_id: d6TKGp6
+        url: https://semgrep.dev/playground/r/d6TKGp6/trailofbits.yaml.ansible.yum-unencrypted-url.yum-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -4204,10 +4204,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113238
-        rv_id: 253309
+        rv_id: 833327
         rule_id: pKU10q4
-        version_id: 5PTk5zd
-        url: https://semgrep.dev/playground/r/5PTk5zd/trailofbits.yaml.ansible.yum-validate-certs-disabled.yum-validate-certs-disabled
+        version_id: ZRTlPX3
+        url: https://semgrep.dev/playground/r/ZRTlPX3/trailofbits.yaml.ansible.yum-validate-certs-disabled.yum-validate-certs-disabled
         origin: community
   patterns:
   - pattern-inside: |
@@ -4253,10 +4253,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113239
-        rv_id: 253310
+        rv_id: 833328
         rule_id: 2ZUzvAk
-        version_id: GxTjwRj
-        url: https://semgrep.dev/playground/r/GxTjwRj/trailofbits.yaml.ansible.zypper-repository-unencrypted-url.zypper-repository-unencrypted-url
+        version_id: nWTy40P
+        url: https://semgrep.dev/playground/r/nWTy40P/trailofbits.yaml.ansible.zypper-repository-unencrypted-url.zypper-repository-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |
@@ -4301,10 +4301,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113240
-        rv_id: 253311
+        rv_id: 833329
         rule_id: X5UQzo1
-        version_id: RGTevlQ
-        url: https://semgrep.dev/playground/r/RGTevlQ/trailofbits.yaml.ansible.zypper-unencrypted-url.zypper-unencrypted-url
+        version_id: ExTrDXA
+        url: https://semgrep.dev/playground/r/ExTrDXA/trailofbits.yaml.ansible.zypper-unencrypted-url.zypper-unencrypted-url
         origin: community
   patterns:
   - pattern-inside: |

--- a/assets/semgrep_rules/generated/oss/others.yaml
+++ b/assets/semgrep_rules/generated/oss/others.yaml
@@ -327,10 +327,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43714
-        rv_id: 764604
+        rv_id: 833208
         rule_id: L1UJDJ
-        version_id: nWTGe7Q
-        url: https://semgrep.dev/playground/r/nWTGe7Q/mobsf.mobsfscan.android.hidden_ui.android_hidden_ui
+        version_id: zyTWJBg
+        url: https://semgrep.dev/playground/r/zyTWJBg/mobsf.mobsfscan.android.hidden_ui.android_hidden_ui
         origin: community
 - id: mobsf.mobsfscan.android.logging.android_logging
   patterns:
@@ -388,10 +388,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43715
-        rv_id: 78319
+        rv_id: 833209
         rule_id: 8GU0OP
-        version_id: JdTJe7
-        url: https://semgrep.dev/playground/r/JdTJe7/mobsf.mobsfscan.android.logging.android_logging
+        version_id: pZTXj2v
+        url: https://semgrep.dev/playground/r/pZTXj2v/mobsf.mobsfscan.android.logging.android_logging
         origin: community
 - id: mobsf.mobsfscan.android.secrets.hardcoded_api_key
   patterns:
@@ -424,10 +424,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43718
-        rv_id: 89493
+        rv_id: 833212
         rule_id: 3qUgDz
-        version_id: WrTWOdb
-        url: https://semgrep.dev/playground/r/WrTWOdb/mobsf.mobsfscan.android.secrets.hardcoded_api_key
+        version_id: jQTrX18
+        url: https://semgrep.dev/playground/r/jQTrX18/mobsf.mobsfscan.android.secrets.hardcoded_api_key
         origin: community
 - id: mobsf.mobsfscan.android.secrets.hardcoded_password
   patterns:
@@ -460,10 +460,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43716
-        rv_id: 89491
+        rv_id: 833210
         rule_id: gxUpG8
-        version_id: BjTXxew
-        url: https://semgrep.dev/playground/r/BjTXxew/mobsf.mobsfscan.android.secrets.hardcoded_password
+        version_id: 2KT7xRo
+        url: https://semgrep.dev/playground/r/2KT7xRo/mobsf.mobsfscan.android.secrets.hardcoded_password
         origin: community
 - id: mobsf.mobsfscan.android.secrets.hardcoded_secret
   patterns:
@@ -496,10 +496,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43719
-        rv_id: 89494
+        rv_id: 833213
         rule_id: 4bUJWL
-        version_id: 0bTLywO
-        url: https://semgrep.dev/playground/r/0bTLywO/mobsf.mobsfscan.android.secrets.hardcoded_secret
+        version_id: 1QTPLEB
+        url: https://semgrep.dev/playground/r/1QTPLEB/mobsf.mobsfscan.android.secrets.hardcoded_secret
         origin: community
 - id: mobsf.mobsfscan.android.secrets.hardcoded_username
   patterns:
@@ -532,10 +532,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43717
-        rv_id: 89492
+        rv_id: 833211
         rule_id: QrULll
-        version_id: DkT6qGO
-        url: https://semgrep.dev/playground/r/DkT6qGO/mobsf.mobsfscan.android.secrets.hardcoded_username
+        version_id: X0T5NYj
+        url: https://semgrep.dev/playground/r/X0T5NYj/mobsf.mobsfscan.android.secrets.hardcoded_username
         origin: community
 - id: mobsf.mobsfscan.android.word_readable_writable.world_readable
   patterns:
@@ -560,10 +560,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43720
-        rv_id: 78324
+        rv_id: 833214
         rule_id: PeUKq9
-        version_id: BjT9GN
-        url: https://semgrep.dev/playground/r/BjT9GN/mobsf.mobsfscan.android.word_readable_writable.world_readable
+        version_id: 9lTJ03r
+        url: https://semgrep.dev/playground/r/9lTJ03r/mobsf.mobsfscan.android.word_readable_writable.world_readable
         origin: community
 - id: mobsf.mobsfscan.android.word_readable_writable.world_writeable
   patterns:
@@ -589,10 +589,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43721
-        rv_id: 78325
+        rv_id: 833215
         rule_id: JDU4Ab
-        version_id: DkTOeW
-        url: https://semgrep.dev/playground/r/DkTOeW/mobsf.mobsfscan.android.word_readable_writable.world_writeable
+        version_id: yeTN1qo
+        url: https://semgrep.dev/playground/r/yeTN1qo/mobsf.mobsfscan.android.word_readable_writable.world_writeable
         origin: community
 - id: mobsf.mobsfscan.best_practices.android_safetynetapi.android_safetynet_api
   patterns:
@@ -627,10 +627,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43722
-        rv_id: 78326
+        rv_id: 833216
         rule_id: 5rUx0W
-        version_id: WrTR6P
-        url: https://semgrep.dev/playground/r/WrTR6P/mobsf.mobsfscan.best_practices.android_safetynetapi.android_safetynet_api
+        version_id: rxTDznQ
+        url: https://semgrep.dev/playground/r/rxTDznQ/mobsf.mobsfscan.best_practices.android_safetynetapi.android_safetynet_api
         origin: community
 - id: mobsf.mobsfscan.best_practices.flag_secure.android_prevent_screenshot
   patterns:
@@ -677,10 +677,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43723
-        rv_id: 78327
+        rv_id: 833217
         rule_id: GdUg51
-        version_id: 0bT462
-        url: https://semgrep.dev/playground/r/0bT462/mobsf.mobsfscan.best_practices.flag_secure.android_prevent_screenshot
+        version_id: bZTBeEj
+        url: https://semgrep.dev/playground/r/bZTBeEj/mobsf.mobsfscan.best_practices.flag_secure.android_prevent_screenshot
         origin: community
 - id: mobsf.mobsfscan.best_practices.root_detection.android_root_detection
   patterns:
@@ -713,10 +713,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43724
-        rv_id: 78328
+        rv_id: 833218
         rule_id: ReUdYj
-        version_id: K3TpO5
-        url: https://semgrep.dev/playground/r/K3TpO5/mobsf.mobsfscan.best_practices.root_detection.android_root_detection
+        version_id: NdTB262
+        url: https://semgrep.dev/playground/r/NdTB262/mobsf.mobsfscan.best_practices.root_detection.android_root_detection
         origin: community
 - id: mobsf.mobsfscan.best_practices.tapjacking.android_detect_tapjacking
   patterns:
@@ -741,10 +741,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43725
-        rv_id: 78329
+        rv_id: 833219
         rule_id: AbUx1o
-        version_id: qkT0KQ
-        url: https://semgrep.dev/playground/r/qkT0KQ/mobsf.mobsfscan.best_practices.tapjacking.android_detect_tapjacking
+        version_id: kbT2lWP
+        url: https://semgrep.dev/playground/r/kbT2lWP/mobsf.mobsfscan.best_practices.tapjacking.android_detect_tapjacking
         origin: community
 - id: mobsf.mobsfscan.best_practices.tls_certificate_transparency.android_certificate_transparency
   patterns:
@@ -777,10 +777,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43726
-        rv_id: 78330
+        rv_id: 833220
         rule_id: BYUoO0
-        version_id: l4TLNX
-        url: https://semgrep.dev/playground/r/l4TLNX/mobsf.mobsfscan.best_practices.tls_certificate_transparency.android_certificate_transparency
+        version_id: w8TAxWo
+        url: https://semgrep.dev/playground/r/w8TAxWo/mobsf.mobsfscan.best_practices.tls_certificate_transparency.android_certificate_transparency
         origin: community
 - id: mobsf.mobsfscan.best_practices.tls_pinning.android_certificate_pinning
   patterns:
@@ -849,10 +849,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43727
-        rv_id: 78331
+        rv_id: 833221
         rule_id: DbUL4y
-        version_id: YDT38v
-        url: https://semgrep.dev/playground/r/YDT38v/mobsf.mobsfscan.best_practices.tls_pinning.android_certificate_pinning
+        version_id: xyTNeR5
+        url: https://semgrep.dev/playground/r/xyTNeR5/mobsf.mobsfscan.best_practices.tls_pinning.android_certificate_pinning
         origin: community
 - id: mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode
   patterns:
@@ -879,10 +879,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43728
-        rv_id: 78332
+        rv_id: 833222
         rule_id: WAUg2K
-        version_id: 6xTL0J
-        url: https://semgrep.dev/playground/r/6xTL0J/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode
+        version_id: O9TJWQY
+        url: https://semgrep.dev/playground/r/O9TJWQY/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode
         origin: community
 - id: mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode_default
   patterns:
@@ -909,10 +909,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43729
-        rv_id: 78333
+        rv_id: 833223
         rule_id: 0oUZRX
-        version_id: o5T759
-        url: https://semgrep.dev/playground/r/o5T759/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode_default
+        version_id: e1TDk4W
+        url: https://semgrep.dev/playground/r/e1TDk4W/mobsf.mobsfscan.crypto.aes_ecb.aes_ecb_mode_default
         origin: community
 - id: mobsf.mobsfscan.crypto.aes_encryption_keys.aes_hardcoded_key
   patterns:
@@ -943,10 +943,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43730
-        rv_id: 78334
+        rv_id: 833224
         rule_id: KxURB0
-        version_id: zyTxeb
-        url: https://semgrep.dev/playground/r/zyTxeb/mobsf.mobsfscan.crypto.aes_encryption_keys.aes_hardcoded_key
+        version_id: vdTOzLZ
+        url: https://semgrep.dev/playground/r/vdTOzLZ/mobsf.mobsfscan.crypto.aes_encryption_keys.aes_hardcoded_key
         origin: community
 - id: mobsf.mobsfscan.crypto.cbc_padding_oracle.cbc_padding_oracle
   patterns:
@@ -987,10 +987,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43731
-        rv_id: 78335
+        rv_id: 833225
         rule_id: qNUrzk
-        version_id: pZTBQn
-        url: https://semgrep.dev/playground/r/pZTBQn/mobsf.mobsfscan.crypto.cbc_padding_oracle.cbc_padding_oracle
+        version_id: d6TKG8D
+        url: https://semgrep.dev/playground/r/d6TKG8D/mobsf.mobsfscan.crypto.cbc_padding_oracle.cbc_padding_oracle
         origin: community
 - id: mobsf.mobsfscan.crypto.cbc_static_iv.cbc_static_iv
   patterns:
@@ -1025,10 +1025,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43732
-        rv_id: 78336
+        rv_id: 833226
         rule_id: lBUYwL
-        version_id: 2KTD6R
-        url: https://semgrep.dev/playground/r/2KTD6R/mobsf.mobsfscan.crypto.cbc_static_iv.cbc_static_iv
+        version_id: ZRTlPDE
+        url: https://semgrep.dev/playground/r/ZRTlPDE/mobsf.mobsfscan.crypto.cbc_static_iv.cbc_static_iv
         origin: community
 - id: mobsf.mobsfscan.crypto.insecure_random.java_insecure_random
   patterns:
@@ -1056,10 +1056,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43733
-        rv_id: 78337
+        rv_id: 833227
         rule_id: PeUKqY
-        version_id: X0TvJk
-        url: https://semgrep.dev/playground/r/X0TvJk/mobsf.mobsfscan.crypto.insecure_random.java_insecure_random
+        version_id: nWTy4Qq
+        url: https://semgrep.dev/playground/r/nWTy4Qq/mobsf.mobsfscan.crypto.insecure_random.java_insecure_random
         origin: community
 - id: mobsf.mobsfscan.crypto.insecure_ssl_v3.insecure_sslv3
   patterns:
@@ -1084,10 +1084,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43734
-        rv_id: 78338
+        rv_id: 833228
         rule_id: JDU4Ag
-        version_id: jQTE9J
-        url: https://semgrep.dev/playground/r/jQTE9J/mobsf.mobsfscan.crypto.insecure_ssl_v3.insecure_sslv3
+        version_id: ExTrDv8
+        url: https://semgrep.dev/playground/r/ExTrDv8/mobsf.mobsfscan.crypto.insecure_ssl_v3.insecure_sslv3
         origin: community
 - id: mobsf.mobsfscan.crypto.rsa_no_oeap.rsa_no_oeap
   patterns:
@@ -1120,10 +1120,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43735
-        rv_id: 89495
+        rv_id: 833229
         rule_id: 5rUx0n
-        version_id: K3TvnrN
-        url: https://semgrep.dev/playground/r/K3TvnrN/mobsf.mobsfscan.crypto.rsa_no_oeap.rsa_no_oeap
+        version_id: 7ZTx9Zg
+        url: https://semgrep.dev/playground/r/7ZTx9Zg/mobsf.mobsfscan.crypto.rsa_no_oeap.rsa_no_oeap
         origin: community
 - id: mobsf.mobsfscan.crypto.sha1_hash.sha1_hash
   patterns:
@@ -1157,10 +1157,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43736
-        rv_id: 78340
+        rv_id: 833230
         rule_id: GdUgKL
-        version_id: 9lTjnn
-        url: https://semgrep.dev/playground/r/9lTjnn/mobsf.mobsfscan.crypto.sha1_hash.sha1_hash
+        version_id: LjTEb97
+        url: https://semgrep.dev/playground/r/LjTEb97/mobsf.mobsfscan.crypto.sha1_hash.sha1_hash
         origin: community
 - id: mobsf.mobsfscan.crypto.weak_ciphers.weak_cipher
   patterns:
@@ -1187,10 +1187,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43737
-        rv_id: 78341
+        rv_id: 833231
         rule_id: ReUdZD
-        version_id: yeT6dQ
-        url: https://semgrep.dev/playground/r/yeT6dQ/mobsf.mobsfscan.crypto.weak_ciphers.weak_cipher
+        version_id: 8KTGkgq
+        url: https://semgrep.dev/playground/r/8KTGkgq/mobsf.mobsfscan.crypto.weak_ciphers.weak_cipher
         origin: community
 - id: mobsf.mobsfscan.crypto.weak_hashes.weak_hash
   patterns:
@@ -1225,10 +1225,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43738
-        rv_id: 78342
+        rv_id: 833232
         rule_id: AbUxZk
-        version_id: rxT58X
-        url: https://semgrep.dev/playground/r/rxT58X/mobsf.mobsfscan.crypto.weak_hashes.weak_hash
+        version_id: gETy2E1
+        url: https://semgrep.dev/playground/r/gETy2E1/mobsf.mobsfscan.crypto.weak_hashes.weak_hash
         origin: community
 - id: mobsf.mobsfscan.crypto.weak_iv.weak_iv
   patterns:
@@ -1264,10 +1264,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43739
-        rv_id: 78343
+        rv_id: 833233
         rule_id: BYUonD
-        version_id: bZTY4P
-        url: https://semgrep.dev/playground/r/bZTY4P/mobsf.mobsfscan.crypto.weak_iv.weak_iv
+        version_id: QkTkrA6
+        url: https://semgrep.dev/playground/r/QkTkrA6/mobsf.mobsfscan.crypto.weak_iv.weak_iv
         origin: community
 - id: mobsf.mobsfscan.crypto.weak_key_size.weak_key_size
   patterns:
@@ -1326,10 +1326,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43740
-        rv_id: 78344
+        rv_id: 833234
         rule_id: DbULZp
-        version_id: NdTxQW
-        url: https://semgrep.dev/playground/r/NdTxQW/mobsf.mobsfscan.crypto.weak_key_size.weak_key_size
+        version_id: 3ZT3AWE
+        url: https://semgrep.dev/playground/r/3ZT3AWE/mobsf.mobsfscan.crypto.weak_key_size.weak_key_size
         origin: community
 - id: mobsf.mobsfscan.deserialization.jackson_deserialization.jackson_deserialization
   patterns:
@@ -1358,10 +1358,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43741
-        rv_id: 78345
+        rv_id: 833235
         rule_id: WAUgAZ
-        version_id: kbToZ0
-        url: https://semgrep.dev/playground/r/kbToZ0/mobsf.mobsfscan.deserialization.jackson_deserialization.jackson_deserialization
+        version_id: 44TQP51
+        url: https://semgrep.dev/playground/r/44TQP51/mobsf.mobsfscan.deserialization.jackson_deserialization.jackson_deserialization
         origin: community
 - id: mobsf.mobsfscan.deserialization.object_deserialization.object_deserialization
   patterns:
@@ -1390,10 +1390,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43742
-        rv_id: 78346
+        rv_id: 833236
         rule_id: 0oUZYJ
-        version_id: w8Te0B
-        url: https://semgrep.dev/playground/r/w8Te0B/mobsf.mobsfscan.deserialization.object_deserialization.object_deserialization
+        version_id: PkTxr20
+        url: https://semgrep.dev/playground/r/PkTxr20/mobsf.mobsfscan.deserialization.object_deserialization.object_deserialization
         origin: community
 - id: mobsf.mobsfscan.injection.command_injection.command_injection
   patterns:
@@ -1420,10 +1420,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43743
-        rv_id: 78347
+        rv_id: 833237
         rule_id: KxUR67
-        version_id: xyTY3g
-        url: https://semgrep.dev/playground/r/xyTY3g/mobsf.mobsfscan.injection.command_injection.command_injection
+        version_id: JdTlrGl
+        url: https://semgrep.dev/playground/r/JdTlrGl/mobsf.mobsfscan.injection.command_injection.command_injection
         origin: community
 - id: mobsf.mobsfscan.injection.command_injection_formated.command_injection_warning
   patterns:
@@ -1494,10 +1494,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43744
-        rv_id: 78348
+        rv_id: 833238
         rule_id: qNUrPW
-        version_id: O9TPZ9
-        url: https://semgrep.dev/playground/r/O9TPZ9/mobsf.mobsfscan.injection.command_injection_formated.command_injection_warning
+        version_id: 5PTyDrN
+        url: https://semgrep.dev/playground/r/5PTyDrN/mobsf.mobsfscan.injection.command_injection_formated.command_injection_warning
         origin: community
 - id: mobsf.mobsfscan.injection.sqlite_injection.sqlite_injection
   patterns:
@@ -1547,10 +1547,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43745
-        rv_id: 78349
+        rv_id: 833239
         rule_id: lBUYAy
-        version_id: e1T6A5
-        url: https://semgrep.dev/playground/r/e1T6A5/mobsf.mobsfscan.injection.sqlite_injection.sqlite_injection
+        version_id: GxTDEYP
+        url: https://semgrep.dev/playground/r/GxTDEYP/mobsf.mobsfscan.injection.sqlite_injection.sqlite_injection
         origin: community
 - id: mobsf.mobsfscan.network.accept_self_signed.accept_self_signed_certificate
   patterns:
@@ -1625,10 +1625,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43746
-        rv_id: 78350
+        rv_id: 833240
         rule_id: YGUxKY
-        version_id: vdTZ3e
-        url: https://semgrep.dev/playground/r/vdTZ3e/mobsf.mobsfscan.network.accept_self_signed.accept_self_signed_certificate
+        version_id: RGTKGnk
+        url: https://semgrep.dev/playground/r/RGTKGnk/mobsf.mobsfscan.network.accept_self_signed.accept_self_signed_certificate
         origin: community
 - id: mobsf.mobsfscan.network.default_http_client_tls.default_http_client_tls
   patterns:
@@ -1654,10 +1654,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43747
-        rv_id: 78351
+        rv_id: 833241
         rule_id: 6JUkwx
-        version_id: d6TBbY
-        url: https://semgrep.dev/playground/r/d6TBbY/mobsf.mobsfscan.network.default_http_client_tls.default_http_client_tls
+        version_id: A8T370X
+        url: https://semgrep.dev/playground/r/A8T370X/mobsf.mobsfscan.network.default_http_client_tls.default_http_client_tls
         origin: community
 - id: mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
   patterns:
@@ -1696,10 +1696,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 134573
-        rv_id: 756521
+        rv_id: 833242
         rule_id: QrUWlLB
-        version_id: vdT4P7g
-        url: https://semgrep.dev/playground/r/vdT4P7g/mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
+        version_id: BjTe0Jk
+        url: https://semgrep.dev/playground/r/BjTe0Jk/mobsf.mobsfscan.webview.webview_allow_file_from_url.webview_allow_file_from_url
         origin: community
 - id: mobsf.mobsfscan.webview.webview_debugging.webview_debugging
   patterns:
@@ -1727,10 +1727,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43748
-        rv_id: 78352
+        rv_id: 833243
         rule_id: oqUPpl
-        version_id: ZRTLyo
-        url: https://semgrep.dev/playground/r/ZRTLyo/mobsf.mobsfscan.webview.webview_debugging.webview_debugging
+        version_id: DkTG0Xk
+        url: https://semgrep.dev/playground/r/DkTG0Xk/mobsf.mobsfscan.webview.webview_debugging.webview_debugging
         origin: community
 - id: mobsf.mobsfscan.webview.webview_external_storage.webview_external_storage
   patterns:
@@ -1766,10 +1766,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43749
-        rv_id: 78353
+        rv_id: 833244
         rule_id: zdU90D
-        version_id: nWT6wg
-        url: https://semgrep.dev/playground/r/nWT6wg/mobsf.mobsfscan.webview.webview_external_storage.webview_external_storage
+        version_id: WrTdpG7
+        url: https://semgrep.dev/playground/r/WrTdpG7/mobsf.mobsfscan.webview.webview_external_storage.webview_external_storage
         origin: community
 - id: mobsf.mobsfscan.webview.webview_file_access.webview_set_allow_file_access
   patterns:
@@ -1793,10 +1793,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43750
-        rv_id: 78354
+        rv_id: 833245
         rule_id: pKUJ40
-        version_id: ExT9YD
-        url: https://semgrep.dev/playground/r/ExT9YD/mobsf.mobsfscan.webview.webview_file_access.webview_set_allow_file_access
+        version_id: 0bTwbgg
+        url: https://semgrep.dev/playground/r/0bTwbgg/mobsf.mobsfscan.webview.webview_file_access.webview_set_allow_file_access
         origin: community
 - id: mobsf.mobsfscan.webview.webview_ignore_ssl_errors.ignore_ssl_certificate_errors
   patterns:
@@ -1824,10 +1824,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43751
-        rv_id: 78355
+        rv_id: 833246
         rule_id: 2ZUXop
-        version_id: 7ZTLYR
-        url: https://semgrep.dev/playground/r/7ZTLYR/mobsf.mobsfscan.webview.webview_ignore_ssl_errors.ignore_ssl_certificate_errors
+        version_id: K3Trq83
+        url: https://semgrep.dev/playground/r/K3Trq83/mobsf.mobsfscan.webview.webview_ignore_ssl_errors.ignore_ssl_certificate_errors
         origin: community
 - id: mobsf.mobsfscan.webview.webview_javascript_interface.webview_javascript_interface
   patterns:
@@ -1854,10 +1854,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43752
-        rv_id: 78356
+        rv_id: 833247
         rule_id: X5Up0Y
-        version_id: LjT1pg
-        url: https://semgrep.dev/playground/r/LjT1pg/mobsf.mobsfscan.webview.webview_javascript_interface.webview_javascript_interface
+        version_id: qkTQnLe
+        url: https://semgrep.dev/playground/r/qkTQnLe/mobsf.mobsfscan.webview.webview_javascript_interface.webview_javascript_interface
         origin: community
 - id: mobsf.mobsfscan.xxe.xmldecoder_xxe.xml_decoder_xxe
   patterns:
@@ -1901,10 +1901,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43753
-        rv_id: 78357
+        rv_id: 833248
         rule_id: j2Up0D
-        version_id: 8KTdLZ
-        url: https://semgrep.dev/playground/r/8KTdLZ/mobsf.mobsfscan.xxe.xmldecoder_xxe.xml_decoder_xxe
+        version_id: l4TyOoN
+        url: https://semgrep.dev/playground/r/l4TyOoN/mobsf.mobsfscan.xxe.xmldecoder_xxe.xml_decoder_xxe
         origin: community
 - id: mobsf.mobsfscan.xxe.xmlfactory_external_entities_enabled.xmlinputfactory_xxe_enabled
   pattern: $XMLFACTORY.setProperty("javax.xml.stream.isSupportingExternalEntities",
@@ -1930,10 +1930,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43754
-        rv_id: 78358
+        rv_id: 833249
         rule_id: 10UnwQ
-        version_id: gETb5l
-        url: https://semgrep.dev/playground/r/gETb5l/mobsf.mobsfscan.xxe.xmlfactory_external_entities_enabled.xmlinputfactory_xxe_enabled
+        version_id: YDTl0kz
+        url: https://semgrep.dev/playground/r/YDTl0kz/mobsf.mobsfscan.xxe.xmlfactory_external_entities_enabled.xmlinputfactory_xxe_enabled
         origin: community
 - id: mobsf.mobsfscan.xxe.xmlfactory_xxe.xmlinputfactory_xxe
   patterns:
@@ -1974,10 +1974,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43755
-        rv_id: 78359
+        rv_id: 833250
         rule_id: 9AUL9X
-        version_id: QkT4Qb
-        url: https://semgrep.dev/playground/r/QkT4Qb/mobsf.mobsfscan.xxe.xmlfactory_xxe.xmlinputfactory_xxe
+        version_id: JdTlrG4
+        url: https://semgrep.dev/playground/r/JdTlrG4/mobsf.mobsfscan.xxe.xmlfactory_xxe.xmlinputfactory_xxe
         origin: community
 - id: trailofbits.jvm.gc-call.gc-call
   message: |
@@ -2007,10 +2007,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 113223
-        rv_id: 253294
+        rv_id: 833287
         rule_id: 5rUdoB9
-        version_id: PkTDL34
-        url: https://semgrep.dev/playground/r/PkTDL34/trailofbits.jvm.gc-call.gc-call
+        version_id: LjTEbBG
+        url: https://semgrep.dev/playground/r/LjTEbBG/trailofbits.jvm.gc-call.gc-call
         origin: community
   pattern-either:
   - pattern: System.gc()
@@ -2038,10 +2038,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17167
-        rv_id: 733074
+        rv_id: 833295
         rule_id: KxU507
-        version_id: pZTz48j
-        url: https://semgrep.dev/playground/r/pZTz48j/trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
+        version_id: 5PTyDEK
+        url: https://semgrep.dev/playground/r/5PTyDEK/trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
         origin: community
   patterns:
   - pattern-either:
@@ -2072,9 +2072,9 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44138
-        rv_id: 95116
+        rv_id: 833308
         rule_id: JDU4RQ
-        version_id: vdTY55y
-        url: https://semgrep.dev/playground/r/vdTY55y/trailofbits.python.pytorch-tensor.pytorch-tensor
+        version_id: o5TBEJD
+        url: https://semgrep.dev/playground/r/o5TBEJD/trailofbits.python.pytorch-tensor.pytorch-tensor
         origin: community
   pattern: torch.Tensor(...)

--- a/assets/semgrep_rules/generated/oss/vulns.yaml
+++ b/assets/semgrep_rules/generated/oss/vulns.yaml
@@ -38,10 +38,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9211
-        rv_id: 109749
+        rv_id: 833983
         rule_id: j2Uv7B
-        version_id: jQTgYdy
-        url: https://semgrep.dev/playground/r/jQTgYdy/java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer
+        version_id: kbT2llw
+        url: https://semgrep.dev/playground/r/kbT2llw/java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer
         origin: community
   languages:
   - java
@@ -101,10 +101,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11752
-        rv_id: 759637
+        rv_id: 833264
         rule_id: EwUQp2
-        version_id: pZTzB2q
-        url: https://semgrep.dev/playground/r/pZTzB2q/trailofbits.go.hanging-goroutine.hanging-goroutine
+        version_id: o5TBEoD
+        url: https://semgrep.dev/playground/r/o5TBEoD/trailofbits.go.hanging-goroutine.hanging-goroutine
         origin: community
   patterns:
   - pattern-either:
@@ -191,10 +191,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14223
-        rv_id: 733070
+        rv_id: 833267
         rule_id: 8GUzNK
-        version_id: YDTAKBW
-        url: https://semgrep.dev/playground/r/YDTAKBW/trailofbits.go.missing-runlock-on-rwmutex.missing-runlock-on-rwmutex
+        version_id: 2KT7x5g
+        url: https://semgrep.dev/playground/r/2KT7x5g/trailofbits.go.missing-runlock-on-rwmutex.missing-runlock-on-rwmutex
         origin: community
   patterns:
   - pattern-either:
@@ -255,10 +255,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14222
-        rv_id: 733071
+        rv_id: 833268
         rule_id: L1U5Gz
-        version_id: 6xTEwrB
-        url: https://semgrep.dev/playground/r/6xTEwrB/trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
+        version_id: X0T5Nkv
+        url: https://semgrep.dev/playground/r/X0T5Nkv/trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
         origin: community
   patterns:
   - pattern-either:
@@ -317,10 +317,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11754
-        rv_id: 95084
+        rv_id: 833269
         rule_id: L1Ur2r
-        version_id: PkTJkk5
-        url: https://semgrep.dev/playground/r/PkTJkk5/trailofbits.go.nil-check-after-call.nil-check-after-call
+        version_id: jQTrXDK
+        url: https://semgrep.dev/playground/r/jQTrXDK/trailofbits.go.nil-check-after-call.nil-check-after-call
         origin: community
   patterns:
   - pattern-either:
@@ -407,10 +407,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11865
-        rv_id: 104226
+        rv_id: 833270
         rule_id: ReUoP7
-        version_id: WrTWdKp
-        url: https://semgrep.dev/playground/r/WrTWdKp/trailofbits.go.racy-append-to-slice.racy-append-to-slice
+        version_id: 1QTPL3x
+        url: https://semgrep.dev/playground/r/1QTPL3x/trailofbits.go.racy-append-to-slice.racy-append-to-slice
         origin: community
   patterns:
   - pattern: "$SLICE = append($SLICE, $ITEM)\n"
@@ -475,10 +475,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11866
-        rv_id: 104227
+        rv_id: 833271
         rule_id: AbUGWD
-        version_id: 0bTLwz3
-        url: https://semgrep.dev/playground/r/0bTLwz3/trailofbits.go.racy-write-to-map.racy-write-to-map
+        version_id: 9lTJ0qD
+        url: https://semgrep.dev/playground/r/9lTJ0qD/trailofbits.go.racy-write-to-map.racy-write-to-map
         origin: community
   patterns:
   - pattern: "$MAP[$KEY] = $VALUE\n"
@@ -531,10 +531,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11757
-        rv_id: 95087
+        rv_id: 833272
         rule_id: QrUp7k
-        version_id: GxTv00x
-        url: https://semgrep.dev/playground/r/GxTv00x/trailofbits.go.servercodec-readrequestbody-unhandled-nil.servercodec-readrequestbody-unhandled-nil
+        version_id: yeTN1ek
+        url: https://semgrep.dev/playground/r/yeTN1ek/trailofbits.go.servercodec-readrequestbody-unhandled-nil.servercodec-readrequestbody-unhandled-nil
         origin: community
   patterns:
   - pattern: |
@@ -580,10 +580,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11760
-        rv_id: 95089
+        rv_id: 833274
         rule_id: PeUBW1
-        version_id: A8T9WWW
-        url: https://semgrep.dev/playground/r/A8T9WWW/trailofbits.go.sync-mutex-value-copied.sync-mutex-value-copied
+        version_id: bZTBelR
+        url: https://semgrep.dev/playground/r/bZTBelR/trailofbits.go.sync-mutex-value-copied.sync-mutex-value-copied
         origin: community
   patterns:
   - pattern-either:
@@ -630,10 +630,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 40518
-        rv_id: 95090
+        rv_id: 833275
         rule_id: pKUQBW
-        version_id: BjTXBB7
-        url: https://semgrep.dev/playground/r/BjTXBB7/trailofbits.go.unsafe-dll-loading.unsafe-dll-loading
+        version_id: NdTB2J9
+        url: https://semgrep.dev/playground/r/NdTB2J9/trailofbits.go.unsafe-dll-loading.unsafe-dll-loading
         origin: community
   patterns:
   - pattern-either:
@@ -686,10 +686,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11761
-        rv_id: 95091
+        rv_id: 833276
         rule_id: JDUQ3v
-        version_id: DkT6WW1
-        url: https://semgrep.dev/playground/r/DkT6WW1/trailofbits.go.waitgroup-add-called-inside-goroutine.waitgroup-add-called-inside-goroutine
+        version_id: kbT2l5k
+        url: https://semgrep.dev/playground/r/kbT2l5k/trailofbits.go.waitgroup-add-called-inside-goroutine.waitgroup-add-called-inside-goroutine
         origin: community
   patterns:
   - pattern-either:
@@ -745,10 +745,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11762
-        rv_id: 95092
+        rv_id: 833277
         rule_id: 5rU8Po
-        version_id: WrTWZZN
-        url: https://semgrep.dev/playground/r/WrTWZZN/trailofbits.go.waitgroup-wait-inside-loop.waitgroup-wait-inside-loop
+        version_id: w8TAx58
+        url: https://semgrep.dev/playground/r/w8TAx58/trailofbits.go.waitgroup-wait-inside-loop.waitgroup-wait-inside-loop
         origin: community
   patterns:
   - pattern-either:
@@ -839,10 +839,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60573
-        rv_id: 250820
+        rv_id: 833278
         rule_id: OrU1Oz
-        version_id: LjT70dp
-        url: https://semgrep.dev/playground/r/LjT70dp/trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
+        version_id: xyTNew2
+        url: https://semgrep.dev/playground/r/xyTNew2/trailofbits.javascript.apollo-graphql.schema-directives.schema-directives
         origin: community
   pattern-either:
   - pattern: 'new ApolloServer({..., schemaDirectives: ..., ...})
@@ -879,10 +879,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60574
-        rv_id: 95094
+        rv_id: 833279
         rule_id: eqUB1Q
-        version_id: K3Tv44w
-        url: https://semgrep.dev/playground/r/K3Tv44w/trailofbits.javascript.apollo-graphql.use-of-graphql-upload.use-of-graphql-upload
+        version_id: O9TJWB6
+        url: https://semgrep.dev/playground/r/O9TJWB6/trailofbits.javascript.apollo-graphql.use-of-graphql-upload.use-of-graphql-upload
         origin: community
   patterns:
   - pattern: app.use(graphqlUploadExpress());
@@ -916,10 +916,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60577
-        rv_id: 95097
+        rv_id: 833282
         rule_id: ZqUbNY
-        version_id: YDTprrn
-        url: https://semgrep.dev/playground/r/YDTprrn/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-bad-cors
+        version_id: d6TKGL6
+        url: https://semgrep.dev/playground/r/d6TKGL6/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-bad-cors
         origin: community
   mode: taint
   pattern-sources:
@@ -988,10 +988,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60576
-        rv_id: 95096
+        rv_id: 833281
         rule_id: d8UYAJ
-        version_id: l4T4ddv
-        url: https://semgrep.dev/playground/r/l4T4ddv/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-no-cors
+        version_id: vdTOzdO
+        url: https://semgrep.dev/playground/r/vdTOzdO/trailofbits.javascript.apollo-graphql.v3-cors-express.v3-express-no-cors
         origin: community
   patterns:
   - pattern-either:
@@ -1035,10 +1035,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60579
-        rv_id: 95099
+        rv_id: 833284
         rule_id: EwUZNW
-        version_id: o5Tgzzd
-        url: https://semgrep.dev/playground/r/o5Tgzzd/trailofbits.javascript.apollo-graphql.v3-cors.v3-bad-cors
+        version_id: nWTy4kP
+        url: https://semgrep.dev/playground/r/nWTy4kP/trailofbits.javascript.apollo-graphql.v3-cors.v3-bad-cors
         origin: community
   mode: taint
   pattern-sources:
@@ -1104,10 +1104,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60578
-        rv_id: 95098
+        rv_id: 833283
         rule_id: nJU3P4
-        version_id: 6xTvqq2
-        url: https://semgrep.dev/playground/r/6xTvqq2/trailofbits.javascript.apollo-graphql.v3-cors.v3-no-cors
+        version_id: ZRTlPW3
+        url: https://semgrep.dev/playground/r/ZRTlPW3/trailofbits.javascript.apollo-graphql.v3-cors.v3-no-cors
         origin: community
   patterns:
   - pattern-either:
@@ -1154,10 +1154,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60580
-        rv_id: 95100
+        rv_id: 833285
         rule_id: 7KU8o3
-        version_id: zyTKyyB
-        url: https://semgrep.dev/playground/r/zyTKyyB/trailofbits.javascript.apollo-graphql.v3-csrf-prevention.v3-csrf-prevention
+        version_id: ExTrD6A
+        url: https://semgrep.dev/playground/r/ExTrD6A/trailofbits.javascript.apollo-graphql.v3-csrf-prevention.v3-csrf-prevention
         origin: community
   patterns:
   - pattern: new ApolloServer({...})
@@ -1197,10 +1197,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 60581
-        rv_id: 253293
+        rv_id: 833286
         rule_id: L1UjQ3
-        version_id: 44T73jp
-        url: https://semgrep.dev/playground/r/44T73jp/trailofbits.javascript.apollo-graphql.v4-csrf-prevention.v4-csrf-prevention
+        version_id: 7ZTx9PE
+        url: https://semgrep.dev/playground/r/7ZTx9PE/trailofbits.javascript.apollo-graphql.v4-csrf-prevention.v4-csrf-prevention
         origin: community
   patterns:
   - pattern: 'new ApolloServer({..., csrfPrevention: false, ...})
@@ -1233,10 +1233,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17166
-        rv_id: 733072
+        rv_id: 833290
         rule_id: 0oUrdJ
-        version_id: o5T2pO6
-        url: https://semgrep.dev/playground/r/o5T2pO6/trailofbits.python.lxml-in-pandas.lxml-in-pandas
+        version_id: QkTkr22
+        url: https://semgrep.dev/playground/r/QkTkr22/trailofbits.python.lxml-in-pandas.lxml-in-pandas
         origin: community
   pattern-either:
   - patterns:
@@ -1290,10 +1290,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 124725
-        rv_id: 733073
+        rv_id: 833291
         rule_id: GdUvWBy
-        version_id: zyTn0O7
-        url: https://semgrep.dev/playground/r/zyTn0O7/trailofbits.python.msgpack-numpy.msgpack-numpy
+        version_id: 3ZT3Abe
+        url: https://semgrep.dev/playground/r/3ZT3Abe/trailofbits.python.msgpack-numpy.msgpack-numpy
         origin: community
   pattern-either:
   - patterns:
@@ -1342,10 +1342,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 124727
-        rv_id: 733076
+        rv_id: 833299
         rule_id: AbU9npB
-        version_id: X0Tg01y
-        url: https://semgrep.dev/playground/r/X0Tg01y/trailofbits.python.pickles-in-keras-deprecation.pickles-in-keras-deprecation
+        version_id: BjTe0vg
+        url: https://semgrep.dev/playground/r/BjTe0vg/trailofbits.python.pickles-in-keras-deprecation.pickles-in-keras-deprecation
         origin: community
   patterns:
   - pattern-either:
@@ -1392,10 +1392,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 124728
-        rv_id: 733077
+        rv_id: 833300
         rule_id: BYUXGv6
-        version_id: jQTQ082
-        url: https://semgrep.dev/playground/r/jQTQ082/trailofbits.python.pickles-in-keras.pickles-in-keras
+        version_id: DkTG07g
+        url: https://semgrep.dev/playground/r/DkTG07g/trailofbits.python.pickles-in-keras.pickles-in-keras
         origin: community
   patterns:
   - pattern-either:
@@ -1439,10 +1439,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17169
-        rv_id: 250823
+        rv_id: 833301
         rule_id: lBUWjy
-        version_id: QkT8J3R
-        url: https://semgrep.dev/playground/r/QkT8J3R/trailofbits.python.pickles-in-numpy.pickles-in-numpy
+        version_id: WrTdpJ9
+        url: https://semgrep.dev/playground/r/WrTdpJ9/trailofbits.python.pickles-in-numpy.pickles-in-numpy
         origin: community
   patterns:
   - pattern: numpy.load(..., allow_pickle=$VALUE, ...)
@@ -1489,10 +1489,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17170
-        rv_id: 95111
+        rv_id: 833302
         rule_id: PeU06j
-        version_id: kbTdRRB
-        url: https://semgrep.dev/playground/r/kbTdRRB/trailofbits.python.pickles-in-pandas.pickles-in-pandas
+        version_id: 0bTwbqN
+        url: https://semgrep.dev/playground/r/0bTwbqN/trailofbits.python.pickles-in-pandas.pickles-in-pandas
         origin: community
   patterns:
   - pattern-either:
@@ -1533,10 +1533,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44135
-        rv_id: 95112
+        rv_id: 833303
         rule_id: qNUrw1
-        version_id: w8T988E
-        url: https://semgrep.dev/playground/r/w8T988E/trailofbits.python.pickles-in-pytorch-distributed.pickles-in-pytorch-distributed
+        version_id: K3Trq3x
+        url: https://semgrep.dev/playground/r/K3Trq3x/trailofbits.python.pickles-in-pytorch-distributed.pickles-in-pytorch-distributed
         origin: community
   patterns:
   - pattern-either:
@@ -1573,10 +1573,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 17171
-        rv_id: 733078
+        rv_id: 833304
         rule_id: JDU6WD
-        version_id: 1QT5wrl
-        url: https://semgrep.dev/playground/r/1QT5wrl/trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
+        version_id: qkTQnJ3
+        url: https://semgrep.dev/playground/r/qkTQnJ3/trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
         origin: community
   patterns:
   - pattern-either:
@@ -1618,10 +1618,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 124729
-        rv_id: 733079
+        rv_id: 833305
         rule_id: DbU6e7r
-        version_id: 9lTZ9vg
-        url: https://semgrep.dev/playground/r/9lTZ9vg/trailofbits.python.pickles-in-tensorflow.pickles-in-tensorflow
+        version_id: l4TyO1n
+        url: https://semgrep.dev/playground/r/l4TyO1n/trailofbits.python.pickles-in-tensorflow.pickles-in-tensorflow
         origin: community
   patterns:
   - pattern: tensorflow.saved_model.load(...)
@@ -1654,10 +1654,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 43929
-        rv_id: 95117
+        rv_id: 833309
         rule_id: DbULlX
-        version_id: d6Trzzd
-        url: https://semgrep.dev/playground/r/d6Trzzd/trailofbits.python.scikit-joblib-load.scikit-joblib-load
+        version_id: zyTWJrZ
+        url: https://semgrep.dev/playground/r/zyTWJrZ/trailofbits.python.scikit-joblib-load.scikit-joblib-load
         origin: community
   patterns:
   - pattern: joblib.load(...)
@@ -1690,10 +1690,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 11763
-        rv_id: 95118
+        rv_id: 833310
         rule_id: GdUZxq
-        version_id: ZRTQqqP
-        url: https://semgrep.dev/playground/r/ZRTQqqP/trailofbits.python.tarfile-extractall-traversal.tarfile-extractall-traversal
+        version_id: pZTXjAW
+        url: https://semgrep.dev/playground/r/pZTXjAW/trailofbits.python.tarfile-extractall-traversal.tarfile-extractall-traversal
         origin: community
   patterns:
   - pattern-either:
@@ -1745,10 +1745,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 44139
-        rv_id: 95120
+        rv_id: 833312
         rule_id: 5rUxGL
-        version_id: ExTj44x
-        url: https://semgrep.dev/playground/r/ExTj44x/trailofbits.python.waiting-with-pytorch-distributed.waiting-with-pytorch-distributed
+        version_id: X0T5Nnv
+        url: https://semgrep.dev/playground/r/X0T5Nnv/trailofbits.python.waiting-with-pytorch-distributed.waiting-with-pytorch-distributed
         origin: community
   patterns:
   - pattern-either:

--- a/assets/semgrep_rules/update-ruleset.rb
+++ b/assets/semgrep_rules/update-ruleset.rb
@@ -254,6 +254,12 @@ RULESETS.each do |ruleset|
 		next if rule['patterns'] && rule['patterns'][0]['pattern'] == 'a()' && rule['patterns'][1]['pattern'] == 'b()'
 		next if rule['patterns'] && rule['patterns'][0]['pattern'] == 'a' && rule['patterns'][1]['pattern'] == 'b'
 
+		# Fix improper metadata
+		if rule['id'] == 'python.lang.security.audit.subprocess-shell-true.subprocess-shell-true'
+			rule['metadata']['category'] = 'security'
+			rule['metadata']['subcategory'] = ['audit']
+		end
+
 		categoriser << rule
 	end
 end


### PR DESCRIPTION
```
@ nonfree.audit (+1, -0)
+ python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
@ nonfree.others (+0, -0)
@ nonfree.security_noaudit_novuln (+0, -5)
- go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
- javascript.intercom.security.audit.intercom-settings-user-identifier-without-user-hash.intercom-settings-user-identifier-without-user-hash
- python.django.security.django-no-csrf-token.django-no-csrf-token
- python.django.security.django-using-request-post-after-is-valid.django-using-request-post-after-is-valid
- terraform.aws.security.aws-provisioner-exec.aws-provisioner-exec
@ nonfree.vulns (+0, -1)
- python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
@ oss.audit (+0, -0)
@ oss.others (+0, -0)
@ oss.security_noaudit_novuln (+0, -0)
@ oss.vulns (+0, -0)
```