### PR TITLE
semgrep rules: September 2024 Update

### DIFF
--- a/assets/semgrep_rules/generated/nonfree/audit.yaml
+++ b/assets/semgrep_rules/generated/nonfree/audit.yaml
@@ -2981,6 +2981,39 @@ rules:
         version_id: 6xTDg3J
         url: https://semgrep.dev/playground/r/6xTDg3J/generic.secrets.security.detected-generic-secret.detected-generic-secret
         origin: community
+- id: generic.secrets.security.detected-onfido-live-api-token.detected-onfido-live-api-token
+  pattern-regex: "(?:api_live(?:_[a-zA-Z]{2})?\\.[a-zA-Z0-9-_]{11}\\.[-_a-zA-Z0-9]{32})"
+  languages:
+  - regex
+  message: Onfido live API Token detected
+  severity: ERROR
+  metadata:
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    category: security
+    technology:
+    - secrets
+    - onfido
+    confidence: HIGH
+    references:
+    - https://documentation.onfido.com/api/latest/#api-tokens
+    subcategory:
+    - audit
+    likelihood: HIGH
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Hard-coded Secrets
+    source: https://semgrep.dev/r/generic.secrets.security.detected-onfido-live-api-token.detected-onfido-live-api-token
+    shortlink: https://sg.run/lBoKD
+    semgrep.dev:
+      rule:
+        r_id: 141957
+        rv_id: 906492
+        rule_id: WAUW9q3
+        version_id: 2KTdZdb
+        url: https://semgrep.dev/playground/r/2KTdZdb/generic.secrets.security.detected-onfido-live-api-token.detected-onfido-live-api-token
+        origin: community
 - id: generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key
   pattern-regex: sk_live_[0-9a-z]{32}
   languages:
@@ -18407,10 +18440,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 14701
-        rv_id: 834457
+        rv_id: 906695
         rule_id: lBU8Ad
-        version_id: 0bTw3xv
-        url: https://semgrep.dev/playground/r/0bTw3xv/python.django.security.injection.tainted-sql-string.tainted-sql-string
+        version_id: X0TA1zR
+        url: https://semgrep.dev/playground/r/X0TA1zR/python.django.security.injection.tainted-sql-string.tainted-sql-string
         origin: community
   severity: ERROR
   languages:
@@ -20361,7 +20394,9 @@ rules:
   - pattern: http.client.HTTPSConnection(...)
   - pattern: six.moves.http_client.HTTPSConnection(...)
 - id: python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
-  pattern: ftplib.FTP(...)
+  patterns:
+  - pattern: ftplib.FTP(...)
+  - pattern-not: ftplib.FTP_TLS(...)
   fix-regex:
     regex: FTP(.*)\)
     replacement: FTP_TLS\1, context=ssl.create_default_context())
@@ -20391,10 +20426,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9650
-        rv_id: 834615
+        rv_id: 904326
         rule_id: qNUjlR
-        version_id: 0bTw350
-        url: https://semgrep.dev/playground/r/0bTw350/python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
+        version_id: O9Tvq3Y
+        url: https://semgrep.dev/playground/r/O9Tvq3Y/python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls
         origin: community
   severity: WARNING
   languages:
@@ -23077,10 +23112,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 10563
-        rv_id: 834719
+        rv_id: 904977
         rule_id: oqUz5y
-        version_id: l4TyDz7
-        url: https://semgrep.dev/playground/r/l4TyDz7/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        version_id: 2KTdkwe
+        url: https://semgrep.dev/playground/r/2KTdkwe/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
         origin: community
   severity: ERROR
   languages:
@@ -27511,60 +27546,6 @@ rules:
         rule_id: 5rUp5w
         version_id: l4TyDvO
         url: https://semgrep.dev/playground/r/l4TyDvO/terraform.aws.security.aws-lambda-environment-unencrypted.aws-lambda-environment-unencrypted
