### PR TITLE
actions/main: disable error without debug

### DIFF
--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -233,7 +233,7 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
       return
     }
 
-    if (fs.existsSync('reviewdog.fail.log')) {
+    if (fs.existsSync('reviewdog.fail.log') && options.debug) {
       // print reviewdog.fail.log to the console
       const log = fs.readFileSync('reviewdog.fail.log', 'UTF-8').replaceAll(/^/g, CONSOLE_BLUE)
       console.log(`${CONSOLE_RED}This action encountered an error while reporting the following findings via the Github API:`)


### PR DESCRIPTION
it's very noisy due to UserWarning: pkg_resources is deprecated as an API warning.

Find a way to disable this warning, and then revert this one.