### PR TITLE
Skip Renovate recommendations for empty repositories

### DIFF
--- a/src/renovateSanityCheck.js
+++ b/src/renovateSanityCheck.js
@@ -60,6 +60,12 @@ export default async function renovateSanityCheck ({
     .filter(r => !skipRepositories.includes(r.name))
 
   for (const repo of repos) {
+    // Skip empty repositories - they don't need Renovate
+    if (repo.size === 0 || !repo.default_branch) {
+      if (debug) console.log(`Skipping ${repo.name} - empty repository`)
+      continue
+    }
+
     // renovate.json
     // renovate.json5
     // .github/renovate.json


### PR DESCRIPTION
Empty repositories have no dependencies to manage, so there's no need to flag them as missing Renovate configuration. This change adds a check to skip repos where size is 0 or no default branch exists.