### PR TITLE
add sources.gni to replace codeowner

### DIFF
--- a/assets/opengrep_rules/client/java_sources_gni.gni
+++ b/assets/opengrep_rules/client/java_sources_gni.gni
@@ -1,0 +1,12 @@
+brave_java_sources = [
+  # ruleid:java_sources_gni
+  "../../brave/android/java/org/chromium/chrome/browser/BraveAdFreeCalloutDialogFragment.java",
+  # ruleid:java_sources_gni
+  "BraveAppHooks.java",
+]
+
+# ruleid:java_sources_gni
+brave_java_sources += brave_ads_java_sources
+
+# ok:java_sources_gni
+brave_java_deps += brave_ads_java_deps

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -11,7 +11,7 @@ rules:
     severity: ERROR
     paths:
       include:
-        - "*java*sources.gni"
+        - "*java*sources*.gni"
     message: >
       New source files should not be added to sources.gni. Please see
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -12,6 +12,7 @@ rules:
     paths:
       include:
         - "brave_java_sources.gni"
+        - "*_sources.gni"
     message: >
       New source files should not be added to sources.gni. Please see
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: java_sources_gni
+    metadata:
+      author: Brian Johnson
+      references:
+        - https://github.com/brave/brave-core/blob/master/docs/gni_sources.md
+      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sources_gni.yaml
+      assignees: |
+        brave/Android
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "brave_java_sources.gni"
+    message: >
+      New source files should not be added to sources.gni. Please see
+      https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for
+      details
+    pattern-either:
+      - pattern-regex: .*\.java
+      - pattern-regex: brave_java_sources \+= .*

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -11,12 +11,11 @@ rules:
     severity: ERROR
     paths:
       include:
-        - "brave_java_sources.gni"
-        - "*_sources.gni"
+        - "*java*sources.gni"
     message: >
       New source files should not be added to sources.gni. Please see
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for
       details
     pattern-either:
       - pattern-regex: .*\.java
-      - pattern-regex: brave_java_sources \+= .*
+      - pattern-regex: .*_sources \+= .*

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -6,12 +6,12 @@ rules:
         - https://github.com/brave/brave-core/blob/master/docs/gni_sources.md
       source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sources_gni.yaml
       assignees: |
-        brave/Android
+        brave/java-sources-gni-reviewers
     languages: [generic]
     severity: ERROR
     paths:
       include:
-        - "*java*sources*.gni"
+        - "*java*_sources*.gni"
     message: >
       New source files should not be added to sources.gni. Please see
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for

--- a/assets/opengrep_rules/client/java_sources_gni.yaml
+++ b/assets/opengrep_rules/client/java_sources_gni.yaml
@@ -2,9 +2,10 @@ rules:
   - id: java_sources_gni
     metadata:
       author: Brian Johnson
+      category: correctness
       references:
         - https://github.com/brave/brave-core/blob/master/docs/gni_sources.md
-      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sources_gni.yaml
+      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/java_sources_gni.yaml
       assignees: |
         brave/java-sources-gni-reviewers
     languages: [generic]

--- a/assets/opengrep_rules/client/sources_gni.gni
+++ b/assets/opengrep_rules/client/sources_gni.gni
@@ -1,0 +1,18 @@
+# ruleid:sources_gni
+brave_chrome_browser_sources = [
+  "//brave/browser/brave_browser_features.cc",
+  "//brave/browser/brave_browser_features.h",
+  "//brave/browser/brave_browser_main_extra_parts.cc",
+  "//brave/browser/brave_browser_main_extra_parts.h",
+  "//brave/browser/brave_browser_main_parts.cc",
+  "//brave/browser/brave_browser_main_parts.h",
+]
+
+# ok:sources_gni
+brave_chrome_browser_deps = [
+  "//base",
+  "//brave/app:brave_generated_resources_grit",
+  "//brave/browser:browser_process",
+  "//brave/browser:sparkle_buildflags",
+  "//brave/browser/ai_chat",
+]

--- a/assets/opengrep_rules/client/sources_gni.gni
+++ b/assets/opengrep_rules/client/sources_gni.gni
@@ -11,10 +11,3 @@ brave_chrome_browser_deps = [
   # ok:sources_gni
   "//brave/app:brave_generated_resources_grit",
 ]
