### PR TITLE
Add crash-vs-dump-without-crashing opengrep rule for Chromium

### DIFF
--- a/assets/opengrep_rules/client/crash-vs-dump-without-crashing.cpp
+++ b/assets/opengrep_rules/client/crash-vs-dump-without-crashing.cpp
@@ -1,0 +1,55 @@
+// Test cases for crash-vs-dump-without-crashing rule
+#include "base/debug/dump_without_crashing.h"
+#include "base/check.h"
+
+class TestClass {
+ public:
+  void BadExamples() {
+    // SHOULD TRIGGER: Direct DumpWithoutCrashing usage (should use DUMP_WILL_BE_CHECK)
+    if (some_error_condition_) {
+      // ruleid: chromium-crash-vs-dump-without-crashing
+      base::debug::DumpWithoutCrashing();
+      return;
+    }
+    
+    // SHOULD TRIGGER: Another direct usage
+    if (!IsValidState()) {
+      // ruleid: chromium-crash-vs-dump-without-crashing
+      base::debug::DumpWithoutCrashing();
+      // Continue execution but log crash dump
+    }
+  }
+  
+  void GoodExamples() {
+    // SHOULD NOT TRIGGER: Using DUMP_WILL_BE_CHECK (preferred)
+    if (some_error_condition_) {
+      // ok: chromium-crash-vs-dump-without-crashing
+      DUMP_WILL_BE_CHECK();
+      return;
+    }
+    
+    // SHOULD NOT TRIGGER: Using CHECK for immediate crash
+    // ok: chromium-crash-vs-dump-without-crashing
+    CHECK(IsValidState()) << "Invalid state detected";
+    
+    // SHOULD NOT TRIGGER: Using DCHECK for debug-only checks
+    // ok: chromium-crash-vs-dump-without-crashing
+    DCHECK(some_condition_) << "Debug assertion failed";
+  }
+  
+  void FunctionWithParameters() {
+    // SHOULD NOT TRIGGER: DumpWithoutCrashing with parameters (internal usage)
+    if (critical_error_) {
+      // ok: chromium-crash-vs-dump-without-crashing
+      base::debug::DumpWithoutCrashing(FROM_HERE, base::Days(1));
+      return;
+    }
+  }
+  
+ private:
+  bool some_error_condition_ = false;
+  bool some_condition_ = true;
+  bool critical_error_ = false;
+  
+  bool IsValidState() const { return true; }
+};

--- a/assets/opengrep_rules/client/crash-vs-dump-without-crashing.yaml
+++ b/assets/opengrep_rules/client/crash-vs-dump-without-crashing.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: chromium-crash-vs-dump-without-crashing
+    metadata:
+      author: Andrea Brancaleoni <abc@pompel.me>
+      references:
+        - https://chromium.googlesource.com/chromium/src/+/main/base/check.h#324
+      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/crash-vs-dump-without-crashing.yaml
+      assignees: |
+        thypon
+        cdesouza-chromium
+      category: correctness
+    languages:
+      - cpp
+      - c
+    message: |
+      Consider using DUMP_WILL_BE_CHECK() instead of base::debug::DumpWithoutCrashing()
+      when the intent is to eventually become a CHECK, as it better communicates this
+      intent and provides better debugging information. However, DumpWithoutCrashing()
+      is appropriate for debugging issues that may not become CHECKs.
+    severity: INFO
+    patterns:
+      - pattern: base::debug::DumpWithoutCrashing()
+      - pattern-not-inside: |
+          void $FUNC(...) {
+            ...
+            base::debug::DumpWithoutCrashing($LOCATION, $INTERVAL);
+            ...
+          }


### PR DESCRIPTION
Supersedes: #855