-        origin: community
-- id: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
-  patterns:
-  - pattern: |
-      resource "aws_lambda_function" $ANYTHING {
-        ...
-      }
-  - pattern-not: |
-      resource "aws_lambda_function" $ANYTHING {
-        ...
-        tracing_config {
-          ...
-          mode = "Active"
-          ...
-        }
-        ...
-      }
-  message: The AWS Lambda function does not have active X-Ray tracing enabled. X-Ray
-    tracing enables end-to-end debugging and analysis of all function activity. This
-    makes it easier to trace the flow of logs and identify bottlenecks, slow downs
-    and timeouts.
-  languages:
-  - hcl
-  severity: INFO
-  metadata:
-    category: security
-    technology:
-    - aws
-    - terraform
-    owasp:
-    - A09:2021 Security Logging and Monitoring Failures
-    cwe:
-    - 'CWE-778: Insufficient Logging'
-    references:
-    - https://cwe.mitre.org/data/definitions/778.html
-    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#mode
-    - https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: LOW
-    confidence: MEDIUM
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    vulnerability_class:
-    - Insufficient Logging
-    source: https://semgrep.dev/r/terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
-    shortlink: https://sg.run/wO2Y
-    semgrep.dev:
-      rule:
-        r_id: 54773
-        rv_id: 834980
-        rule_id: eqUl1O
-        version_id: 6xTDXJ9
-        url: https://semgrep.dev/playground/r/6xTDXJ9/terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
         origin: community
 - patterns:
   - pattern-either:

--- a/assets/semgrep_rules/generated/nonfree/vulns.yaml
+++ b/assets/semgrep_rules/generated/nonfree/vulns.yaml
@@ -15078,10 +15078,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 22076
-        rv_id: 834016
+        rv_id: 904972
         rule_id: 6JUxGN
-        version_id: zyTWJJx
-        url: https://semgrep.dev/playground/r/zyTWJJx/java.spring.security.injection.tainted-system-command.tainted-system-command
+        version_id: YDTY1OG
+        url: https://semgrep.dev/playground/r/YDTY1OG/java.spring.security.injection.tainted-system-command.tainted-system-command
         origin: community
 - id: java.spring.security.injection.tainted-url-host.tainted-url-host
   languages:
@@ -16526,10 +16526,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9244
-        rv_id: 834054
+        rv_id: 904973
         rule_id: 0oU5b5
-        version_id: K3TrqLq
-        url: https://semgrep.dev/playground/r/K3TrqLq/javascript.browser.security.raw-html-concat.raw-html-concat
+        version_id: 6xTylzO
+        url: https://semgrep.dev/playground/r/6xTylzO/javascript.browser.security.raw-html-concat.raw-html-concat
         origin: community
   languages:
   - javascript
@@ -22204,6 +22204,133 @@ rules:
         version_id: A8T376P
         url: https://semgrep.dev/playground/r/A8T376P/php.lang.security.injection.printed-request.printed-request
         origin: community