-
-brave_java_sources = [
-  # ruleid:sources_gni
-  "../../brave/android/java/org/chromium/chrome/browser/BraveAdFreeCalloutDialogFragment.java",
-  # ruleid:sources_gni
-  "BraveAppHooks.java",
-]

--- a/assets/opengrep_rules/client/sources_gni.gni
+++ b/assets/opengrep_rules/client/sources_gni.gni
@@ -11,3 +11,10 @@ brave_chrome_browser_deps = [
   # ok:sources_gni
   "//brave/app:brave_generated_resources_grit",
 ]
+
+brave_java_sources = [
+  # ruleid:sources_gni
+  "../../brave/android/java/org/chromium/chrome/browser/BraveAdFreeCalloutDialogFragment.java",
+  # ruleid:sources_gni
+  "BraveAppHooks.java",
+]

--- a/assets/opengrep_rules/client/sources_gni.gni
+++ b/assets/opengrep_rules/client/sources_gni.gni
@@ -1,18 +1,13 @@
-# ruleid:sources_gni
 brave_chrome_browser_sources = [
+  # ruleid:sources_gni
   "//brave/browser/brave_browser_features.cc",
-  "//brave/browser/brave_browser_features.h",
-  "//brave/browser/brave_browser_main_extra_parts.cc",
-  "//brave/browser/brave_browser_main_extra_parts.h",
-  "//brave/browser/brave_browser_main_parts.cc",
-  "//brave/browser/brave_browser_main_parts.h",
+  # ruleid:sources_gni
+  "brave_browser_features.h",
 ]
 
-# ok:sources_gni
 brave_chrome_browser_deps = [
+  # ok:sources_gni
   "//base",
+  # ok:sources_gni
   "//brave/app:brave_generated_resources_grit",
-  "//brave/browser:browser_process",
-  "//brave/browser:sparkle_buildflags",
-  "//brave/browser/ai_chat",
 ]

--- a/assets/opengrep_rules/client/sources_gni.yaml
+++ b/assets/opengrep_rules/client/sources_gni.yaml
@@ -23,3 +23,4 @@ rules:
       - pattern-regex: .*\.mm
       - pattern-regex: .*\.cpp
       - pattern-regex: .*\.hpp
+      - pattern-regex: .*\.java

--- a/assets/opengrep_rules/client/sources_gni.yaml
+++ b/assets/opengrep_rules/client/sources_gni.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: sources_gni
+    metadata:
+      author: Brian Johnson
+      references:
+        - https://github.com/brave/brave-core/blob/master/docs/gni_sources.md
+      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sources_gni.yaml
+      assignees: |
+        brave/sources-gni-reviewers
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "*_sources.gni"
+        - "sources.gni"
+    message: >
+      New source files should not be added to sources.gni. Please see
+      https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for
+      details
+    pattern-either:
+      - pattern-regex: .*\.h
+      - pattern-regex: .*\.cc
+      - pattern-regex: .*\.mm
+      - pattern-regex: .*\.cpp
+      - pattern-regex: .*\.hpp

--- a/assets/opengrep_rules/client/sources_gni.yaml
+++ b/assets/opengrep_rules/client/sources_gni.yaml
@@ -13,6 +13,7 @@ rules:
       include:
         - "*_sources.gni"
         - "sources.gni"
+        - "sources_gni.gni"
     message: >
       New source files should not be added to sources.gni. Please see
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for

--- a/assets/opengrep_rules/client/sources_gni.yaml
+++ b/assets/opengrep_rules/client/sources_gni.yaml
@@ -2,6 +2,7 @@ rules:
   - id: sources_gni
     metadata:
       author: Brian Johnson
+      category: correctness
       references:
         - https://github.com/brave/brave-core/blob/master/docs/gni_sources.md
       source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sources_gni.yaml


### PR DESCRIPTION
Convert brave-core sources.gni https://github.com/brave/brave-core/blob/master/.github/CODEOWNERS#L229C16-L229C44 entries to semgrep to cut down on false positives 