### PR TITLE
Remove unsafe_buffers and unsafe_todo rules

### DIFF
--- a/assets/semgrep_rules/client/unsafe-cpp-constructs.cpp
+++ b/assets/semgrep_rules/client/unsafe-cpp-constructs.cpp
@@ -5,10 +5,6 @@
 #pragma allow_unsafe_buffers
 #endif
 // ruleid: unsafe_cpp_constructs
-UNSAFE_BUFFERS(data());
-// ruleid: unsafe_cpp_constructs
-UNSAFE_TODO(base::make_span(&web_script_source, 1u));
-// ruleid: unsafe_cpp_constructs
 std::next(it);
 // ruleid: unsafe_cpp_constructs
 std::advance(cert_iter, cert_idx);

--- a/assets/semgrep_rules/client/unsafe-cpp-constructs.yaml
+++ b/assets/semgrep_rules/client/unsafe-cpp-constructs.yaml
@@ -15,8 +15,6 @@ rules:
     severity: WARNING
     patterns:
       - pattern-either:
-          - pattern: "UNSAFE_TODO(...)"
-          - pattern: "UNSAFE_BUFFERS(...)"
           - pattern: "std::next(...)"
           - pattern: "std::advance(...)"
           - pattern: "std::prev(...)"


### PR DESCRIPTION
Remove these two rules as they are now covered by the new presubmit PR comments: https://bravesoftware.slack.com/archives/C7VLGSR55/p1744661807785779