### PR TITLE
remove English language exception

### DIFF
--- a/assets/semgrep_rules/client/privacy.yaml
+++ b/assets/semgrep_rules/client/privacy.yaml
@@ -53,7 +53,6 @@ rules:
         - "*.dv.md"
         - "*.nl.md"
         - "*.dz.md"
-        - "*.en.md"
         - "*.eo.md"
         - "*.et.md"
         - "*.ee.md"


### PR DESCRIPTION
We still want to evaluate privacy.en.md since it's in english, but all the other languages are fine to not be included.