+- id: php.lang.security.injection.tainted-callable.tainted-callable
+  severity: WARNING
+  message: Callable based on user input risks remote code execution.
+  metadata:
+    technology:
+    - php
+    category: security
+    cwe:
+    - 'CWE-94: Improper Control of Generation of Code (''Code Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://www.php.net/manual/en/language.types.callable.php
+    subcategory:
+    - vuln
+    impact: HIGH
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    vulnerability_class:
+    - Code Injection
+    source: https://semgrep.dev/r/php.lang.security.injection.tainted-callable.tainted-callable
+    shortlink: https://sg.run/YGb33
+    semgrep.dev:
+      rule:
+        r_id: 141958
+        rv_id: 906493
+        rule_id: 0oULBKK
+        version_id: X0TA1AZ
+        url: https://semgrep.dev/playground/r/X0TA1AZ/php.lang.security.injection.tainted-callable.tainted-callable
+        origin: community
+  languages:
+  - php
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: "$_GET"
+      - pattern: "$_POST"
+      - pattern: "$_COOKIE"
+      - pattern: "$_REQUEST"
+      - pattern: file_get_contents('php://input')
+  pattern-sinks:
+  - patterns:
+    - pattern: "$CALLABLE"
+    - pattern-either:
+      - pattern-inside: "$ARRAYITERATOR->uasort($CALLABLE)"
+      - pattern-inside: "$ARRAYITERATOR->uksort($CALLABLE)"
+      - pattern-inside: "$EVENTHTTP->setCallback($CALLABLE, ...)"
+      - pattern-inside: "$EVENTHTTPCONNECTION->setCloseCallback($CALLABLE, ...)"
+      - pattern-inside: "$EVLOOP->fork($CALLABLE, ...)"
+      - pattern-inside: "$EVLOOP->idle($CALLABLE, ...)"
+      - pattern-inside: "$EVLOOP->prepare($CALLABLE, ...)"
+      - pattern-inside: "$EVWATCHER->setCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setClientCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setCompleteCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setCreatedCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setDataCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setExceptionCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setFailCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setStatusCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setWarningCallback($CALLABLE)"
+      - pattern-inside: "$GEARMANCLIENT->setWorkloadCallback($CALLABLE)"
+      - pattern-inside: "$IMAGICK->setProgressMonitor($CALLABLE)"
+      - pattern-inside: "$OAUTHPROVIDER->consumerHandler($CALLABLE)"
+      - pattern-inside: "$OAUTHPROVIDER->tokenHandler($CALLABLE)"
+      - pattern-inside: "$PDO->sqliteCreateCollation($NAME, $CALLABLE)"
+      - pattern-inside: "$PDOSTATEMENT->fetchAll(PDO::FETCH_FUNC, $CALLABLE)"
+      - pattern-inside: "$SQLITE3->createCollation($NAME, $CALLABLE)"
+      - pattern-inside: "$SQLITE3->setAuthorizer($CALLABLE)"
+      - pattern-inside: "$ZIPARCHIVE->registerCancelCallback($CALLABLE)"
+      - pattern-inside: "$ZIPARCHIVE->registerProgressCallback($RATE, $CALLABLE)"
+      - pattern-inside: "$ZMQDEVICE->setIdleCallback($CALLABLE, ...)"
+      - pattern-inside: "$ZMQDEVICE->setTimerCallback($CALLABLE, ...)"
+      - pattern-inside: apcu_entry($KEY, $CALLABLE, ...)
+      - pattern-inside: array_filter($ARRAY, $CALLABLE, ...)
+      - pattern-inside: array_map($CALLABLE, ...)
+      - pattern-inside: array_reduce($ARRAY, $CALLABLE, ...)
+      - pattern-inside: array_walk_recursive($ARRAY, $CALLABLE, ...)
+      - pattern-inside: array_walk($ARRAY, $CALLABLE, ...)
+      - pattern-inside: call_user_func_array($CALLABLE, ...)
+      - pattern-inside: call_user_func($CALLABLE, ...)
+      - pattern-inside: Closure::fromCallable($CALLABLE)
+      - pattern-inside: createCollation($NAME, $CALLABLE)
+      - pattern-inside: eio_grp($CALLABLE, ...)
+      - pattern-inside: eio_nop($PRI, $CALLABLE, ...)
+      - pattern-inside: eio_sync($PRI, $CALLABLE, ...)
+      - pattern-inside: EvPrepare::createStopped($CALLABLE, ...)
+      - pattern-inside: fann_set_callback($ANN, $CALLABLE)
+      - pattern-inside: fdf_enum_values($FDF_DOCUMENT, $CALLABLE, ...)
+      - pattern-inside: forward_static_call_array($CALLABLE, ...)
+      - pattern-inside: forward_static_call($CALLABLE, ...)
+      - pattern-inside: header_register_callback($CALLABLE)
+      - pattern-inside: ibase_set_event_handler($CALLABLE, ...)
+      - pattern-inside: IntlChar::enumCharTypes($CALLABLE)
+      - pattern-inside: iterator_apply($ITERATOR, $CALLABLE)
+      - pattern-inside: ldap_set_rebind_proc($LDAP, $CALLABLE)
+      - pattern-inside: libxml_set_external_entity_loader($CALLABLE, ...)
+      - pattern-inside: new CallbackFilterIterator($ITERATOR, $CALLABLE)
+      - pattern-inside: new EvCheck($CALLABLE, ...)
+      - pattern-inside: new EventHttpRequest($CALLABLE, ...)
+      - pattern-inside: new EvFork($CALLABLE, ...)
+      - pattern-inside: new EvIdle($CALLABLE, ...)
+      - pattern-inside: new Fiber($CALLABLE)
+      - pattern-inside: new Memcached($PERSISTENT_ID, $CALLABLE, ...)
+      - pattern-inside: new RecursiveCallbackFilterIterator($ITERATOR, $CALLABLE)
+      - pattern-inside: new Zookeeper($HOST, $CALLABLE, ...)
+      - pattern-inside: ob_start($CALLABLE, ...)
+      - pattern-inside: oci_register_taf_callback($CONNECTION, $CALLABLE)
+      - pattern-inside: readline_callback_handler_install($PROMPT, $CALLABLE)
+      - pattern-inside: readline_completion_function($CALLABLE)
+      - pattern-inside: register_shutdown_function($CALLABLE, ...)
+      - pattern-inside: register_tick_function($CALLABLE, ...)
+      - pattern-inside: rnp_ffi_set_pass_provider($FFI, $CALLABLE)
+      - pattern-inside: sapi_windows_set_ctrl_handler($CALLABLE, ...)
+      - pattern-inside: set_error_handler($CALLABLE, ...)
+      - pattern-inside: set_exception_handler($CALLABLE)
+      - pattern-inside: setAuthorizer($CALLABLE)
+      - pattern-inside: spl_autoload_register($CALLABLE, ...)
+      - pattern-inside: uasort($ARRAY, $CALLABLE)
+      - pattern-inside: uksort($ARRAY, $CALLABLE)
+      - pattern-inside: usort($ARRAY, $CALLABLE)
+      - pattern-inside: xml_set_character_data_handler($PARSER, $CALLABLE)
+      - pattern-inside: xml_set_default_handler($PARSER, $CALLABLE)
+      - pattern-inside: xml_set_element_handler($PARSER, $CALLABLE, $CALLABLE)
+      - pattern-inside: xml_set_notation_decl_handler($PARSER, $CALLABLE)
+      - pattern-inside: Yar_Concurrent_Client::loop($CALLABLE, ...)
 - id: php.lang.security.injection.tainted-filename.tainted-filename
   severity: WARNING
   message: File name based on user input risks server-side request forgery.
