### PR TITLE
Add configurability options for codeowners comments

### DIFF
--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -63,7 +63,9 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     baseline_scan_only: 'true',
     assignees: ASSIGNEES,
     hotwords: HOTWORDS,
-    hotwords_enabled: 'true'
+    hotwords_enabled: 'true',
+    codeowners_min_files: '50',
+    codeowners_mode: 'groups'
   }, config, properties, inputs)
 
   options.enabled = options.enabled === 'true'
@@ -139,7 +141,9 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
       context,
       github,
       matchResult: codeownersMatch,
-      debug: options.debug
+      debug: options.debug,
+      minFiles: options.codeowners_min_files,
+      mode: options.codeowners_mode
     })
     debugLog('Posted codeowners comment')
 

--- a/actions/main/action.yml
+++ b/actions/main/action.yml
@@ -41,6 +41,12 @@ inputs:
   gh_to_slack_user_map:
     description: JSON map of github usernames to slack usernames
     required: false
+  codeowners_min_files:
+    description: Minimum number of changed files to trigger codeowners comment (default 50)
+    required: false
+  codeowners_mode:
+    description: 'When to post codeowners comment: never, groups, always (default: groups)'
+    required: false
 outputs:
   reviewdog-findings:
     description: number of reviewdog findings


### PR DESCRIPTION
Add two new configuration options:

- codeowners_min_files: Minimum number of changed files to trigger comment (default: 50)
- codeowners_mode: Control when to post comments with options:
  - "never": Never post codeowners comments
  - "groups": Only post if teams/groups are assigned (default)
  - "always": Post even if only individuals are assigned

These can be configured via action inputs, .github/security-action.json, or repository custom properties with security_action_ prefix.