### PR TITLE
fix: add JSON5 support to renovate sanity check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "@tryfabric/mack": "^1.2.1",
                 "glob": "^12.0.0",
                 "js-yaml": "^4.1.1",
+                "json5": "^2.2.3",
                 "markdown-to-txt": "^2.0.1"
             },
             "devDependencies": {
@@ -2571,15 +2572,15 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -3831,6 +3832,19 @@
                 "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/json5": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
             }
         },
         "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@tryfabric/mack": "^1.2.1",
         "glob": "^12.0.0",
         "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
         "markdown-to-txt": "^2.0.1"
     },
     "devDependencies": {

--- a/src/renovateSanityCheck.js
+++ b/src/renovateSanityCheck.js
@@ -1,3 +1,5 @@
+import JSON5 from 'json5'
+
 async function getConfig ({ github, owner, repo, paths, debug }) {
   if (typeof paths === 'string') {
     paths = [paths]
@@ -12,7 +14,7 @@ async function getConfig ({ github, owner, repo, paths, debug }) {
       })
       const fileContent = Buffer.from(data.content, 'base64').toString('utf8')
       if (debug) console.log(fileContent)
-      return JSON.parse(fileContent)
+      return JSON5.parse(fileContent)
     } catch (err) {
       if (debug) console.log(err)
     }


### PR DESCRIPTION
The renovateSanityCheck.js script was failing to parse renovate.json5 files that contain JavaScript-style comments and JSON5 syntax. This caused false positives reporting repositories as missing renovate configs when they actually had valid renovate.json5 files.

Changes:
- Add json5 as an explicit dependency (v2.2.3)
- Import and use JSON5.parse() instead of JSON.parse()
- Now supports both standard JSON and JSON5 config formats

This fix ensures the sanity check correctly validates renovate configs in all supported formats including files with comments, trailing commas, and other JSON5 features.