@@ -36072,10 +36199,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33634
-        rv_id: 834677
+        rv_id: 904974
         rule_id: JDUGnK
-        version_id: 6xTDXqe
-        url: https://semgrep.dev/playground/r/6xTDXqe/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
+        version_id: o5TK3Rp
+        url: https://semgrep.dev/playground/r/o5TK3Rp/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
         origin: community
   options:
     symbolic_propagation: true
@@ -36122,10 +36249,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33635
-        rv_id: 834678
+        rv_id: 904975
         rule_id: 5rUr73
-        version_id: o5TB1zx
-        url: https://semgrep.dev/playground/r/o5TB1zx/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
+        version_id: zyTGwQw
+        url: https://semgrep.dev/playground/r/zyTGwQw/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
         origin: community
   options:
     symbolic_propagation: true
@@ -36173,10 +36300,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 33636
-        rv_id: 834679
+        rv_id: 904976
         rule_id: GdUYlW
-        version_id: zyTW3yP
-        url: https://semgrep.dev/playground/r/zyTW3yP/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
+        version_id: pZTbdx8
+        url: https://semgrep.dev/playground/r/pZTbdx8/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
         origin: community
   options:
     symbolic_propagation: true
@@ -37642,10 +37769,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 134692
-        rv_id: 834721
+        rv_id: 904149
         rule_id: oqUgjj2
-        version_id: 6xTDX6e
-        url: https://semgrep.dev/playground/r/6xTDX6e/python.twilio.security.twiml-injection.twiml-injection
+        version_id: qkTpdYy
+        url: https://semgrep.dev/playground/r/qkTpdYy/python.twilio.security.twiml-injection.twiml-injection
         origin: community
   mode: taint
   pattern-sources:

--- a/assets/semgrep_rules/generated/oss/vulns.yaml
+++ b/assets/semgrep_rules/generated/oss/vulns.yaml
@@ -38,10 +38,10 @@ rules:
     semgrep.dev:
       rule:
         r_id: 9211
-        rv_id: 833983
+        rv_id: 904971
         rule_id: j2Uv7B
-        version_id: kbT2llw
-        url: https://semgrep.dev/playground/r/kbT2llw/java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer
+        version_id: l4TXK23
+        url: https://semgrep.dev/playground/r/l4TXK23/java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer
         origin: community
   languages:
   - java


### PR DESCRIPTION
```
@ nonfree.audit (+1, -1)
+ generic.secrets.security.detected-onfido-live-api-token.detected-onfido-live-api-token
- terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
@ nonfree.others (+0, -0)
@ nonfree.security_noaudit_novuln (+0, -5)
- go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion
- javascript.intercom.security.audit.intercom-settings-user-identifier-without-user-hash.intercom-settings-user-identifier-without-user-hash
- python.django.security.django-no-csrf-token.django-no-csrf-token
- python.django.security.django-using-request-post-after-is-valid.django-using-request-post-after-is-valid
- terraform.aws.security.aws-provisioner-exec.aws-provisioner-exec
@ nonfree.vulns (+1, -0)
+ php.lang.security.injection.tainted-callable.tainted-callable
@ oss.audit (+0, -0)
@ oss.others (+0, -0)
@ oss.security_noaudit_novuln (+0, -0)
@ oss.vulns (+0, -0)
```