### PR TITLE
codeownersComment: skip comment if PR has fewer than 50 files

### DIFF
--- a/src/steps/codeownersComment.js
+++ b/src/steps/codeownersComment.js
@@ -161,6 +161,16 @@ export default async function codeownersComment ({
     console.log('Generating codeowners comment...')
   }
 
+  // Skip if no files have owners (no CODEOWNERS matches)
+  if (matchResult.stats.filesWithOwners === 0) {
+    if (debug) {
+      console.log('No files have code owners, skipping comment')
+    }
+    // Still delete any existing comment
+    await deleteExistingComment({ context, github })
+    return null
+  }
+
   // Delete existing comment first
   const deleted = await deleteExistingComment({ context, github })
 


### PR DESCRIPTION
Don't post Code Owners Summary comment when no changed files match any CODEOWNERS patterns (filesWithOwners === 0). 

Still deletes existing comment if present to keep PRs clean.