### PR TITLE
Add CODEOWNERS comment feature to PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run lint-rules
+      - run: npm test
       - if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         run: npm audit

--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -125,6 +125,24 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     fs.writeFileSync(`${actionPath}/assets/all_changed_files.txt`, changedFiles.join('\0'))
     debugLog('Wrote changed files to file')
 
+    // codeowners matching step
+    const { default: matchCodeowners } = await import(`${actionPath}/src/matchCodeowners.js`)
+    const { default: codeownersComment } = await import(`${actionPath}/src/steps/codeownersComment.js`)
+
+    const codeownersMatch = matchCodeowners({
+      changedFiles,
+      basePath: process.cwd(),
+      debug: options.debug
+    })
+
+    await codeownersComment({
+      context,
+      github,
+      matchResult: codeownersMatch,
+      debug: options.debug
+    })
+    debugLog('Posted codeowners comment')
+
     // comments-before steps
     const { default: commentsNumber } = await import(`${actionPath}/src/steps/commentsNumber.js`)
     const { default: cleanupComments } = await import(`${actionPath}/src/steps/cleanupComments.js`)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "scripts": {
         "lint": "standard --ignore assets/opengrep_rules",
         "lint-fix": "standard --fix --ignore assets/opengrep_rules",
-        "lint-rules": "node src/checkRuleMetadata.js"
+        "lint-rules": "node src/checkRuleMetadata.js",
+        "test": "find src -name '*.test.js' -type f -exec node {} \\;"
     },
     "dependencies": {
         "@octokit/core": "^6.1.4",

--- a/src/matchCodeowners.js
+++ b/src/matchCodeowners.js
@@ -1,0 +1,238 @@
+/**
+ * Match files against CODEOWNERS file patterns.
+ * This module reads changed files and identifies their code owners.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Find CODEOWNERS file using GitHub's search order:
+ * 1. .github/CODEOWNERS
+ * 2. CODEOWNERS
+ * 3. docs/CODEOWNERS
+ */
+export function findCodeownersPath (basePath = '.') {
+  const searchPaths = [
+    path.join(basePath, '.github/CODEOWNERS'),
+    path.join(basePath, 'CODEOWNERS'),
+    path.join(basePath, 'docs/CODEOWNERS')
+  ]
+
+  for (const searchPath of searchPaths) {
+    if (fs.existsSync(searchPath)) {
+      return searchPath
+    }
+  }
+
+  return null
+}
+
+/**
+ * Parse CODEOWNERS file and return list of [pattern, owners] entries.
+ * Returns patterns in order (more specific patterns should come first).
+ */
+export function parseCodeowners (codeownersPath) {
+  const patterns = []
+
+  if (!codeownersPath || !fs.existsSync(codeownersPath)) {
+    return patterns
+  }
+
+  const content = fs.readFileSync(codeownersPath, 'utf-8')
+  const lines = content.split('\n')
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const parts = trimmed.split(/\s+/)
+    if (parts.length < 2) {
+      continue
+    }
+
+    const pattern = parts[0]
+    const owners = parts.slice(1)
+    patterns.push([pattern, owners])
+  }
+
+  return patterns
+}
+
+/**
+ * Convert CODEOWNERS glob pattern to regex.
+ * CODEOWNERS patterns follow gitignore-style glob patterns.
+ */
+export function patternToRegex (pattern) {
+  let regex = pattern
+
+  // Handle glob patterns BEFORE escaping
+  // Special case: /**/ should match zero or more directories
+  regex = regex.replace(/\/\*\*\//g, '___DOUBLESLASH___')
+  // Replace ** with a placeholder
+  regex = regex.replace(/\*\*/g, '___DOUBLESTAR___')
+  // Replace single * with placeholder
+  regex = regex.replace(/\*/g, '___STAR___')
+
+  // Escape special regex characters
+  regex = regex.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+
+  // Replace placeholders with regex patterns
+  // /**/ matches zero or more path segments (including none)
+  regex = regex.replace(/___DOUBLESLASH___/g, '(/.*)?/')
+  // ** matches any number of characters (including /)
+  regex = regex.replace(/___DOUBLESTAR___/g, '.*')
+  // * matches anything except /
+  regex = regex.replace(/___STAR___/g, '[^/]*')
+
+  // If pattern starts with /, it's from root
+  if (pattern.startsWith('/')) {
+    regex = '^' + regex.substring(1) // Remove leading / and anchor to start
+  } else {
+    // Pattern can match anywhere in path
+    regex = '(^|/)' + regex
+  }
+
+  // If pattern ends with /, it matches directories
+  if (pattern.endsWith('/')) {
+    regex = regex + '.*'
+  } else {
+    // Match exact file or directory
+    regex = regex + '($|/)'
+  }
+
+  return new RegExp(regex)
+}
+
+/**
+ * Find owners for a given file path.
+ * Returns the most specific matching pattern's owners.
+ * CODEOWNERS uses the last matching pattern (most specific).
+ */
+export function findOwners (filePath, patterns) {
+  let matchedOwners = []
+
+  for (const [pattern, owners] of patterns) {
+    const regex = patternToRegex(pattern)
+    if (regex.test(filePath)) {
+      matchedOwners = owners
+    }
+  }
+
+  return matchedOwners
+}
+
+/**
+ * Match changed files against CODEOWNERS patterns.
+ * Returns a mapping of owners to their files and files without owners.
+ */
+export default function matchCodeowners ({
+  changedFiles,
+  codeownersPath = null,
+  basePath = '.',
+  debug = false
+}) {
+  debug = debug === 'true' || debug === true
+
+  // Auto-detect CODEOWNERS file if not specified
+  if (!codeownersPath) {
+    codeownersPath = findCodeownersPath(basePath)
+  }
+
+  if (!codeownersPath) {
+    if (debug) {
+      console.log('No CODEOWNERS file found')
+    }
+    return {
+      ownersToFiles: {},
+      filesWithoutOwners: changedFiles,
+      stats: {
+        totalFiles: changedFiles.length,
+        filesWithOwners: 0,
+        filesWithoutOwners: changedFiles.length,
+        uniqueOwners: 0,
+        teams: 0,
+        individuals: 0,
+        teamsList: [],
+        individualsList: []
+      }
+    }
+  }
+
+  if (debug) {
+    console.log(`Loading CODEOWNERS from ${codeownersPath}...`)
+  }
+
+  const patterns = parseCodeowners(codeownersPath)
+
+  if (debug) {
+    console.log(`Found ${patterns.length} ownership patterns`)
+    console.log(`Analyzing ${changedFiles.length} changed files`)
+  }
+
+  // Map owners to their files
+  const ownersToFiles = {}
+  const filesWithoutOwners = []
+
+  for (const filePath of changedFiles) {
+    const owners = findOwners(filePath, patterns)
+
+    if (owners.length > 0) {
+      for (const owner of owners) {
+        if (!ownersToFiles[owner]) {
+          ownersToFiles[owner] = []
+        }
+        ownersToFiles[owner].push(filePath)
+      }
+    } else {
+      filesWithoutOwners.push(filePath)
+    }
+  }
+
+  // Sort owners by number of affected files (descending)
+  const sortedOwners = Object.entries(ownersToFiles)
+    .sort((a, b) => b[1].length - a[1].length)
+
+  // Calculate statistics
+  const teams = new Set()
+  const individuals = new Set()
+
+  for (const owner of Object.keys(ownersToFiles)) {
+    if (owner.startsWith('@') && owner.includes('/')) {
+      teams.add(owner)
+    } else {
+      individuals.add(owner)
+    }
+  }
+
+  const result = {
+    ownersToFiles: Object.fromEntries(sortedOwners),
+    filesWithoutOwners,
+    stats: {
+      totalFiles: changedFiles.length,
+      filesWithOwners: changedFiles.length - filesWithoutOwners.length,
+      filesWithoutOwners: filesWithoutOwners.length,
+      uniqueOwners: Object.keys(ownersToFiles).length,
+      teams: teams.size,
+      individuals: individuals.size,
+      teamsList: Array.from(teams).sort(),
+      individualsList: Array.from(individuals).sort()
+    }
+  }
+
+  if (debug) {
+    console.log('\nCodeowners matching results:')
+    console.log(`- Total files: ${result.stats.totalFiles}`)
+    console.log(`- Files with owners: ${result.stats.filesWithOwners}`)
+    console.log(`- Files without owners: ${result.stats.filesWithoutOwners}`)
+    console.log(`- Unique owners: ${result.stats.uniqueOwners}`)
+    console.log(`- Teams: ${result.stats.teams}`)
+    console.log(`- Individuals: ${result.stats.individuals}`)
+  }
+
+  return result
+}

--- a/src/matchCodeowners.test.js
+++ b/src/matchCodeowners.test.js
@@ -1,0 +1,165 @@
+/**
+ * Tests for matchCodeowners module
+ */
+
+import matchCodeowners, { parseCodeowners, patternToRegex, findOwners, findCodeownersPath } from './matchCodeowners.js'
+import { strict as assert } from 'assert'
+
+// Mock fs for testing
+import fs from 'fs'
+
+// Test parseCodeowners
+console.log('Testing parseCodeowners...')
+const mockCodeownersContent = `# This is a comment
+* @global-owner
+
+/assets/ @acme/assets-team
+*.js @javascript-team
+docs/ @myorg/docs-team @bob
+/src/**/*.test.js @test-team
+`
+const originalReadFileSync = fs.readFileSync
+const originalExistsSync = fs.existsSync
+
+fs.readFileSync = (path, encoding) => {
+  if (path === 'test-codeowners') {
+    return mockCodeownersContent
+  }
+  return originalReadFileSync(path, encoding)
+}
+
+fs.existsSync = (path) => {
+  if (path === 'test-codeowners') {
+    return true
+  }
+  return originalExistsSync(path)
+}
+
+const patterns = parseCodeowners('test-codeowners')
+assert.equal(patterns.length, 5, 'Should parse 5 patterns')
+assert.deepEqual(patterns[0], ['*', ['@global-owner']], 'First pattern should be global owner')
+assert.deepEqual(patterns[1], ['/assets/', ['@acme/assets-team']], 'Second pattern should be assets team')
+assert.deepEqual(patterns[3], ['docs/', ['@myorg/docs-team', '@bob']], 'Fourth pattern should have multiple owners')
+console.log('✓ parseCodeowners works correctly')
+
+// Test patternToRegex
+console.log('\nTesting patternToRegex...')
+
+// Test wildcard patterns
+let regex = patternToRegex('*.js')
+assert.equal(regex.test('file.js'), true, '*.js should match file.js')
+assert.equal(regex.test('path/to/file.js'), true, '*.js should match path/to/file.js')
+assert.equal(regex.test('file.ts'), false, '*.js should not match file.ts')
+
+// Test directory patterns
+regex = patternToRegex('/assets/')
+assert.equal(regex.test('assets/file.txt'), true, '/assets/ should match assets/file.txt')
+assert.equal(regex.test('other/assets/file.txt'), false, '/assets/ should not match other/assets/file.txt')
+
+// Test double wildcard
+regex = patternToRegex('/src/**/*.test.js')
+assert.equal(regex.test('src/foo/bar/baz.test.js'), true, 'Should match nested test files')
+assert.equal(regex.test('src/foo.test.js'), true, 'Should match direct test files')
+assert.equal(regex.test('other/src/foo.test.js'), false, 'Should not match if not from root')
+
+console.log('✓ patternToRegex works correctly')
+
+// Test findOwners
+console.log('\nTesting findOwners...')
+
+// Last matching pattern wins (most specific)
+const testPatterns = [
+  ['*', ['@global-owner']],
+  ['*.js', ['@javascript-team']],
+  ['/src/**/*.test.js', ['@test-team']]
+]
+
+let owners = findOwners('README.md', testPatterns)
+assert.deepEqual(owners, ['@global-owner'], 'README.md should match global owner')
+
+owners = findOwners('script.js', testPatterns)
+assert.deepEqual(owners, ['@javascript-team'], 'script.js should match javascript team')
+
+owners = findOwners('src/foo/bar.test.js', testPatterns)
+assert.deepEqual(owners, ['@test-team'], 'Test file should match test team (most specific)')
+
+console.log('✓ findOwners works correctly')
+
+// Test findCodeownersPath
+console.log('\nTesting findCodeownersPath...')
+
+// Mock different locations
+fs.existsSync = (path) => {
+  if (path === '.github/CODEOWNERS') {
+    return true
+  }
+  return false
+}
+
+let foundPath = findCodeownersPath('.')
+assert.equal(foundPath, '.github/CODEOWNERS', 'Should find .github/CODEOWNERS first')
+
+// Test fallback to root
+fs.existsSync = (path) => {
+  if (path === 'CODEOWNERS') {
+    return true
+  }
+  return false
+}
+
+foundPath = findCodeownersPath('.')
+assert.equal(foundPath, 'CODEOWNERS', 'Should fallback to root CODEOWNERS')
+
+// Test fallback to docs
+fs.existsSync = (path) => {
+  if (path === 'docs/CODEOWNERS') {
+    return true
+  }
+  return false
+}
+
+foundPath = findCodeownersPath('.')
+assert.equal(foundPath, 'docs/CODEOWNERS', 'Should fallback to docs/CODEOWNERS')
+
+// Test not found
+fs.existsSync = () => false
+foundPath = findCodeownersPath('.')
+assert.equal(foundPath, null, 'Should return null if not found')
+
+console.log('✓ findCodeownersPath works correctly')
+
+// Test team vs individual detection
+console.log('\nTesting team vs individual detection...')
+
+const testFiles = ['file1.js', 'file2.md', 'file3.txt']
+fs.readFileSync = (path) => {
+  if (path === 'test-codeowners-2') {
+    return `*.js @acme/frontend-team @github/security
+*.md @alice
+*.txt @bob`
+  }
+  return originalReadFileSync(path)
+}
+
+fs.existsSync = (path) => path === 'test-codeowners-2'
+
+const result = matchCodeowners({
+  changedFiles: testFiles,
+  codeownersPath: 'test-codeowners-2',
+  debug: false
+})
+
+assert.equal(result.stats.teams, 2, 'Should detect 2 teams')
+assert.equal(result.stats.individuals, 2, 'Should detect 2 individuals')
+assert.ok(result.stats.teamsList.includes('@acme/frontend-team'), 'Should include @acme/frontend-team')
+assert.ok(result.stats.teamsList.includes('@github/security'), 'Should include @github/security')
+assert.ok(result.stats.individualsList.includes('@alice'), 'Should include @alice')
+assert.ok(result.stats.individualsList.includes('@bob'), 'Should include @bob')
+
+console.log('✓ Team vs individual detection works correctly')
+
+// Restore mocks
+fs.readFileSync = originalReadFileSync
+fs.existsSync = originalExistsSync
+
+console.log('\n✅ All tests passed!')

--- a/src/steps/codeownersComment.js
+++ b/src/steps/codeownersComment.js
@@ -1,0 +1,187 @@
+/**
+ * Generate and post a GitHub comment showing code owners for changed files.
+ * Removes old codeowners comments and posts a new one.
+ */
+
+import crypto from 'crypto'
+
+const COMMENT_IDENTIFIER = '<!-- security-action:codeowners-summary -->'
+const MAX_FILES_BEFORE_COLLAPSE = 5
+
+/**
+ * Generate GitHub PR file diff anchor hash
+ * GitHub uses SHA256 hash of the file path for #diff-<hash> anchors
+ */
+function generateFileDiffHash (filePath) {
+  return crypto.createHash('sha256').update(filePath).digest('hex')
+}
+
+/**
+ * Format file list with collapsible details if needed
+ */
+function formatFileList (files, repoOwner, repoName, prNumber, maxVisible = MAX_FILES_BEFORE_COLLAPSE) {
+  const sortedFiles = files.sort()
+
+  if (sortedFiles.length === 0) {
+    return ''
+  }
+
+  let output = ''
+
+  // Show first N files directly
+  const visibleFiles = sortedFiles.slice(0, maxVisible)
+  for (const file of visibleFiles) {
+    const diffHash = generateFileDiffHash(file)
+    const fileUrl = `https://github.com/${repoOwner}/${repoName}/pull/${prNumber}/files#diff-${diffHash}`
+    output += `- [\`${file}\`](${fileUrl})\n`
+  }
+
+  // Collapse remaining files if more than maxVisible
+  if (sortedFiles.length > maxVisible) {
+    const remainingFiles = sortedFiles.slice(maxVisible)
+    output += '\n<details>\n'
+    output += `<summary>... and ${remainingFiles.length} more files</summary>\n\n`
+
+    for (const file of remainingFiles) {
+      const diffHash = generateFileDiffHash(file)
+      const fileUrl = `https://github.com/${repoOwner}/${repoName}/pull/${prNumber}/files#diff-${diffHash}`
+      output += `- [\`${file}\`](${fileUrl})\n`
+    }
+
+    output += '</details>\n'
+  }
+
+  return output
+}
+
+/**
+ * Generate markdown comment body
+ */
+function generateCommentBody (matchResult, repoOwner, repoName, prNumber) {
+  const { ownersToFiles, filesWithoutOwners, stats } = matchResult
+
+  let body = COMMENT_IDENTIFIER + '\n'
+  body += '## 📋 Code Owners Summary\n\n'
+
+  if (stats.uniqueOwners === 0 && stats.filesWithoutOwners === 0) {
+    body += '_No files require code owner review._\n'
+    return body
+  }
+
+  body += `**${stats.totalFiles}** file(s) changed\n`
+  body += `- **${stats.filesWithOwners}** with assigned owners\n`
+  body += `- **${stats.filesWithoutOwners}** without owners\n\n`
+
+  if (stats.teams > 0) {
+    body += `**${stats.teams}** team(s) affected: ${stats.teamsList.join(', ')}\n`
+  }
+
+  if (stats.individuals > 0) {
+    body += `**${stats.individuals}** individual(s) affected: ${stats.individualsList.join(', ')}\n`
+  }
+
+  body += '\n---\n\n'
+
+  // Show owners sorted by number of files
+  if (Object.keys(ownersToFiles).length > 0) {
+    body += '### Owners and Their Files\n\n'
+
+    for (const [owner, files] of Object.entries(ownersToFiles)) {
+      const ownerDisplay = owner.startsWith('@') ? owner : `@${owner}`
+      body += `#### ${ownerDisplay} — ${files.length} file(s)\n\n`
+      body += formatFileList(files, repoOwner, repoName, prNumber)
+      body += '\n'
+    }
+  }
+
+  // Show files without owners
+  if (filesWithoutOwners.length > 0) {
+    body += '### ⚠️ Files Without Owners\n\n'
+    body += formatFileList(filesWithoutOwners, repoOwner, repoName, prNumber)
+  }
+
+  return body
+}
+
+/**
+ * Find existing codeowners comment
+ */
+async function findExistingComment ({ context, github }) {
+  const comments = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number
+  })
+
+  return comments.data.find(comment =>
+    comment.body && comment.body.includes(COMMENT_IDENTIFIER)
+  )
+}
+
+/**
+ * Delete existing codeowners comment
+ */
+async function deleteExistingComment ({ context, github }) {
+  const existingComment = await findExistingComment({ context, github })
+
+  if (existingComment) {
+    await github.rest.issues.deleteComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id
+    })
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Post or update codeowners comment
+ */
+export default async function codeownersComment ({
+  context,
+  github,
+  matchResult,
+  debug = false
+}) {
+  debug = debug === 'true' || debug === true
+
+  if (debug) {
+    console.log('Generating codeowners comment...')
+  }
+
+  // Delete existing comment first
+  const deleted = await deleteExistingComment({ context, github })
+
+  if (debug && deleted) {
+    console.log('Deleted existing codeowners comment')
+  }
+
+  // Generate new comment body
+  const body = generateCommentBody(
+    matchResult,
+    context.repo.owner,
+    context.repo.repo,
+    context.issue.number
+  )
+
+  if (debug) {
+    console.log('Comment body:')
+    console.log(body)
+  }
+
+  // Post new comment
+  const comment = await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+    body
+  })
+
+  if (debug) {
+    console.log(`Posted codeowners comment: ${comment.data.html_url}`)
+  }
+
+  return comment.data
+}


### PR DESCRIPTION
This commit introduces automatic CODEOWNERS analysis and comment posting on pull requests, helping reviewers and authors quickly identify which teams and individuals are responsible for reviewing changed files.

Key features:
- Automatic CODEOWNERS file discovery following GitHub's standard search order (.github/CODEOWNERS, root CODEOWNERS, docs/CODEOWNERS)
- Full glob pattern support including wildcards (*), double wildcards (**), and directory patterns
- Team vs individual detection (works with any GitHub organization)
- Collapsible file lists (first 5 files shown, rest collapsed)
- Direct links to PR file diffs for easy navigation
- Automatic cleanup of old codeowners comments to prevent spam
- Statistics showing affected teams, individuals, and ownership coverage

Implementation:
- src/matchCodeowners.js: Core pattern matching and file discovery logic
- src/steps/codeownersComment.js: GitHub comment generation and posting
- actions/main/action.cjs: Integration into PR workflow
- src/matchCodeowners.test.js: Comprehensive test suite

The feature activates automatically on PRs when a CODEOWNERS file is present in the repository, requiring no additional configuration.