### PR TITLE
sendSlackMessage: don't send again if the there it increased by one f…

### DIFF
--- a/src/sendSlackMessage.js
+++ b/src/sendSlackMessage.js
@@ -50,6 +50,8 @@ export default async function sendSlackMessage ({
     throw new Error('message || token is required!')
   }
 
+  const filteredMessage = message?.replace(/Findings: \n+/g, 'Findings: n+')
+
   if (colorCodes[color]) {
     color = colorCodes[color]
   }
@@ -68,7 +70,7 @@ export default async function sendSlackMessage ({
   const crypto = await import('crypto')
   const hash = crypto.createHash('sha256')
   if (text !== null) hash.update(text)
-  if (message !== null) hash.update(message)
+  if (filteredMessage !== null) hash.update(filteredMessage)
   if (color !== null) hash.update(color)
   const hashHex = hash.digest('hex')
 


### PR DESCRIPTION
…inding every time

use filteredMessage as a way to prevent over notification on slack. This would not send again any notification if there is an extra finding on a given PR, for the previous 50 message, or a day ago.

This would debounce chaingun messages in any slack channel from the main action itself.

It should not have any other side-effect.

This will effectively change the hash function, so invalidate the debounce for all the previous messages.