### PR TITLE
feat(slack): add threaded messaging for PR notifications

### DIFF
--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, unlabeled]
     branches: [main]
 permissions:
   actions: read
@@ -29,4 +29,5 @@ jobs:
         with:
           debug: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
           gh_to_slack_user_map: ${{ secrets.GH_TO_SLACK_USER_MAP }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # security-action
 
-Composite GitHub CI Action[^1] containing the minimal viable security lint for brave repositories
+Composite GitHub CI Action[^1] containing the minimal viable security lint for
+brave repositories
 
 ## Usage
 
-Add an action under `.github/workflow/security-action.yml` with the following content:
+Add an action under `.github/workflow/security-action.yml` with the following
+content:
 
 ```yml
 name: security
@@ -36,12 +38,35 @@ jobs:
             yoursecondsecuritycontact
 ```
 
+### Slack Threading and Completion Notifications
+
+When a Slack token is configured, this action uses threaded messages to reduce
+channel noise:
+
+- **First run for a PR**: Creates a new thread in the Slack channel
+- **Subsequent runs**: Replies are posted to the existing thread
+- **Review completion**: When the `needs-security-review` label is removed by an
+  assignee, a completion message is posted to the thread with a ✅ checkmark
+  reaction on the parent message
+
+To receive completion notifications when the security review label is removed,
+add the `unlabeled` event type to your workflow:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, unlabeled]
+```
+
 ## Branching Strategy
 
-- main branch, this should be tracked and included by all the repositories, without versioning. It should be always "stable" and contain the latest and greatest security checks
-- feature/*, feature branches including new security checkers
-- bugfix/*, fixes for specific bugs in the action
+- main branch, this should be tracked and included by all the repositories,
+  without versioning. It should be always "stable" and contain the latest and
+  greatest security checks
+- feature/\*, feature branches including new security checkers
+- bugfix/\*, fixes for specific bugs in the action
 
 ## References
 
-[^1]: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+[^1]:
+    https://docs.github.com/en/actions/creating-actions/creating-a-composite-action

--- a/src/sendSlackMessage.test.js
+++ b/src/sendSlackMessage.test.js
@@ -1,0 +1,236 @@
+/**
+ * Tests for sendSlackMessage module - threading functionality
+ */
+
+import { strict as assert } from 'assert'
+import sendSlackMessage, {
+  findExistingThreadForPR,
+  addCompletionReaction
+} from './sendSlackMessage.js'
+
+// We need to test the helper functions, so we'll need to export them
+// For now, test the main function behavior with mocked Slack client
+
+console.log('Testing sendSlackMessage threading functionality...')
+
+// Mock Slack WebClient
+function createMockWebClient (options = {}) {
+  const {
+    channels = [{ id: 'C123', name: 'secops-hotspots' }],
+    messages = [],
+    postMessageResult = { ok: true, ts: '1234567890.123456' },
+    reactionsAddResult = { ok: true }
+  } = options
+
+  return {
+    conversations: {
+      list: async ({ cursor }) => ({
+        channels,
+        response_metadata: { next_cursor: null }
+      }),
+      history: async ({ channel, limit, oldest }) => ({
+        messages
+      })
+    },
+    chat: {
+      postMessage: async (opts) => {
+        // Store the call for assertions
+        createMockWebClient.lastPostMessageCall = opts
+        return postMessageResult
+      }
+    },
+    reactions: {
+      add: async (opts) => {
+        createMockWebClient.lastReactionsAddCall = opts
+        return reactionsAddResult
+      }
+    }
+  }
+}
+
+// Test 1: findExistingThreadForPR should return null when no matching thread exists
+console.log(
+  '\nTest 1: findExistingThreadForPR returns null when no matching thread'
+)
+
+const mockWeb1 = createMockWebClient({
+  messages: [
+    { ts: '111', text: 'random message' },
+    { ts: '222', metadata: { event_type: 'other_type', event_payload: {} } }
+  ]
+})
+
+const result1 = await findExistingThreadForPR(
+  mockWeb1,
+  'C123',
+  'brave/test-repo#42'
+)
+assert.equal(
+  result1,
+  null,
+  'Should return null when no matching thread exists'
+)
+console.log('✓ Returns null when no matching thread')
+
+// Test 2: findExistingThreadForPR should return thread ts when matching thread exists
+console.log(
+  '\nTest 2: findExistingThreadForPR returns ts when matching thread exists'
+)
+
+const mockWeb2 = createMockWebClient({
+  messages: [
+    { ts: '111', text: 'random message' },
+    {
+      ts: '222',
+      metadata: {
+        event_type: 'security_action_thread',
+        event_payload: { pr_identifier: 'brave/test-repo#42' }
+      }
+    },
+    { ts: '333', text: 'another message' }
+  ]
+})
+
+const result2 = await findExistingThreadForPR(
+  mockWeb2,
+  'C123',
+  'brave/test-repo#42'
+)
+assert.equal(result2, '222', 'Should return the ts of the matching thread')
+console.log('✓ Returns correct ts when matching thread exists')
+
+// Test 3: findExistingThreadForPR should not match different PR identifiers
+console.log(
+  '\nTest 3: findExistingThreadForPR does not match different PR identifiers'
+)
+
+const mockWeb3 = createMockWebClient({
+  messages: [
+    {
+      ts: '222',
+      metadata: {
+        event_type: 'security_action_thread',
+        event_payload: { pr_identifier: 'brave/other-repo#99' }
+      }
+    }
+  ]
+})
+
+const result3 = await findExistingThreadForPR(
+  mockWeb3,
+  'C123',
+  'brave/test-repo#42'
+)
+assert.equal(
+  result3,
+  null,
+  'Should return null when PR identifier does not match'
+)
+console.log('✓ Does not match different PR identifiers')
+
+console.log('\n✅ All findExistingThreadForPR tests passed!')
+
+// Test 4: sendSlackMessage should accept prIdentifier and isCompletion parameters
+console.log('\nTest 4: sendSlackMessage accepts threading parameters')
+
+// Check that the function exists and is callable
+assert.equal(
+  typeof sendSlackMessage,
+  'function',
+  'sendSlackMessage should be a function'
+)
+console.log('✓ sendSlackMessage is a function')
+
+// We can't easily test the full function without real Slack credentials,
+// but we can verify it throws the expected error for missing token with new params
+try {
+  await sendSlackMessage({
+    text: 'test',
+    channel: '#test',
+    prIdentifier: 'brave/test#1',
+    isCompletion: false
+  })
+  assert.fail('Should have thrown an error for missing token')
+} catch (e) {
+  assert.equal(
+    e.message,
+    'token is required!',
+    'Should throw token required error'
+  )
+  console.log(
+    '✓ sendSlackMessage accepts prIdentifier and isCompletion without error'
+  )
+}
+
+console.log('\n✅ All sendSlackMessage parameter tests passed!')
+
+// Test 5: addCompletionReaction should add white_check_mark emoji
+console.log('\nTest 5: addCompletionReaction adds checkmark emoji')
+
+const mockWeb5 = createMockWebClient()
+createMockWebClient.lastReactionsAddCall = null
+
+const result5 = await addCompletionReaction(
+  mockWeb5,
+  'C123',
+  '1234567890.123456'
+)
+assert.equal(result5, true, 'Should return true on success')
+assert.deepEqual(
+  createMockWebClient.lastReactionsAddCall,
+  {
+    channel: 'C123',
+    timestamp: '1234567890.123456',
+    name: 'white_check_mark'
+  },
+  'Should call reactions.add with correct parameters'
+)
+console.log('✓ addCompletionReaction calls Slack API correctly')
+
+// Test 6: addCompletionReaction should handle already_reacted error gracefully
+console.log('\nTest 6: addCompletionReaction handles already_reacted error')
+
+const mockWeb6 = {
+  reactions: {
+    add: async () => {
+      const error = new Error('already_reacted')
+      error.data = { error: 'already_reacted' }
+      throw error
+    }
+  }
+}
+
+const result6 = await addCompletionReaction(
+  mockWeb6,
+  'C123',
+  '1234567890.123456'
+)
+assert.equal(result6, true, 'Should return true even if already reacted')
+console.log('✓ addCompletionReaction handles already_reacted gracefully')
+
+// Test 7: addCompletionReaction should throw on other errors
+console.log('\nTest 7: addCompletionReaction throws on other errors')
+
+const mockWeb7 = {
+  reactions: {
+    add: async () => {
+      const error = new Error('channel_not_found')
+      error.data = { error: 'channel_not_found' }
+      throw error
+    }
+  }
+}
+
+try {
+  await addCompletionReaction(mockWeb7, 'C123', '1234567890.123456')
+  assert.fail('Should have thrown an error')
+} catch (e) {
+  assert.equal(
+    e.message,
+    'channel_not_found',
+    'Should throw the original error'
+  )
+  console.log('✓ addCompletionReaction throws on other errors')
+}
+
+console.log('\n✅ All addCompletionReaction tests passed!')

--- a/src/steps/securityReviewCompleted.js
+++ b/src/steps/securityReviewCompleted.js
@@ -1,0 +1,41 @@
+/**
+ * Detects if the needs-security-review label was removed by an assignee
+ * on the current workflow run (not just historically).
+ */
+export default async function securityReviewCompleted ({
+  context,
+  github,
+  assignees
+}) {
+  // Only relevant for pull_request events with label activity
+  if (context.eventName !== 'pull_request') {
+    return false
+  }
+
+  // Check if this is an unlabeled event for needs-security-review
+  const payload = context.payload
+  if (
+    payload.action !== 'unlabeled' ||
+    payload.label?.name !== 'needs-security-review'
+  ) {
+    return false
+  }
+
+  // Check if the actor is one of the security assignees
+  const assigneesOutput = assignees
+    .split(/\s+/)
+    .filter((str) => str !== '')
+    .map((a) => a.toLowerCase())
+  const actor = payload.sender?.login?.toLowerCase()
+
+  if (!actor) {
+    return false
+  }
+
+  const isAssignee = assigneesOutput.includes(actor)
+  console.log(
+    `securityReviewCompleted: label=${payload.label?.name}, actor=${actor}, isAssignee=${isAssignee}`
+  )
+
+  return isAssignee
+}

--- a/src/steps/securityReviewCompleted.test.js
+++ b/src/steps/securityReviewCompleted.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for securityReviewCompleted module
+ */
+
+import { strict as assert } from 'assert'
+import securityReviewCompleted from './securityReviewCompleted.js'
+
+console.log('Testing securityReviewCompleted...')
+
+// Test 1: Returns false for non-pull_request events
+console.log('\nTest 1: Returns false for non-pull_request events')
+
+const result1 = await securityReviewCompleted({
+  context: {
+    eventName: 'push',
+    payload: {}
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result1, false, 'Should return false for push events')
+console.log('✓ Returns false for non-pull_request events')
+
+// Test 2: Returns false for non-unlabeled actions
+console.log('\nTest 2: Returns false for non-unlabeled actions')
+
+const result2 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'opened',
+      label: { name: 'needs-security-review' },
+      sender: { login: 'user1' }
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result2, false, 'Should return false for opened action')
+console.log('✓ Returns false for non-unlabeled actions')
+
+// Test 3: Returns false for wrong label
+console.log('\nTest 3: Returns false for wrong label')
+
+const result3 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'unlabeled',
+      label: { name: 'bug' },
+      sender: { login: 'user1' }
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result3, false, 'Should return false for wrong label')
+console.log('✓ Returns false for wrong label')
+
+// Test 4: Returns false if actor is not an assignee
+console.log('\nTest 4: Returns false if actor is not an assignee')
+
+const result4 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'unlabeled',
+      label: { name: 'needs-security-review' },
+      sender: { login: 'random-user' }
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result4, false, 'Should return false if actor is not an assignee')
+console.log('✓ Returns false if actor is not an assignee')
+
+// Test 5: Returns true when label removed by assignee
+console.log('\nTest 5: Returns true when label removed by assignee')
+
+const result5 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'unlabeled',
+      label: { name: 'needs-security-review' },
+      sender: { login: 'user1' }
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(
+  result5,
+  true,
+  'Should return true when label removed by assignee'
+)
+console.log('✓ Returns true when label removed by assignee')
+
+// Test 6: Case insensitive matching
+console.log('\nTest 6: Case insensitive matching')
+
+const result6 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'unlabeled',
+      label: { name: 'needs-security-review' },
+      sender: { login: 'User1' }
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result6, true, 'Should match case-insensitively')
+console.log('✓ Case insensitive matching works')
+
+// Test 7: Handles missing sender gracefully
+console.log('\nTest 7: Handles missing sender gracefully')
+
+const result7 = await securityReviewCompleted({
+  context: {
+    eventName: 'pull_request',
+    payload: {
+      action: 'unlabeled',
+      label: { name: 'needs-security-review' },
+      sender: null
+    }
+  },
+  github: {},
+  assignees: 'user1 user2'
+})
+
+assert.equal(result7, false, 'Should return false when sender is missing')
+console.log('✓ Handles missing sender gracefully')
+
+console.log('\n✅ All securityReviewCompleted tests passed!')


### PR DESCRIPTION
- Messages for the same PR are grouped into threads
- Subsequent runs reply to existing thread instead of new messages
- Completion message with ✅ reaction when needs-security-review label removed
- Add securityReviewCompleted detection function
- Update README with threading documentation

Test trigger words:
- "authentication" "password"