### PR TITLE
Remove "privacy preserving"

### DIFF
--- a/assets/semgrep_rules/client/privacy.yaml
+++ b/assets/semgrep_rules/client/privacy.yaml
@@ -28,5 +28,3 @@ rules:
       - pattern: "unhackable"
       - pattern: "hackerproof"
       - pattern: "hacker-proof"
-      - pattern: "privacy-preserving"
-      - pattern: "privacy preserving"


### PR DESCRIPTION
This rule generates a lot of noise, and is not very useful for catching things. Let's keep this list for egregious privacy terminology.