### PR TITLE
fix: Add null check for message in renovate-sanity-check action

### DIFF
--- a/actions/renovate-sanity-check/action.cjs
+++ b/actions/renovate-sanity-check/action.cjs
@@ -9,5 +9,5 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     debug
   })
 
-  if (message.length > 0) { await sendSlackMessage({ debug, username: 'renovate-sanity-check', message, color: 'yellow', channel: '#secops-hotspots', token: inputs.slack_token }) }
+  if (message && message.length > 0) { await sendSlackMessage({ debug, username: 'renovate-sanity-check', message, color: 'yellow', channel: '#secops-hotspots', token: inputs.slack_token }) }
 }


### PR DESCRIPTION
- Fixes TypeError when renovateSanityCheck returns undefined
- Only sends Slack message when message exists and has content
- Prevents action from failing when no issues are found