### PR TITLE
brave-third-party-action-not-pinned-to-commit-sha: new policy update

### DIFF
--- a/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
+++ b/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
@@ -6,12 +6,12 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
-      - uses: actions/checkout@v2
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
+      - uses: actions/checkout@v2 # v2.1.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
-      - uses: actions/setup-node@master
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
+      - uses: actions/setup-node@master # v1.2.3
       - run: |
           npm install
           npm build
@@ -20,15 +20,17 @@ jobs:
         with:
           arg1: ${{ secrets.supersecret1 }}
       # ok: brave-third-party-action-not-pinned-to-commit-sha
-      - uses: completely/fakeaction@5fd3084fc36e372ff1fff382a39b10d03659f355
+      - uses: completely/fakeaction@5fd3084fc36e372ff1fff382a39b10d03659f355 # v1.2.3
         with:
           arg2: ${{ secrets.supersecret2 }}
       # ok: brave-third-party-action-not-pinned-to-commit-sha
-      - uses: docker://alpine@sha256:402d21757a03a114d273bbe372fa4b9eca567e8b6c332fa7ebf982b902207242
+      - uses: docker://alpine@sha256:402d21757a03a114d273bbe372fa4b9eca567e8b6c332fa7ebf982b902207242 # v1.2.3
       # ruleid: brave-third-party-action-not-pinned-to-commit-sha
-      - uses: completely/fakeaction@5fd3084
+      - uses: completely/fakeaction@5fd3084 # v1.2.3
         with:
           arg2: ${{ secrets.supersecret2 }}
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
+      - uses: completely/fakeaction@5fd3084
       # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: fakerepo/comment-on-pr@v1
         with:
@@ -40,13 +42,13 @@ jobs:
       - uses: brave/test@v1
       # ok: brave-third-party-action-not-pinned-to-commit-sha
       - uses: brave-experiments/test@v1
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: aws-actions/test@v1
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: github/test@v1
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: ruby/setup-ruby@v1
-      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: slackapi/slack-github-action@v1.24.0
       # ruleid: brave-third-party-action-not-pinned-to-commit-sha
       - uses: fakerepo/comment-on-pr

--- a/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
+++ b/assets/semgrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
@@ -1,28 +1,36 @@
 rules:
   - id: brave-third-party-action-not-pinned-to-commit-sha
+    languages:
+      - yaml
+    severity: ERROR
+    message: An action sourced from a third-party repository on GitHub is not pinned
+      to a full length commit SHA. Pinning an action to a full length commit SHA
+      is currently the only way to use an action as an immutable release.
+      Pinning to a particular SHA helps mitigate the risk of a bad actor adding
+      a backdoor to the action's repository, as they would need to generate a
+      SHA-1 collision for a valid Git object payload.
     patterns:
       - pattern-inside: "{steps: ...}"
-      - pattern: |
-          uses: "$USES"
       - metavariable-pattern:
           metavariable: $USES
           language: generic
           patterns:
             - pattern-not-regex: ^[.]/
-            - pattern-not-regex: ^actions/
             - pattern-not-regex: ^brave/
             - pattern-not-regex: ^brave-intl/
             - pattern-not-regex: ^brave-experiments/
-            - pattern-not-regex: ^github/
-            - pattern-not-regex: ^aws-actions/
-            - pattern-not-regex: ^ruby/
-            - pattern-not-regex: ^slackapi/
             - pattern-not-regex: "@[0-9a-f]{40}$"
             - pattern-not-regex: ^docker://.*@sha256:[0-9a-f]{64}$
-    message: An action sourced from a third-party repository on GitHub is not pinned to a full length commit SHA. Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.
-    languages:
-      - yaml
-    severity: WARNING
+      - pattern-either:
+        - patterns:
+          - pattern-regex: uses:\s+['"]?(?<USES>[^\s'"]*)['"]?(#\s+(?<VERSION>.*))
+          - metavariable-pattern:
+              metavariable: $VERSION
+              language: generic
+              patterns:
+                - pattern-not-regex: ^v\d+\.\d+\.\d+
+                - pattern-not-regex: ^\d+\.\d+\.\d+
+        - pattern-regex: uses:\s+['"]?(?<USES>[^\s'"]*)['"]?
     metadata:
       cwe:
         - "CWE-1357: Reliance on Insufficiently Trustworthy Component"


### PR DESCRIPTION
follow the new policy regarding pinning