### PR TITLE
Allow rules to specify specific repositories to ignore or run in

### DIFF
--- a/.github/workflows/semgrep-self-test.yml
+++ b/.github/workflows/semgrep-self-test.yml
@@ -15,14 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set repository variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - run: |
           python3 -m pip --disable-pip-version-check install -r requirements.txt
         shell: bash
       - run: |
-          cd assets/semgrep_rules/; semgrep --test --disable-version-check --strict --metrics=off
+          cd assets/semgrep_rules/
+          SEMGREP_REPO_NAME=$REPO_NAME semgrep --test --disable-version-check --strict --metrics=off
         shell: bash
       - run: |
-          JSON=$(semgrep \
+          JSON=$(SEMGREP_REPO_NAME=$REPO_NAME semgrep \
             --disable-version-check --strict --metrics=off --json \
             $(find assets/semgrep_rules -name '*.yml' -or -name '*.yaml' -not -name '*.test.yml' -not -name '*.test.yaml' -not -path "assets/semgrep_rules/generated/*" | sed 's/^/-c /g') \
             assets/semgrep_rules/{client,services} || true)


### PR DESCRIPTION
This is useful in the case where we want to make specific modifications to rules for only a select number of repositories. One example of this is that we want to allow expect usage, but still alert on unwrap in Search specific repositories. However, within Brave-core we want to make sure we alert on both. This should allow us to fork rules to make them specific to the repository they run on.