### PR TITLE
feat: Slack message lifecycle management — dismiss reconciliation & security-action cleanup

### DIFF
--- a/.claude/skills/add-maintainer-property/SKILL.md
+++ b/.claude/skills/add-maintainer-property/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: add-maintainer-property
+description: Auto-detect top maintainers for each repo in an org and set the maintainers custom property via the GitHub API. Use when the user wants to populate or update maintainer metadata.
+argument-hint: "[org]"
+allowed-tools: Bash(node *)
+---
+
+# Add Maintainer Custom Property
+
+Determine top maintainers for each repository in an org and set the `maintainers` custom property.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Full scan (2-year commit history analysis)
+node run.js ./src/addMaintainerCustomProperty.js --org=brave
+
+# Simple scan (uses contributor list, faster)
+node run.js ./src/addMaintainerCustomProperty.js --org=brave --simpleScan=true
+
+# Debug mode (dry run)
+node run.js ./src/addMaintainerCustomProperty.js --org=brave --debug=true
+
+# Skip repos and ignore specific users
+node run.js ./src/addMaintainerCustomProperty.js --org=brave --skipRepositories=chromium,fork-repo --ignoreMaintainers=bot-user,dependabot
+```
+
+## Parameters
+
+| Parameter            | Required | Default         | Description |
+|----------------------|----------|-----------------|-------------|
+| `--org`              | Yes      | -               | GitHub organization name |
+| `--githubToken`      | No       | `$GITHUB_TOKEN` | GitHub PAT |
+| `--debug`            | No       | `false`         | Dry run with verbose logging |
+| `--simpleScan`       | No       | `false`         | Use contributor list instead of commit history |
+| `--skipRepositories` | No       | `chromium`      | Comma-separated repo names to skip |
+| `--ignoreMaintainers`| No       | -               | Comma-separated usernames to exclude |
+
+## Output
+
+Returns a Markdown string listing repositories with no identifiable maintainers, or empty string if all repos have maintainers.
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs org custom properties write + repo read permissions)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Full scan analyzes 2 years of commit history; `simpleScan` uses the contributor list (faster but less accurate)
+- This is a write operation -- it patches the `maintainers` custom property on each repo
+- Use `--debug=true` first to preview changes

--- a/.claude/skills/check-rule-metadata/SKILL.md
+++ b/.claude/skills/check-rule-metadata/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-rule-metadata
+description: Validate metadata fields (author, source, category) in opengrep/semgrep YAML rule files. Use when the user wants to lint or check rule quality.
+argument-hint: "[dirs]"
+allowed-tools: Bash(node *)
+---
+
+# Check Rule Metadata
+
+Validate metadata fields in opengrep/semgrep YAML rule files to ensure compliance with project standards.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Default directories (assets/opengrep_rules/services + client)
+node run.js ./src/checkRuleMetadata.js
+
+# Custom directories
+node run.js ./src/checkRuleMetadata.js --dirs="assets/opengrep_rules/services,assets/opengrep_rules/client"
+
+# Non-exit mode (returns result object instead of calling process.exit)
+node run.js ./src/checkRuleMetadata.js --exitOnError=false
+```
+
+Or via npm script:
+```bash
+npm run lint-rules
+```
+
+## Parameters
+
+| Parameter       | Required | Default                                                         | Description |
+|-----------------|----------|-----------------------------------------------------------------|-------------|
+| `--dirs`        | No       | `assets/opengrep_rules/services,assets/opengrep_rules/client`  | Comma-separated directory paths to scan |
+| `--basePath`    | No       | `process.cwd()`                                                 | Base path for relative directory resolution |
+| `--exitOnError` | No       | `true`                                                          | Call `process.exit` on completion |
+
+## Validation Rules
+
+Each YAML rule file is checked for:
+- `metadata.author` -- must be present
+- `metadata.source` -- must match the expected GitHub URL pattern
+- `metadata.category` -- must be one of: `security`, `correctness`, `privacy`
+
+## Output
+
+When `exitOnError=false`, returns `{ success: boolean, errors: string[] }`. Otherwise calls `process.exit(0)` or `process.exit(1)`.
+
+## Prerequisites
+
+- Rule YAML files in the specified directories
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Test files (`*.test.yaml`) are skipped
+- This is a read-only validation tool -- it does not modify any files

--- a/.claude/skills/cleanup-slack-messages/SKILL.md
+++ b/.claude/skills/cleanup-slack-messages/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: cleanup-slack-messages
+description: Clean up stale security-action Slack messages based on review signals (reactions, label removal, resolved threads). Use when the user wants to clean old notifications from a Slack channel.
+argument-hint: "[channel]"
+allowed-tools: Bash(node *)
+---
+
+# Cleanup Security Action Slack Messages
+
+Delete stale security-action messages from a Slack channel based on review completion signals.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Default channel (#secops-hotspots)
+node run.js ./src/cleanupSecurityActionMessages.js --token=xoxb-... --githubToken=ghp_...
+
+# Custom channel
+node run.js ./src/cleanupSecurityActionMessages.js --token=xoxb-... --githubToken=ghp_... --channel="#security-alerts"
+
+# Dry run (debug mode)
+node run.js ./src/cleanupSecurityActionMessages.js --token=xoxb-... --githubToken=ghp_... --debug=true
+```
+
+## Parameters
+
+| Parameter            | Required | Default              | Description |
+|----------------------|----------|----------------------|-------------|
+| `--token`            | Yes      | `$SLACK_TOKEN`       | Slack bot token |
+| `--githubToken`      | Yes      | `$GITHUB_TOKEN`      | GitHub PAT for PR queries |
+| `--channel`          | No       | `#secops-hotspots`   | Slack channel name |
+| `--debug`            | No       | `false`              | Log what would be deleted without deleting |
+| `--defaultAssignees` | No       | -                    | Comma-separated fallback GitHub usernames |
+
+## Deletion Signals
+
+A message is deleted if any of these signals are detected:
+
+1. Checkmark reaction from a `/cc`'d person
+2. Thumbsup from a `/cc`'d person
+3. `needs-security-review` label removed by a security assignee on the linked PR
+4. All `github-actions` review threads resolved by a security assignee
+
+## Output
+
+Returns a number -- count of messages deleted (or count that would be deleted in debug mode).
+
+## Prerequisites
+
+- `.env` file with `SLACK_TOKEN` and `GITHUB_TOKEN`
+- Bot must have `chat:write`, `channels:read`, `channels:history`, `reactions:read` scopes
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Use `--debug=true` first to preview what would be deleted
+- This is a destructive operation -- messages cannot be recovered after deletion

--- a/.claude/skills/delete-slack-messages/SKILL.md
+++ b/.claude/skills/delete-slack-messages/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: delete-slack-messages
+description: Delete Slack messages from a channel filtered by bot username and repository names. Use when the user wants to bulk-delete bot messages for specific repos.
+argument-hint: "[channel] [username] [repos]"
+allowed-tools: Bash(node *)
+---
+
+# Delete Slack Messages
+
+Delete Slack messages from a channel that match a specific bot username and repository filter.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Delete messages from a specific bot for specific repos
+node run.js ./src/deleteSlackMessages.js --token=xoxb-... --channel="#secops-hotspots" --username=github-actions --repos="org/repo1,org/repo2"
+
+# Dry run
+node run.js ./src/deleteSlackMessages.js --token=xoxb-... --channel="#secops-hotspots" --username=github-actions --repos="org/repo1" --debug=true
+
+# Custom lookback window
+node run.js ./src/deleteSlackMessages.js --token=xoxb-... --channel="#secops-hotspots" --username=github-actions --repos="org/repo1" --lookbackDays=14
+```
+
+## Parameters
+
+| Parameter        | Required | Default          | Description |
+|------------------|----------|------------------|-------------|
+| `--token`        | Yes      | `$SLACK_TOKEN`   | Slack bot token |
+| `--channel`      | Yes      | -                | Slack channel name |
+| `--username`     | Yes      | -                | Bot username to filter messages by |
+| `--repos`        | No       | -                | Comma-separated repo full names (e.g. `org/repo`) |
+| `--debug`        | No       | `false`          | Log what would be deleted without deleting |
+| `--lookbackDays` | No       | `8`              | Number of days to look back |
+
+## Output
+
+Returns a number -- count of messages deleted.
+
+## Prerequisites
+
+- `.env` file with `SLACK_TOKEN`
+- Bot must have `chat:write`, `channels:read`, `channels:history` scopes
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Use `--debug=true` first to preview what would be deleted
+- This is a destructive operation -- messages cannot be recovered after deletion

--- a/.claude/skills/dependabot-dismiss/SKILL.md
+++ b/.claude/skills/dependabot-dismiss/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: dependabot-dismiss
+description: Auto-dismiss Dependabot alerts matching configurable hotwords (e.g. DoS) or a GHSA/CVE dismiss list. Use when the user wants to bulk-dismiss low-priority Dependabot alerts.
+argument-hint: "[org]"
+allowed-tools: Bash(node *)
+---
+
+# Dependabot Auto-Dismiss
+
+Fetch open Dependabot alerts across an org and auto-dismiss those matching hotwords or a dismiss list file.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Dismiss DoS-related alerts in an org
+node run.js ./src/dependabotDismiss.js --org=brave
+
+# Dry run (debug mode)
+node run.js ./src/dependabotDismiss.js --org=brave --debug=true
+
+# Custom severity threshold
+node run.js ./src/dependabotDismiss.js --org=brave --minlevel=medium
+
+# Custom dismiss list file
+node run.js ./src/dependabotDismiss.js --org=brave --dependabotDismissConfig=./my-dismiss-list.txt
+```
+
+## Parameters
+
+| Parameter                  | Required | Default                  | Description |
+|----------------------------|----------|--------------------------|-------------|
+| `--org`                    | Yes      | -                        | GitHub organization name |
+| `--githubToken`            | No       | `$GITHUB_TOKEN`          | GitHub PAT |
+| `--minlevel`               | No       | `low`                    | Minimum severity: low, medium, high, critical |
+| `--debug`                  | No       | `false`                  | Log dismiss actions without actually dismissing |
+| `--hotwords`               | No       | DoS-related terms        | Comma-separated summary keywords to match |
+| `--actor`                  | No       | `security-action`        | Name used in dismiss comment |
+| `--dependabotDismissConfig`| No       | `dependabot-dismiss.txt` | Path to file with GHSA/CVE IDs to dismiss |
+
+## Output
+
+Returns `{ message, dismissedRepos }` -- a Markdown summary of dismissed alerts and an array of affected repo full names.
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs Dependabot alerts read + dismiss permissions)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Use `--debug=true` first to preview what would be dismissed
+- Alerts are dismissed with a "not_used" reason and a comment identifying the actor
+- This is a write operation -- alerts will be permanently dismissed

--- a/.claude/skills/dependabot-nudge/SKILL.md
+++ b/.claude/skills/dependabot-nudge/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: dependabot-nudge
+description: Scan org repos for open Dependabot alerts at or above a severity threshold and build notification messages for maintainers. Use when the user wants to check or nudge about Dependabot vulnerabilities.
+argument-hint: "[org]"
+allowed-tools: Bash(node *)
+---
+
+# Dependabot Nudge
+
+Scan all repositories in a GitHub organization for open Dependabot alerts and build formatted notification messages for maintainers.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Scan an org with default settings (high+ severity)
+node run.js ./src/dependabotNudge.js --org=brave
+
+# Custom severity threshold
+node run.js ./src/dependabotNudge.js --org=brave --minlevel=critical
+
+# Debug mode (verbose + dry-run for assignee patching)
+node run.js ./src/dependabotNudge.js --org=brave --debug=true
+
+# Skip specific repos
+node run.js ./src/dependabotNudge.js --org=brave --skipRepositories=chromium,large-repo
+
+# Single output message (joined string instead of array)
+node run.js ./src/dependabotNudge.js --org=brave --singleOutputMessage=true
+```
+
+## Parameters
+
+| Parameter              | Required | Default                | Description |
+|------------------------|----------|------------------------|-------------|
+| `--org`                | Yes      | -                      | GitHub organization name |
+| `--githubToken`        | No       | `$GITHUB_TOKEN`        | GitHub PAT |
+| `--minlevel`           | No       | `high`                 | Minimum severity: low, medium, high, critical |
+| `--debug`              | No       | `false`                | Verbose logging and dry-run |
+| `--skipRepositories`   | No       | `chromium`             | Comma-separated repo names to skip |
+| `--skipHotwords`       | No       | DoS-related terms      | Comma-separated advisory keywords to skip |
+| `--defaultContact`     | No       | `yan`                  | Comma-separated fallback GitHub usernames |
+| `--singleOutputMessage`| No       | `false`                | Return a single joined string |
+
+## Output
+
+Returns an array of `{ repo, message }` objects (one per repo with alerts), or a single joined Markdown string if `singleOutputMessage` or `debug` is true.
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs repo + org read permissions)
+- Optionally `GH_TO_SLACK_USER_MAP` for Slack handle resolution
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Skips archived and disabled repositories automatically
+- DoS-related advisories are skipped by default (configurable via `--skipHotwords`)
+- Each alert is assigned to its repo's maintainers via the GitHub API

--- a/.claude/skills/get-config/SKILL.md
+++ b/.claude/skills/get-config/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: get-config
+description: Fetch and parse a JSON config file from a GitHub repository. Use when the user wants to read a configuration file from a remote repo.
+argument-hint: "[owner] [repo] [path]"
+allowed-tools: Bash(node *)
+---
+
+# Get Config
+
+Fetch and JSON-parse a configuration file from a GitHub repository via the contents API.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Fetch a config file
+node run.js ./src/getConfig.js --owner=brave --repo=brave-browser --path=.github/security-action.json
+
+# With debug logging
+node run.js ./src/getConfig.js --owner=brave --repo=brave-browser --path=.github/security-action.json --debug=true
+```
+
+## Parameters
+
+| Parameter       | Required | Default         | Description |
+|-----------------|----------|-----------------|-------------|
+| `--owner`       | Yes      | -               | Repository owner |
+| `--repo`        | Yes      | -               | Repository name |
+| `--path`        | Yes      | -               | File path within the repo |
+| `--githubToken` | No       | `$GITHUB_TOKEN` | GitHub PAT |
+| `--debug`       | No       | `false`         | Enable verbose logging |
+
+## Output
+
+Returns the parsed JSON object from the file, or `{}` on error (file not found, invalid JSON, etc.).
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN`
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Returns an empty object if the file doesn't exist or can't be parsed
+- Commonly used to fetch `.github/security-action.json` per-repo configuration

--- a/.claude/skills/get-maintainers/SKILL.md
+++ b/.claude/skills/get-maintainers/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: get-maintainers
+description: List all repositories in a GitHub org with their maintainers custom property. Use when the user wants to see who maintains each repo.
+argument-hint: "[org]"
+allowed-tools: Bash(node *)
+---
+
+# Get Maintainers
+
+List all repositories in a GitHub organization along with their `maintainers` custom property value.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# List maintainers for all repos in an org
+node run.js ./src/getMaintainers.js --org=brave
+
+# With explicit token
+node run.js ./src/getMaintainers.js --org=brave --githubToken=ghp_...
+```
+
+## Parameters
+
+| Parameter       | Required | Default         | Description |
+|-----------------|----------|-----------------|-------------|
+| `--org`         | Yes      | -               | GitHub organization name |
+| `--githubToken` | No       | `$GITHUB_TOKEN` | GitHub PAT |
+
+## Output
+
+Returns a Markdown-formatted string with one line per repo that has maintainers:
+```
+- https://github.com/org/repo maintainers: user1, user2
+```
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs org custom properties read + repo metadata permissions)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Only repos with a non-empty `maintainers` property are listed

--- a/.claude/skills/get-properties/SKILL.md
+++ b/.claude/skills/get-properties/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: get-properties
+description: Fetch custom properties for a GitHub repository. Use when the user wants to inspect repo metadata like runtime, maintainers, or other custom properties.
+argument-hint: "[owner] [repo]"
+allowed-tools: Bash(node *)
+---
+
+# Get Properties
+
+Fetch custom properties for a GitHub repository, optionally stripping a prefix from property names.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Get all custom properties
+node run.js ./src/getProperties.js --owner=brave --repo=brave-browser
+
+# With prefix stripping (prefixed properties take priority)
+node run.js ./src/getProperties.js --owner=brave --repo=brave-browser --prefix=sec-
+
+# With debug logging
+node run.js ./src/getProperties.js --owner=brave --repo=brave-browser --debug=true
+```
+
+## Parameters
+
+| Parameter       | Required | Default         | Description |
+|-----------------|----------|-----------------|-------------|
+| `--owner`       | Yes      | -               | Repository owner |
+| `--repo`        | Yes      | -               | Repository name |
+| `--githubToken` | No       | `$GITHUB_TOKEN` | GitHub PAT |
+| `--debug`       | No       | `false`         | Enable verbose logging |
+| `--prefix`      | No       | `""`            | Property name prefix to strip (prefixed props get priority) |
+
+## Output
+
+Returns an object mapping property names to their values, e.g. `{ maintainers: "alice,bob", runtime: "node" }`.
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs org custom properties read permission)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- When `--prefix` is set, a property named `sec-maintainers` becomes `maintainers` and takes priority over an unprefixed `maintainers` property

--- a/.claude/skills/match-codeowners/SKILL.md
+++ b/.claude/skills/match-codeowners/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: match-codeowners
+description: Match a list of changed file paths against a CODEOWNERS file to determine code ownership. Use when the user wants to find who owns specific files or directories.
+argument-hint: "[file-paths]"
+allowed-tools: Bash(node *)
+---
+
+# Match CODEOWNERS
+
+Match changed file paths against a CODEOWNERS file to determine ownership (teams and individuals).
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Match specific files
+node run.js ./src/matchCodeowners.js --changedFiles="src/foo.js,src/bar.js"
+
+# With explicit CODEOWNERS path
+node run.js ./src/matchCodeowners.js --changedFiles="src/foo.js" --codeownersPath=./CODEOWNERS
+
+# With debug logging
+node run.js ./src/matchCodeowners.js --changedFiles="src/foo.js,src/bar.js" --debug=true
+```
+
+## Parameters
+
+| Parameter          | Required | Default       | Description |
+|--------------------|----------|---------------|-------------|
+| `--changedFiles`   | Yes      | -             | Comma-separated list of file paths |
+| `--codeownersPath` | No       | Auto-detected | Explicit path to CODEOWNERS file |
+| `--basePath`       | No       | `.`           | Base directory for CODEOWNERS search |
+| `--debug`          | No       | `false`       | Enable verbose logging |
+
+## Output
+
+Returns a JSON object with:
+- `ownersToFiles`: Map of owner -> array of matched file paths
+- `filesWithoutOwners`: Array of files with no matching CODEOWNERS rule
+- `stats`: Summary with `totalFiles`, `filesWithOwners`, `filesWithoutOwners`, `uniqueOwners`, `teams`, `individuals`, `teamsList`, `individualsList`
+
+## Prerequisites
+
+- A CODEOWNERS file in the repository (searched in `.github/CODEOWNERS`, `CODEOWNERS`, or `docs/CODEOWNERS`)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- CODEOWNERS patterns use gitignore-style glob matching
+- Both teams (`@org/team`) and individuals (`@user`) are supported
+- Files are matched against patterns in order; later rules take precedence

--- a/.claude/skills/opengrep-compare/SKILL.md
+++ b/.claude/skills/opengrep-compare/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: opengrep-compare
+description: Compare opengrep scan findings between current and base branch rules to detect new/removed findings. Use when the user wants to evaluate the impact of rule changes.
+argument-hint: "[target-repo or local-target]"
+allowed-tools: Bash(node *)
+---
+
+# Opengrep Compare
+
+Compare opengrep scan findings between the current branch's rules and a base branch's rules to compute a delta.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Compare against a remote repo
+node run.js ./src/opengrepCompare.js --target-repo=brave/brave-browser
+
+# Compare against a subdirectory of a remote repo
+node run.js ./src/opengrepCompare.js --target-repo=brave/brave-browser --target-path=browser/
+
+# Compare against a local directory
+node run.js ./src/opengrepCompare.js --local-target=/path/to/codebase
+
+# Custom base branch
+node run.js ./src/opengrepCompare.js --target-repo=brave/brave-browser --base-ref=develop
+
+# Only scan changed rules
+node run.js ./src/opengrepCompare.js --target-repo=brave/brave-browser --changed-rules-only=true
+```
+
+## Parameters
+
+| Parameter             | Required | Default  | Description |
+|-----------------------|----------|----------|-------------|
+| `--target-repo`       | No*      | -        | GitHub repo to clone and scan (e.g. `org/repo`) |
+| `--target-path`       | No       | -        | Subdirectory within the target repo to scan |
+| `--local-target`      | No*      | -        | Local filesystem path to scan instead of cloning |
+| `--base-ref`          | No       | `main`   | Git ref for base branch comparison |
+| `--compare-rules`     | No       | `true`   | Whether to run base-branch comparison |
+| `--changed-rules-only`| No       | `true`   | Only scan rule files changed between branches |
+
+\* One of `--target-repo` or `--local-target` is required.
+
+## Output
+
+Returns a JSON object with:
+- `total`: Total findings count
+- `rules`: Number of rules scanned
+- `summary`: Per-rule finding counts
+- `findings`: All individual findings
+- `delta`: New and removed findings vs. base branch
+- `percentageIncrease`: Finding count change percentage
+- `baseTotal`: Base branch findings count
+- `noChanges`: Boolean indicating if no rule changes were detected
+
+## Prerequisites
+
+- `opengrep` CLI must be installed and on PATH
+- Git access to the target repository (for cloning)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- The tool uses `git diff` to detect changed rule files between branches
+- Opengrep must be pre-installed (use `installOpengrep.js` or install manually)
+- This is a read-only analysis tool -- it does not modify any files

--- a/.claude/skills/renovate-sanity-check/SKILL.md
+++ b/.claude/skills/renovate-sanity-check/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: renovate-sanity-check
+description: Check all repos in a GitHub org for Renovate config compliance (must extend the shared org config). Use when the user wants to audit Renovate adoption.
+argument-hint: "[org]"
+allowed-tools: Bash(node *)
+---
+
+# Renovate Sanity Check
+
+Check all non-archived, non-fork repositories in a GitHub organization for Renovate configuration compliance.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Check an org
+node run.js ./src/renovateSanityCheck.js --org=brave
+
+# Debug mode
+node run.js ./src/renovateSanityCheck.js --org=brave --debug=true
+
+# Skip specific repos
+node run.js ./src/renovateSanityCheck.js --org=brave --skipRepositories=chromium,renovate-config
+```
+
+## Parameters
+
+| Parameter            | Required | Default                     | Description |
+|----------------------|----------|-----------------------------|-------------|
+| `--org`              | Yes      | -                           | GitHub organization name |
+| `--githubToken`      | No       | `$GITHUB_TOKEN`             | GitHub PAT |
+| `--debug`            | No       | `false`                     | Enable verbose logging |
+| `--skipRepositories` | No       | `chromium,renovate-config`  | Comma-separated repo names to skip |
+
+## Output
+
+Returns a Markdown string listing:
+- Repos without any Renovate config
+- Repos that have a Renovate config but don't extend the shared org config (`local>ORG/renovate-config`)
+
+Returns `undefined` if all repos are compliant.
+
+## Prerequisites
+
+- `.env` file with `GITHUB_TOKEN` (needs repo read permissions)
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Checks for Renovate config in `renovate.json`, `.github/renovate.json`, `renovate.json5`, and `package.json` (renovate key)
+- A compliant config must extend `local>ORG/renovate-config`

--- a/.claude/skills/send-slack-message/SKILL.md
+++ b/.claude/skills/send-slack-message/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: send-slack-message
+description: Send a message to a Slack channel with markdown support, colored attachments, and deduplication. Use when the user wants to post notifications or alerts to Slack.
+argument-hint: "[channel] [message-text]"
+allowed-tools: Bash(node *)
+---
+
+# Send Slack Message
+
+Send a markdown or plain-text message to a Slack channel.
+
+## Usage
+
+Run from the project root:
+
+```bash
+# Simple text message
+node run.js ./src/sendSlackMessage.js --channel="#secops-hotspots" --text="Hello world"
+
+# Markdown body message
+node run.js ./src/sendSlackMessage.js --channel="#secops-hotspots" --message="**Bold** message"
+
+# With color (named or hex)
+node run.js ./src/sendSlackMessage.js --channel="#secops-hotspots" --message="Alert!" --color=red
+
+# With custom bot username
+node run.js ./src/sendSlackMessage.js --channel="#secops-hotspots" --text="Hello" --username=security-bot
+```
+
+## Parameters
+
+| Parameter    | Required | Default            | Description |
+|--------------|----------|--------------------|-------------|
+| `--token`    | No       | `$SLACK_TOKEN`     | Slack bot token (xoxb-...). Falls back to env var |
+| `--channel`  | Yes      | -                  | Slack channel name (e.g. `#secops-hotspots`) |
+| `--text`     | No*      | -                  | Plain text / mrkdwn summary line |
+| `--message`  | No*      | -                  | Markdown body (converted to Slack Block Kit) |
+| `--color`    | No       | -                  | Named color (red, green, yellow, blue, cyan, magenta, black, white) or hex (#FF5733) |
+| `--username` | No       | `github-actions`   | Bot display name |
+| `--debug`    | No       | `false`            | Enable debug logging |
+
+\* At least one of `--text` or `--message` is required. Both can be provided.
+
+## Output
+
+Returns the Slack API response JSON including `ok` status, message timestamp (`ts`), and channel ID.
+
+## Prerequisites
+
+- `.env` file with `SLACK_TOKEN` (bot token with `chat:write`, `channels:read`, `channels:history` scopes)
+- The bot must be invited to the target channel
+
+## Notes
+
+- The `run.js` entry point automatically loads `.env` credentials
+- Markdown is converted to Slack Block Kit format via `@tryfabric/mack`
+- Messages are deduplicated: the same (text + message + color) combination won't be posted twice within 24 hours
+- Slack blocks are capped at 50 (Slack API limit); longer messages are truncated
+- This is a write operation -- confirm with the user before sending if the message wasn't explicitly provided

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# =============================================================================
+# GitHub Token (Required for most tools)
+# Create a fine-grained token at: https://github.com/settings/tokens?type=beta
+# Required fine-grained permissions:
+#   Repository permissions:
+#     - Metadata: Read-only (granted by default)
+#     - Pull requests: Read-write (for PR comments, assignees)
+#     - Issues: Read-write (for Dependabot alert assignment)
+#   Organization permissions:
+#     - Custom properties: Read-write (for maintainer/runtime properties)
+#     - Members: Read-only (for org repo listing)
+# =============================================================================
+GITHUB_TOKEN=ghp_your_github_token
+
+# =============================================================================
+# Slack Bot Token (Required for Slack tools)
+# Create a Slack app at: https://api.slack.com/apps
+# Required OAuth scopes:
+#   - chat:write       (post messages)
+#   - channels:read    (resolve channel names to IDs)
+#   - channels:history (read recent messages for deduplication/cleanup)
+#   - reactions:read   (read reactions for cleanup signals)
+# The bot must be invited to the target channel
+# =============================================================================
+# SLACK_TOKEN=xoxb-your-slack-bot-token
+
+# =============================================================================
+# GitHub to Slack User Map (Required for Slack notification tools)
+# JSON object mapping lowercase GitHub usernames to Slack user mentions
+# Used by dependabotNudge and cleanupSecurityActionMessages to CC maintainers
+# Example: {"alice":"<@U123ALICE>","bob":"<@U456BOB>"}
+# =============================================================================
+# GH_TO_SLACK_USER_MAP={"username":"<@SLACK_USER_ID>"}
+
+# =============================================================================
+# Debug Mode (Optional)
+# Set to "true" to enable verbose logging and dry-run behavior in most tools
+# =============================================================================
+# SEC_ACTION_DEBUG=false
+
+# =============================================================================
+# Python Package Index Configuration (Optional - for pip-audit scanner)
+# Set a custom PyPI index URL and/or trusted hosts for pip-audit
+# =============================================================================
+# PYPI_INDEX_URL=https://pypi.org/simple
+# PYPI_INSECURE_HOSTS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# Security Action - Security Scanning GitHub Action
+
+This project provides a GitHub Action and CLI tools for automated security scanning, code ownership analysis, Dependabot alert management, and Slack notifications for Brave repositories.
+
+## Skills
+
+The following skills are available in `.claude/skills/`. Load them with the `skill` tool when the user's request matches their description.
+
+| Skill | Description |
+|-------|-------------|
+| `send-slack-message` | Send a message to a Slack channel with markdown support, colored attachments, and deduplication |
+| `cleanup-slack-messages` | Clean up stale security-action Slack messages based on review signals |
+| `delete-slack-messages` | Delete Slack messages from a channel by bot username and repo filter |
+| `dependabot-nudge` | Scan org repos for open Dependabot alerts and notify maintainers |
+| `dependabot-dismiss` | Auto-dismiss Dependabot alerts matching hotwords or a dismiss list |
+| `match-codeowners` | Match changed files against a CODEOWNERS file to find owners |
+| `get-config` | Fetch and parse a JSON config file from a GitHub repository |
+| `get-properties` | Fetch custom properties for a GitHub repository |
+| `get-maintainers` | List all repositories in an org with their maintainers property |
+| `add-maintainer-property` | Auto-detect top maintainers and set the custom property on org repos |
+| `renovate-sanity-check` | Check org repos for Renovate config compliance |
+| `check-rule-metadata` | Validate metadata fields in opengrep/semgrep YAML rule files |
+| `opengrep-compare` | Compare opengrep scan findings between current and base branch rules |
+
+## Prerequisites
+
+- Node.js >= 22
+- `.env` file with `GITHUB_TOKEN` (for GitHub API tools)
+- `.env` file with `SLACK_TOKEN` (for Slack tools)
+- `.env` file with `GH_TO_SLACK_USER_MAP` (for Slack notification tools)
+- See `.env.example` for the full list of environment variables
+
+## Entry Point
+
+All tools are run via `node run.js ./src/<script>.js` from the project root. The `run.js` entry point automatically loads `.env` credentials when the file exists.
+
+## Credential Resolution
+
+Most tools accept credentials as CLI parameters with automatic fallback to environment variables. The pattern is:
+
+```js
+token = token || process.env.GITHUB_TOKEN
+```
+
+Tools that accept a pre-constructed `github` (Octokit) instance will create one from `githubToken` if not provided. When running via `run.js`, all parameters come from `--flag=value` CLI arguments.
+
+| Env Var | Used By | Notes |
+|---------|---------|-------|
+| `GITHUB_TOKEN` | Most tools (as `githubToken` param fallback) | Fine-grained PAT with repo + org permissions |
+| `SLACK_TOKEN` | `sendSlackMessage`, `cleanupSecurityActionMessages`, `deleteSlackMessages` | Bot token (xoxb-...) |
+| `GH_TO_SLACK_USER_MAP` | `dependabotNudge`, `cleanupSecurityActionMessages` | JSON mapping GitHub users to Slack mentions |
+| `SEC_ACTION_DEBUG` | Shell scripts (`reviewdog.sh`) | Debug/verbose mode for scanners |
+| `PYPI_INDEX_URL` | `pip-audit.py` | Custom PyPI index |
+| `PYPI_INSECURE_HOSTS` | `pip-audit.py` | Trusted hosts for pip-audit |
+
+## Development Workflow
+
+### Linting
+
+Before committing, always run:
+
+```bash
+npx standard --fix --ignore assets/opengrep_rules
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+### Rule Metadata Validation
+
+```bash
+npm run lint-rules
+```
+
+### Opengrep Rule Testing
+
+```bash
+cd assets/opengrep_rules && opengrep test --strict .
+```
+
+### Commits
+
+- Always commit self-contained changes, preferably under 800 lines of code.
+- If you encounter errors related to SSH keys or commit signatures, ask the user to fix these.

--- a/actions/dependabot-auto-dismiss/action.cjs
+++ b/actions/dependabot-auto-dismiss/action.cjs
@@ -1,6 +1,71 @@
-module.exports = async ({ github, context, inputs, actionPath, core, debug = false }) => {
-  const { default: sendSlackMessage } = await import(`${actionPath}/src/sendSlackMessage.js`)
-  const { default: dependabotDismiss } = await import(`${actionPath}/src/dependabotDismiss.js`)
-  const message = await dependabotDismiss({ debug, org: context.repo.owner, github, dependabotDismissConfig: `${actionPath}/actions/dependabot-auto-dismiss/dismiss.txt` })
-  if (message.length > 0) { await sendSlackMessage({ debug, username: 'dependabot-auto-dismiss', message, channel: '#secops-hotspots', token: inputs.slack_token }) }
+module.exports = async ({
+  github, context, inputs, actionPath, core,
+  debug = false
+}) => {
+  const { default: sendSlackMessage } =
+    await import(
+      `${actionPath}/src/sendSlackMessage.js`
+    )
+  const {
+    default: deleteSlackMessages,
+    listSlackMessageRepos
+  } = await import(
+    `${actionPath}/src/deleteSlackMessages.js`
+  )
+  const { default: dependabotDismiss } =
+    await import(
+      `${actionPath}/src/dependabotDismiss.js`
+    )
+  const { default: reconcileNudgeMessages } =
+    await import(
+      `${actionPath}/src/reconcileNudgeMessages.js`
+    )
+
+  const org = context.repo.owner
+  const channel = '#secops-hotspots'
+  const dismissConfig =
+    `${actionPath}/actions/dependabot-auto-dismiss` +
+    '/dismiss.txt'
+
+  const { message, dismissedRepos } =
+    await dependabotDismiss({
+      debug,
+      org,
+      github,
+      dependabotDismissConfig: dismissConfig
+    })
+
+  // Remove stale nudge messages for repos that had
+  // alerts dismissed in this run.
+  if (dismissedRepos.length > 0) {
+    await deleteSlackMessages({
+      debug,
+      token: inputs.slack_token,
+      channel,
+      username: 'dependabot',
+      repos: dismissedRepos
+    })
+  }
+
+  // Reconciliation: find nudge messages for repos
+  // that no longer have any qualifying open alerts.
+  await reconcileNudgeMessages({
+    github,
+    slackToken: inputs.slack_token,
+    channel,
+    dismissedRepos,
+    debug,
+    listSlackMessageRepos,
+    deleteSlackMessages
+  })
+
+  if (message.length > 0) {
+    await sendSlackMessage({
+      debug,
+      username: 'dependabot-auto-dismiss',
+      message,
+      channel,
+      token: inputs.slack_token
+    })
+  }
 }

--- a/actions/dependabot-nudge/action.cjs
+++ b/actions/dependabot-nudge/action.cjs
@@ -19,9 +19,11 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
 
   const messages = await dependabotNudge({ debug, org: context.repo.owner, github, minlevel, githubToSlack, actionPath })
 
-  for (const message of messages) {
+  const channel = inputs.slack_channel || '#secops-hotspots'
+
+  for (const { repo, message } of messages) {
     try {
-      await sendSlackMessage({ debug, username: 'dependabot', message, channel: '#secops-hotspots', token: inputs.slack_token })
+      await sendSlackMessage({ debug, username: 'dependabot', message, channel, token: inputs.slack_token, eventPayload: { repo } })
     } catch (error) {
       if (debug) { console.log(error) }
     }

--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -229,6 +229,7 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
 
     const { default: sendSlackMessage } = await import(`${actionPath}/src/sendSlackMessage.js`)
 
+    const channel = options.slack_channel || '#secops-hotspots'
     const repoName = `${context.repo.owner}/${context.repo.repo}`
 
     const message = `Repository: [${repoName}](https://github.com/${repoName})\npull-request: ${context.payload.pull_request.html_url}\nFindings: ${commentsAfter}`
@@ -275,7 +276,7 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
           token: options.slack_token,
           text: `[error] ${actor} action failed, plz take a look. /cc ${slackAssignees} ${reviewdogFailLogHead}`,
           message,
-          channel: '#secops-hotspots',
+          channel,
           color: 'red',
           username: 'security-action'
         })
@@ -293,11 +294,38 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
         token: options.slack_token,
         text: `${actor} pushed commits. /cc ${slackAssignees}`,
         message,
-        channel: '#secops-hotspots',
+        channel,
         color: 'green',
         username: 'security-action'
       })
       debugLog('Comments after:', commentsAfter)
+    }
+
+    // Cleanup stale security-action Slack messages.
+    // Removes messages that have been acknowledged via
+    // reactions, label removal, or thread resolution.
+    if (options.slack_token) {
+      try {
+        const { default: cleanupMessages } =
+          await import(
+            `${actionPath}/src/cleanupSecurityActionMessages.js`
+          )
+        const cleaned = await cleanupMessages({
+          token: options.slack_token,
+          github,
+          channel,
+          debug: options.debug,
+          defaultAssignees: assignees
+        })
+        debugLog(
+          'Cleaned up stale messages:', cleaned
+        )
+      } catch (cleanupErr) {
+        console.error(
+          'Slack message cleanup failed:',
+          cleanupErr.message
+        )
+      }
     }
   } else if (context.actor === 'dependabot[bot]') {
     // if the actor is dependabot[bot], add security label to PR, and nothing more

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "security-action",
             "dependencies": {
                 "@octokit/core": "^6.1.4",
                 "@slack/web-api": "^7.0.0",
@@ -15,6 +14,7 @@
                 "markdown-to-txt": "^2.0.1"
             },
             "devDependencies": {
+                "dotenv": "^17.3.1",
                 "standard": "17.1.2"
             }
         },
@@ -883,6 +883,19 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+            "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "markdown-to-txt": "^2.0.1"
     },
     "devDependencies": {
+        "dotenv": "^17.3.1",
         "standard": "17.1.2"
     }
 }

--- a/run.js
+++ b/run.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
+import { existsSync } from 'fs'
 import { parseArgs } from 'node:util'
+
+if (existsSync('.env')) {
+  const { config } = await import('dotenv')
+  config()
+}
+
 const [,, _module, ...args] = process.argv
 
 const run = (await import(_module)).default

--- a/src/cleanupSecurityActionMessages.js
+++ b/src/cleanupSecurityActionMessages.js
@@ -1,0 +1,429 @@
+// Cleanup stale security-action Slack messages from
+// #secops-hotspots. A message is deleted if ANY of:
+//
+// Signal A: checkmark reaction from a /cc'd person
+// Signal B: thumbsup from a /cc'd person
+// Signal C: needs-security-review label removed by
+//           a security assignee on the linked PR
+// Signal D: all github-actions review threads on the
+//           linked PR are resolved by a security
+//           assignee
+
+import { findChannelId, fetchMessages } from './slackUtils.js'
+
+const CHECKMARK_REACTIONS = [
+  'white_check_mark',
+  'heavy_check_mark',
+  'ballot_box_with_check'
+]
+
+const THUMBSUP_REACTIONS = ['thumbsup', '+1']
+
+const SECURITY_ACTION_USERNAME = 'security-action'
+
+// Parse /cc <@U1234> <@U5678> from Slack message text.
+// Returns an array of Slack user IDs.
+export function parseCcUserIds (text) {
+  if (!text) return []
+  const ccIdx = text.indexOf('/cc ')
+  if (ccIdx === -1) return []
+  const after = text.slice(ccIdx + 4)
+  const ids = []
+  for (const m of after.matchAll(/<@(\w+)>/g)) {
+    ids.push(m[1])
+  }
+  return ids
+}
+
+// Extract the PR URL from the Slack message blocks.
+// The message body contains "pull-request: <url>".
+export function extractPrUrl (msg) {
+  const sources = [
+    msg.text || '',
+    ...(msg.blocks || []).map(
+      b => b.text?.text || ''
+    ),
+    ...(msg.attachments || []).flatMap(
+      a => (a.blocks || []).map(
+        b => b.text?.text || ''
+      )
+    )
+  ]
+
+  for (const src of sources) {
+    const match = src.match(
+      /pull-request:\s*(https:\/\/github\.com\/[^\s>]+)/
+    )
+    if (match) return match[1]
+  }
+  return null
+}
+
+// Parse owner, repo, number from a GitHub PR URL.
+export function parsePrUrl (url) {
+  if (!url) return null
+  const match = url.match(
+    /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/
+  )
+  if (!match) return null
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: parseInt(match[3], 10)
+  }
+}
+
+// Query review threads for a PR, including
+// isResolved and resolvedBy fields.
+const REVIEW_THREADS_QUERY = `
+  query(
+    $owner: String!,
+    $name: String!,
+    $prnumber: Int!
+  ) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $prnumber) {
+        reviewThreads(last: 100) {
+          nodes {
+            isResolved
+            resolvedBy { login }
+            comments(first: 1) {
+              totalCount
+              nodes {
+                author { login }
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }`
+
+// Query timeline for UNLABELED_EVENT items.
+const UNLABELED_QUERY = `
+  query(
+    $owner: String!,
+    $name: String!,
+    $prnumber: Int!
+  ) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $prnumber) {
+        timelineItems(
+          last: 100,
+          itemTypes: UNLABELED_EVENT
+        ) {
+          nodes {
+            ... on UnlabeledEvent {
+              label { name }
+              actor { login }
+            }
+          }
+        }
+      }
+    }
+  }`
+
+// Compute assignees from review thread Cc patterns,
+// mirroring the logic in assigneesAfter.js.
+export function extractAssigneesFromThreads (
+  threads, defaultAssignees
+) {
+  const found = [
+    ...new Set(
+      threads.nodes
+        .filter(t =>
+          t.comments.nodes[0]?.author?.login ===
+            'github-actions' &&
+          t.comments.nodes[0]?.body
+            ?.includes('<br>Cc ')
+        )
+        .map(t =>
+          t.comments.nodes[0].body
+            .replace(/\n<!--(.*) -->\n/, '')
+            .replace(/.*<br>Cc(.*)/, '$1')
+            .replaceAll('@', '')
+            .trim()
+            .split(' ')
+        )
+        .flat()
+    )
+  ]
+
+  if (found.length > 0) return found
+  return defaultAssignees
+}
+
+// Check Signal C: needs-security-review label
+// removed by an assignee.
+async function checkLabelRemoved (
+  github, pr, assignees
+) {
+  const result = await github.graphql(
+    UNLABELED_QUERY,
+    {
+      owner: pr.owner,
+      name: pr.repo,
+      prnumber: pr.number
+    }
+  )
+
+  const items =
+    result.repository.pullRequest.timelineItems
+  return items.nodes.some(
+    item =>
+      item.label?.name === 'needs-security-review' &&
+      assignees.some(
+        a => item.actor?.login?.toLowerCase() ===
+          a.toLowerCase()
+      )
+  )
+}
+
+// Check Signal D: all github-actions review threads
+// with <br>Cc are resolved by a security assignee.
+export function checkAllThreadsResolved (threads, assignees) {
+  const securityThreads = threads.nodes.filter(
+    t =>
+      t.comments.nodes[0]?.author?.login ===
+        'github-actions' &&
+      t.comments.nodes[0]?.body
+        ?.includes('<br>Cc ')
+  )
+
+  if (securityThreads.length === 0) return false
+
+  return securityThreads.every(t => {
+    if (!t.isResolved) return false
+    const resolver =
+      t.resolvedBy?.login?.toLowerCase()
+    return assignees.some(
+      a => a.toLowerCase() === resolver
+    )
+  })
+}
+
+// Main cleanup function.
+//
+// @param {object} opts
+// @param {string} opts.token        - Slack bot token
+// @param {object} opts.github       - Octokit instance
+// @param {string} opts.channel      - Slack channel
+// @param {boolean} [opts.debug]
+// @param {string[]} opts.defaultAssignees
+//   - Fallback security assignees (GitHub usernames).
+//     Caller must provide this; no hardcoded default.
+export default async function cleanupSecurityActionMessages ({
+  token = null,
+  github = null,
+  channel = '#secops-hotspots',
+  debug = false,
+  defaultAssignees = []
+}) {
+  if (!token) {
+    throw new Error('token is required!')
+  }
+  if (!github) {
+    throw new Error('github is required!')
+  }
+  if (defaultAssignees.length === 0) {
+    console.log(
+      'cleanup: no defaultAssignees provided, ' +
+      'signals C/D may not work correctly'
+    )
+  }
+
+  debug = debug === 'true' || debug === true
+
+  const { WebClient } = await import('@slack/web-api')
+  const web = new WebClient(token)
+
+  const channelId = await findChannelId(web, channel)
+
+  // Fetch messages from the last 30 days (paginated).
+  const allMessages = await fetchMessages(
+    web, channelId, 30
+  )
+
+  const messages = allMessages.filter(
+    m => m.username === SECURITY_ACTION_USERNAME
+  )
+
+  if (messages.length === 0) {
+    if (debug) {
+      console.log(
+        'cleanup: no security-action messages found'
+      )
+    }
+    return 0
+  }
+
+  if (debug) {
+    console.log(
+      `cleanup: found ${messages.length} ` +
+      'security-action message(s) to evaluate'
+    )
+  }
+
+  const toDelete = []
+
+  for (const msg of messages) {
+    // Reactions are included in the history response,
+    // so no separate reactions.get call is needed.
+    const reactions = msg.reactions || []
+
+    // Extract /cc user IDs for signals A and B.
+    const ccUserIds = parseCcUserIds(msg.text)
+
+    // Signal A: checkmark reaction from a /cc'd
+    // person.
+    if (ccUserIds.length > 0) {
+      const hasCheckmark = reactions.some(r => {
+        if (!CHECKMARK_REACTIONS.includes(r.name)) {
+          return false
+        }
+        return (r.users || []).some(
+          uid => ccUserIds.includes(uid)
+        )
+      })
+
+      if (hasCheckmark) {
+        if (debug) {
+          console.log(
+            `cleanup: ts=${msg.ts} has checkmark ` +
+            'from cc\'d person'
+          )
+        }
+        toDelete.push(msg)
+        continue
+      }
+    }
+
+    // Signal B: thumbsup from a /cc'd person.
+    if (ccUserIds.length > 0) {
+      const hasThumbsup = reactions.some(r => {
+        if (!THUMBSUP_REACTIONS.includes(r.name)) {
+          return false
+        }
+        return (r.users || []).some(
+          uid => ccUserIds.includes(uid)
+        )
+      })
+
+      if (hasThumbsup) {
+        if (debug) {
+          console.log(
+            `cleanup: ts=${msg.ts} has thumbsup ` +
+            'from cc\'d person'
+          )
+        }
+        toDelete.push(msg)
+        continue
+      }
+    }
+
+    // For signals C and D we need the PR URL.
+    const prUrl = extractPrUrl(msg)
+    const pr = parsePrUrl(prUrl)
+    if (!pr) {
+      if (debug) {
+        console.log(
+          `cleanup: ts=${msg.ts} no PR URL found`
+        )
+      }
+      continue
+    }
+
+    try {
+      // Fetch review threads (for assignees + D).
+      const threadResult = await github.graphql(
+        REVIEW_THREADS_QUERY,
+        {
+          owner: pr.owner,
+          name: pr.repo,
+          prnumber: pr.number
+        }
+      )
+      const threads =
+        threadResult.repository.pullRequest
+          .reviewThreads
+
+      // Determine the assignees for this PR.
+      const assignees = extractAssigneesFromThreads(
+        threads, defaultAssignees
+      )
+
+      // Signal C: label removed by assignee.
+      const labelRemoved = await checkLabelRemoved(
+        github, pr, assignees
+      )
+      if (labelRemoved) {
+        if (debug) {
+          console.log(
+            `cleanup: ts=${msg.ts} label removed ` +
+            'by assignee'
+          )
+        }
+        toDelete.push(msg)
+        continue
+      }
+
+      // Signal D: all threads resolved by assignee.
+      const allResolved = checkAllThreadsResolved(
+        threads, assignees
+      )
+      if (allResolved) {
+        if (debug) {
+          console.log(
+            `cleanup: ts=${msg.ts} all threads ` +
+            'resolved by assignee'
+          )
+        }
+        toDelete.push(msg)
+        continue
+      }
+    } catch (err) {
+      if (debug) {
+        console.log(
+          'cleanup: error checking PR ' +
+          `${prUrl}: ${err.message}`
+        )
+      }
+      // Don't delete on error — leave the message.
+    }
+  }
+
+  if (debug) {
+    console.log(
+      `cleanup: ${toDelete.length} message(s) ` +
+      'marked for deletion'
+    )
+    for (const msg of toDelete) {
+      console.log(`  would delete ts=${msg.ts}`)
+    }
+    return toDelete.length
+  }
+
+  let deleted = 0
+  for (const msg of toDelete) {
+    try {
+      await web.chat.delete({
+        channel: channelId, ts: msg.ts
+      })
+      deleted++
+
+      if (toDelete.length > 1) {
+        await new Promise(resolve => setTimeout(resolve, 1200))
+      }
+    } catch (err) {
+      console.error(
+        'cleanup: failed to delete ' +
+        `ts=${msg.ts}: ${err.message}`
+      )
+    }
+  }
+
+  console.log(`cleanup: deleted ${deleted} message(s)`)
+
+  return deleted
+}

--- a/src/cleanupSecurityActionMessages.test.js
+++ b/src/cleanupSecurityActionMessages.test.js
@@ -1,0 +1,363 @@
+/**
+ * Tests for cleanupSecurityActionMessages helpers
+ */
+import { strict as assert } from 'assert'
+import {
+  parseCcUserIds,
+  extractPrUrl,
+  parsePrUrl,
+  extractAssigneesFromThreads,
+  checkAllThreadsResolved
+} from './cleanupSecurityActionMessages.js'
+
+// ---- parseCcUserIds ----
+
+console.log('Testing parseCcUserIds...')
+
+// Test: extracts multiple user IDs
+{
+  const text = 'Some alert message /cc <@U123> <@U456>'
+  const ids = parseCcUserIds(text)
+  assert.deepEqual(ids, ['U123', 'U456'], 'Should extract 2 IDs')
+}
+console.log('  parseCcUserIds: extracts multiple IDs')
+
+// Test: extracts single user ID
+{
+  const ids = parseCcUserIds('Message /cc <@UABC>')
+  assert.deepEqual(ids, ['UABC'], 'Should extract 1 ID')
+}
+console.log('  parseCcUserIds: extracts single ID')
+
+// Test: returns empty for no /cc
+{
+  const ids = parseCcUserIds('No cc here')
+  assert.deepEqual(ids, [], 'Should return empty array')
+}
+console.log('  parseCcUserIds: empty for no /cc')
+
+// Test: returns empty for null/undefined
+assert.deepEqual(parseCcUserIds(null), [])
+assert.deepEqual(parseCcUserIds(undefined), [])
+assert.deepEqual(parseCcUserIds(''), [])
+console.log('  parseCcUserIds: handles null/undefined/empty')
+
+// Test: only captures after /cc
+{
+  const text = '<@UBEFORE> /cc <@UAFTER>'
+  const ids = parseCcUserIds(text)
+  assert.deepEqual(ids, ['UAFTER'], 'Should only capture after /cc')
+}
+console.log('  parseCcUserIds: only captures after /cc')
+
+// ---- extractPrUrl ----
+
+console.log('\nTesting extractPrUrl...')
+
+// Test: extracts from text
+{
+  const msg = {
+    text: 'pull-request: https://github.com/brave/brave-core/pull/123'
+  }
+  assert.equal(
+    extractPrUrl(msg),
+    'https://github.com/brave/brave-core/pull/123'
+  )
+}
+console.log('  extractPrUrl: from text')
+
+// Test: extracts from blocks
+{
+  const msg = {
+    text: '',
+    blocks: [{
+      text: {
+        text: 'pull-request: https://github.com/org/repo/pull/42'
+      }
+    }]
+  }
+  assert.equal(
+    extractPrUrl(msg),
+    'https://github.com/org/repo/pull/42'
+  )
+}
+console.log('  extractPrUrl: from blocks')
+
+// Test: extracts from attachment blocks
+{
+  const msg = {
+    text: '',
+    blocks: [],
+    attachments: [{
+      blocks: [{
+        text: {
+          text: 'pull-request: https://github.com/org/repo/pull/99'
+        }
+      }]
+    }]
+  }
+  assert.equal(
+    extractPrUrl(msg),
+    'https://github.com/org/repo/pull/99'
+  )
+}
+console.log('  extractPrUrl: from attachments')
+
+// Test: returns null when no PR URL found
+{
+  const msg = { text: 'no pr url here' }
+  assert.equal(extractPrUrl(msg), null)
+}
+console.log('  extractPrUrl: null when not found')
+
+// Test: handles missing blocks/attachments
+{
+  const msg = { text: '' }
+  assert.equal(extractPrUrl(msg), null)
+}
+console.log('  extractPrUrl: handles missing blocks')
+
+// ---- parsePrUrl ----
+
+console.log('\nTesting parsePrUrl...')
+
+// Test: parses valid PR URL
+{
+  const result = parsePrUrl(
+    'https://github.com/brave/brave-core/pull/123'
+  )
+  assert.deepEqual(result, {
+    owner: 'brave',
+    repo: 'brave-core',
+    number: 123
+  })
+}
+console.log('  parsePrUrl: parses valid URL')
+
+// Test: returns null for non-PR URL
+assert.equal(parsePrUrl('https://github.com/brave/repo'), null)
+console.log('  parsePrUrl: null for non-PR URL')
+
+// Test: returns null for null/undefined
+assert.equal(parsePrUrl(null), null)
+assert.equal(parsePrUrl(undefined), null)
+console.log('  parsePrUrl: null for null/undefined')
+
+// ---- extractAssigneesFromThreads ----
+
+console.log('\nTesting extractAssigneesFromThreads...')
+
+// Test: extracts assignees from Cc pattern
+// Real-world format: the body is a single line with
+// <br> acting as line break within HTML comment body.
+{
+  const threads = {
+    nodes: [{
+      comments: {
+        nodes: [{
+          author: { login: 'github-actions' },
+          body: 'Some finding<br>Cc @alice @bob'
+        }]
+      }
+    }]
+  }
+  const assignees = extractAssigneesFromThreads(
+    threads, ['default-user']
+  )
+  assert.deepEqual(assignees, ['alice', 'bob'])
+}
+console.log('  extractAssigneesFromThreads: extracts from Cc')
+
+// Test: falls back to defaults when no Cc found
+{
+  const threads = {
+    nodes: [{
+      comments: {
+        nodes: [{
+          author: { login: 'some-user' },
+          body: 'Regular comment'
+        }]
+      }
+    }]
+  }
+  const assignees = extractAssigneesFromThreads(
+    threads, ['fallback']
+  )
+  assert.deepEqual(assignees, ['fallback'])
+}
+console.log('  extractAssigneesFromThreads: falls back to defaults')
+
+// Test: deduplicates assignees
+{
+  const threads = {
+    nodes: [
+      {
+        comments: {
+          nodes: [{
+            author: { login: 'github-actions' },
+            body: 'Finding 1<br>Cc @alice @bob'
+          }]
+        }
+      },
+      {
+        comments: {
+          nodes: [{
+            author: { login: 'github-actions' },
+            body: 'Finding 2<br>Cc @alice @charlie'
+          }]
+        }
+      }
+    ]
+  }
+  const assignees = extractAssigneesFromThreads(
+    threads, []
+  )
+  assert.ok(assignees.includes('alice'), 'Should include alice')
+  assert.ok(assignees.includes('bob'), 'Should include bob')
+  assert.ok(assignees.includes('charlie'), 'Should include charlie')
+  // Verify no duplicates
+  assert.equal(
+    assignees.length,
+    new Set(assignees).size,
+    'Should have no duplicates'
+  )
+}
+console.log('  extractAssigneesFromThreads: deduplicates')
+
+// Test: empty threads falls back to defaults
+{
+  const threads = { nodes: [] }
+  const assignees = extractAssigneesFromThreads(
+    threads, ['default1']
+  )
+  assert.deepEqual(assignees, ['default1'])
+}
+console.log('  extractAssigneesFromThreads: empty threads')
+
+// ---- checkAllThreadsResolved ----
+
+console.log('\nTesting checkAllThreadsResolved...')
+
+// Test: true when all security threads resolved by assignee
+{
+  const threads = {
+    nodes: [{
+      isResolved: true,
+      resolvedBy: { login: 'alice' },
+      comments: {
+        nodes: [{
+          author: { login: 'github-actions' },
+          body: 'Finding<br>Cc @alice'
+        }]
+      }
+    }]
+  }
+  assert.equal(
+    checkAllThreadsResolved(threads, ['alice']),
+    true,
+    'Should return true when all resolved by assignee'
+  )
+}
+console.log('  checkAllThreadsResolved: all resolved by assignee')
+
+// Test: false when some threads unresolved
+{
+  const threads = {
+    nodes: [
+      {
+        isResolved: true,
+        resolvedBy: { login: 'alice' },
+        comments: {
+          nodes: [{
+            author: { login: 'github-actions' },
+            body: 'Finding 1<br>Cc @alice'
+          }]
+        }
+      },
+      {
+        isResolved: false,
+        resolvedBy: null,
+        comments: {
+          nodes: [{
+            author: { login: 'github-actions' },
+            body: 'Finding 2<br>Cc @alice'
+          }]
+        }
+      }
+    ]
+  }
+  assert.equal(
+    checkAllThreadsResolved(threads, ['alice']),
+    false,
+    'Should return false when some unresolved'
+  )
+}
+console.log('  checkAllThreadsResolved: false when unresolved')
+
+// Test: false when resolved by non-assignee
+{
+  const threads = {
+    nodes: [{
+      isResolved: true,
+      resolvedBy: { login: 'stranger' },
+      comments: {
+        nodes: [{
+          author: { login: 'github-actions' },
+          body: 'Finding<br>Cc @alice'
+        }]
+      }
+    }]
+  }
+  assert.equal(
+    checkAllThreadsResolved(threads, ['alice']),
+    false,
+    'Should return false when resolved by non-assignee'
+  )
+}
+console.log('  checkAllThreadsResolved: false for non-assignee resolver')
+
+// Test: false when no security threads
+{
+  const threads = {
+    nodes: [{
+      isResolved: true,
+      resolvedBy: { login: 'alice' },
+      comments: {
+        nodes: [{
+          author: { login: 'regular-user' },
+          body: 'Normal comment'
+        }]
+      }
+    }]
+  }
+  assert.equal(
+    checkAllThreadsResolved(threads, ['alice']),
+    false,
+    'Should return false when no security threads'
+  )
+}
+console.log('  checkAllThreadsResolved: false for no security threads')
+
+// Test: case-insensitive login comparison
+{
+  const threads = {
+    nodes: [{
+      isResolved: true,
+      resolvedBy: { login: 'Alice' },
+      comments: {
+        nodes: [{
+          author: { login: 'github-actions' },
+          body: 'Finding<br>Cc @alice'
+        }]
+      }
+    }]
+  }
+  assert.equal(
+    checkAllThreadsResolved(threads, ['alice']),
+    true,
+    'Should be case-insensitive'
+  )
+}
+console.log('  checkAllThreadsResolved: case-insensitive')
+
+console.log('\n✅ All cleanupSecurityActionMessages tests passed!')

--- a/src/deleteSlackMessages.js
+++ b/src/deleteSlackMessages.js
@@ -1,0 +1,152 @@
+import {
+  findChannelId,
+  fetchMessages,
+  deleteMessages
+} from './slackUtils.js'
+
+// Extract the repo full name from a Slack message.
+// Prefers metadata.event_payload.repo, falls back to
+// matching a github.com org/repo URL in the message.
+export function extractRepoFromMessage (m) {
+  const payloadRepo = m.metadata?.event_payload?.repo
+  if (payloadRepo) return payloadRepo
+
+  const textContent = [
+    m.text || '',
+    ...(m.blocks || []).map(
+      b => b.text?.text || ''
+    ),
+    ...(m.attachments || []).flatMap(
+      a => (a.blocks || []).map(
+        b => b.text?.text || ''
+      )
+    )
+  ].join(' ')
+
+  // Match org/repo from a github.com URL to avoid
+  // false positives on arbitrary word/word patterns.
+  const urlMatch = textContent.match(
+    /github\.com\/([a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+)/
+  )
+  if (urlMatch) return urlMatch[1]
+
+  return null
+}
+
+// Helper: create a WebClient, resolve channel, and
+// fetch messages. Shared by both exported functions
+// to avoid creating duplicate clients/fetches.
+async function prepareSlackContext (
+  token, channel, lookbackDays
+) {
+  const { WebClient } = await import('@slack/web-api')
+  const web = new WebClient(token)
+  const channelId = await findChannelId(web, channel)
+  const messages = await fetchMessages(
+    web, channelId, lookbackDays
+  )
+  return { web, channelId, messages }
+}
+
+// List unique repo names that have Slack messages from
+// a given username within the lookback window.
+//
+// @param {object} options
+// @param {string} options.token       - Slack bot token
+// @param {string} options.channel     - Channel name
+// @param {string} options.username    - Bot username
+// @param {boolean} [options.debug]
+// @param {number} [options.lookbackDays] - Default: 8
+// @returns {Promise<string[]>} Repo full names
+export async function listSlackMessageRepos ({
+  token = null,
+  channel = null,
+  username = null,
+  debug = false,
+  lookbackDays = 8
+}) {
+  if (!token || !channel || !username) {
+    throw new Error(
+      'token, channel, and username are required!'
+    )
+  }
+
+  debug = debug === 'true' || debug === true
+
+  const { messages } = await prepareSlackContext(
+    token, channel, lookbackDays
+  )
+
+  const repos = new Set()
+  for (const m of messages) {
+    if (m.username !== username) continue
+
+    const repo = extractRepoFromMessage(m)
+    if (repo) repos.add(repo)
+  }
+
+  if (debug) {
+    console.log(
+      'listSlackMessageRepos: found repos: ' +
+      Array.from(repos).join(', ')
+    )
+  }
+
+  return Array.from(repos)
+}
+
+// Delete Slack messages from a channel posted by a
+// given username whose repo matches one of the
+// provided names.
+//
+// @param {object} options
+// @param {string} options.token       - Slack bot token
+// @param {string} options.channel     - Channel name
+// @param {string} options.username    - Bot username
+// @param {string[]} options.repos     - Repo full names
+// @param {boolean} [options.debug]
+// @param {number} [options.lookbackDays] - Default: 8
+// @returns {Promise<number>} Number deleted
+export default async function deleteSlackMessages ({
+  token = null,
+  channel = null,
+  username = null,
+  repos = [],
+  debug = false,
+  lookbackDays = 8
+}) {
+  if (!token) throw new Error('token is required!')
+  if (!channel) {
+    throw new Error('channel is required!')
+  }
+  if (!username) {
+    throw new Error('username is required!')
+  }
+
+  if (!repos || repos.length === 0) return 0
+
+  debug = debug === 'true' || debug === true
+
+  const { web, channelId, messages } =
+    await prepareSlackContext(
+      token, channel, lookbackDays
+    )
+
+  const toDelete = messages.filter(m => {
+    if (m.username !== username) return false
+    const repo = extractRepoFromMessage(m)
+    return repo && repos.includes(repo)
+  })
+
+  if (debug) {
+    console.log(
+      'deleteSlackMessages: found ' +
+      `${toDelete.length} message(s) to delete ` +
+      `for repos: ${repos.join(', ')}`
+    )
+  }
+
+  return deleteMessages(
+    web, channelId, toDelete, debug
+  )
+}

--- a/src/deleteSlackMessages.test.js
+++ b/src/deleteSlackMessages.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests for deleteSlackMessages module
+ */
+import { strict as assert } from 'assert'
+import { extractRepoFromMessage } from './deleteSlackMessages.js'
+
+// ---- extractRepoFromMessage ----
+
+console.log('Testing extractRepoFromMessage...')
+
+// Test: extracts from metadata event_payload
+{
+  const msg = {
+    metadata: { event_payload: { repo: 'brave/brave-browser' } },
+    text: 'some text'
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/brave-browser', 'Should extract from metadata')
+}
+console.log('  extractRepoFromMessage: from metadata')
+
+// Test: metadata takes precedence over text
+{
+  const msg = {
+    metadata: { event_payload: { repo: 'brave/from-metadata' } },
+    text: 'https://github.com/brave/from-text/pull/1'
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/from-metadata', 'Metadata should take precedence')
+}
+console.log('  extractRepoFromMessage: metadata precedence')
+
+// Test: falls back to github.com URL in text
+{
+  const msg = {
+    text: 'Alert for https://github.com/brave/brave-core/pull/123'
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/brave-core', 'Should extract from URL in text')
+}
+console.log('  extractRepoFromMessage: from text URL')
+
+// Test: falls back to github.com URL in blocks
+{
+  const msg = {
+    text: '',
+    blocks: [{
+      text: { text: 'See https://github.com/brave/adblock/issues/5' }
+    }]
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/adblock', 'Should extract from blocks')
+}
+console.log('  extractRepoFromMessage: from blocks')
+
+// Test: falls back to github.com URL in attachments
+{
+  const msg = {
+    text: '',
+    blocks: [],
+    attachments: [{
+      blocks: [{
+        text: { text: 'https://github.com/brave/star-core/pull/42' }
+      }]
+    }]
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/star-core', 'Should extract from attachments')
+}
+console.log('  extractRepoFromMessage: from attachments')
+
+// Test: returns null for no match
+{
+  const msg = { text: 'No repo here' }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, null, 'Should return null when no repo found')
+}
+console.log('  extractRepoFromMessage: null for no match')
+
+// Test: returns null for empty metadata
+{
+  const msg = {
+    metadata: { event_payload: {} },
+    text: 'No github URL'
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, null, 'Should return null for empty metadata and no URL')
+}
+console.log('  extractRepoFromMessage: null for empty metadata')
+
+// Test: handles dots in repo names
+{
+  const msg = {
+    text: 'https://github.com/brave/brave.browser.v2/pull/1'
+  }
+  const repo = extractRepoFromMessage(msg)
+  assert.equal(repo, 'brave/brave.browser.v2', 'Should handle dots in repo names')
+}
+console.log('  extractRepoFromMessage: handles dots in repo names')
+
+console.log('\n✅ All deleteSlackMessages tests passed!')

--- a/src/dependabotConstants.js
+++ b/src/dependabotConstants.js
@@ -1,0 +1,44 @@
+// Shared constants and helpers for Dependabot-related
+// modules (nudge, dismiss, reconciliation).
+
+export const DEFAULT_SKIP_HOTWORDS = [
+  'dos',
+  'denial of service',
+  'redos',
+  'denial-of-service',
+  'memory explosion',
+  'inefficient regular expression',
+  'regular expression complexity'
+]
+
+// Severity enum used by both nudge and dismiss.
+export const Severity = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3
+}
+
+// Compute the minimum severity level that matches
+// the nudge action's date-based logic:
+//   - 'medium' if today is within the first 7 days
+//     of the month (matching the nudge action)
+//   - 'high' otherwise
+//
+// The nudge action (action.cjs) uses getDate() <= 7;
+// this helper replicates that logic exactly.
+export function nudgeSeverityForToday () {
+  const today = new Date()
+  return today.getDate() <= 7 ? 'medium' : 'high'
+}
+
+// Return the severity keys at or above `minlevel`.
+// E.g. severityKeysAbove('high') => ['high','critical']
+export function severityKeysAbove (minlevel) {
+  const min = typeof minlevel === 'string'
+    ? Severity[minlevel]
+    : minlevel
+  return Object.keys(Severity).filter(
+    s => Severity[s] >= min
+  )
+}

--- a/src/dependabotConstants.test.js
+++ b/src/dependabotConstants.test.js
@@ -1,0 +1,82 @@
+/**
+ * Tests for dependabotConstants module
+ */
+import { strict as assert } from 'assert'
+import {
+  DEFAULT_SKIP_HOTWORDS,
+  Severity,
+  nudgeSeverityForToday,
+  severityKeysAbove
+} from './dependabotConstants.js'
+
+// ---- DEFAULT_SKIP_HOTWORDS ----
+
+console.log('Testing DEFAULT_SKIP_HOTWORDS...')
+
+assert.ok(Array.isArray(DEFAULT_SKIP_HOTWORDS), 'Should be an array')
+assert.ok(DEFAULT_SKIP_HOTWORDS.length > 0, 'Should not be empty')
+assert.ok(DEFAULT_SKIP_HOTWORDS.includes('dos'), 'Should include dos')
+assert.ok(
+  DEFAULT_SKIP_HOTWORDS.includes('denial of service'),
+  'Should include denial of service'
+)
+console.log('  DEFAULT_SKIP_HOTWORDS: valid')
+
+// ---- Severity ----
+
+console.log('\nTesting Severity...')
+
+assert.equal(Severity.low, 0)
+assert.equal(Severity.medium, 1)
+assert.equal(Severity.high, 2)
+assert.equal(Severity.critical, 3)
+console.log('  Severity: correct values')
+
+// ---- nudgeSeverityForToday ----
+
+console.log('\nTesting nudgeSeverityForToday...')
+
+{
+  const result = nudgeSeverityForToday()
+  const today = new Date()
+  const expected = today.getDate() <= 7 ? 'medium' : 'high'
+  assert.equal(result, expected, `Should return ${expected} for day ${today.getDate()}`)
+}
+console.log('  nudgeSeverityForToday: correct for today')
+
+// ---- severityKeysAbove ----
+
+console.log('\nTesting severityKeysAbove...')
+
+{
+  const keys = severityKeysAbove('low')
+  assert.deepEqual(keys, ['low', 'medium', 'high', 'critical'])
+}
+console.log('  severityKeysAbove: low includes all')
+
+{
+  const keys = severityKeysAbove('medium')
+  assert.deepEqual(keys, ['medium', 'high', 'critical'])
+}
+console.log('  severityKeysAbove: medium includes medium+')
+
+{
+  const keys = severityKeysAbove('high')
+  assert.deepEqual(keys, ['high', 'critical'])
+}
+console.log('  severityKeysAbove: high includes high+')
+
+{
+  const keys = severityKeysAbove('critical')
+  assert.deepEqual(keys, ['critical'])
+}
+console.log('  severityKeysAbove: critical only')
+
+// Test: accepts numeric values too
+{
+  const keys = severityKeysAbove(2)
+  assert.deepEqual(keys, ['high', 'critical'])
+}
+console.log('  severityKeysAbove: accepts numeric input')
+
+console.log('\n✅ All dependabotConstants tests passed!')

--- a/src/dependabotDismiss.js
+++ b/src/dependabotDismiss.js
@@ -1,11 +1,5 @@
 import fs from 'node:fs/promises'
-
-const Severity = {
-  low: 0,
-  medium: 1,
-  high: 2,
-  critical: 3
-}
+import { Severity } from './dependabotConstants.js'
 
 export default async function dependabotDismiss ({
   org,
@@ -25,6 +19,7 @@ export default async function dependabotDismiss ({
 }) {
   const watermark = 'The following alerts were dismissed:\n\n'
   let message = ''
+  const dismissedRepos = new Set()
 
   let dependabotDismissIds = []
 
@@ -76,6 +71,7 @@ export default async function dependabotDismiss ({
     }
 
     message += `- [${a.security_advisory.summary} in \`${org}/${a.repository.name}\`](${a.html_url})\n`
+    dismissedRepos.add(`${org}/${a.repository.name}`)
 
     if (debug) {
       console.log(dismissComment)
@@ -98,9 +94,8 @@ export default async function dependabotDismiss ({
     })
   }
 
-  if (message.length > 0) {
-    return watermark + message
-  } else {
-    return ''
+  return {
+    message: message.length > 0 ? watermark + message : '',
+    dismissedRepos: Array.from(dismissedRepos)
   }
 }

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -1,9 +1,7 @@
-const Severity = {
-  low: 0,
-  medium: 1,
-  high: 2,
-  critical: 3
-}
+import {
+  Severity,
+  DEFAULT_SKIP_HOTWORDS
+} from './dependabotConstants.js'
 
 // original code at: https://stackoverflow.com/questions/44195322/a-plain-javascript-way-to-decode-html-entities-works-on-both-browsers-and-node
 function decodeEntities (encodedString) {
@@ -30,10 +28,11 @@ export default async function dependabotNudge ({
   debug = false,
   minlevel = Severity.high,
   skipRepositories = ['chromium'],
-  skipHotwords = ['dos', 'denial of service', 'redos', 'denial-of-service', 'memory explosion', 'inefficient regular expression', 'regular expression complexity'],
+  skipHotwords = DEFAULT_SKIP_HOTWORDS,
   defaultContact = ['yan'],
   githubToSlack = {},
   singleOutputMessage = false,
+  assignMaintainers = true,
   actionPath
 }) {
   const { default: getConfig } = await import(`${actionPath}/src/getConfig.js`)
@@ -117,10 +116,16 @@ export default async function dependabotNudge ({
       })).filter(a => !skipHotwords.some(h => a.security_advisory.summary.toLowerCase().includes(h)))
         .filter(a => a.security_vulnerability?.first_patched_version?.identifier)
 
-      // get property values for this repository
-      let maintainers = (props.maintainers || '').toLowerCase().split(',').filter(Boolean)
+      // Resolve GitHub usernames for alert assignment (before Slack name conversion)
+      const githubMaintainers = (props.maintainers || '').toLowerCase().split(',').filter(Boolean)
         .map(m => options.elected_maintainers[m] || m)
-        .map(m => githubToSlack[m] ? githubToSlack[m] : `@${m}`) || []
+
+      // Remove duplicates
+      const uniqueGithubMaintainers = Array.from(new Set(githubMaintainers))
+
+      // Convert to Slack handles for the message
+      let maintainers = uniqueGithubMaintainers
+        .map(m => githubToSlack[m] ? githubToSlack[m] : `@${m}`)
 
       // remove duplicates
       maintainers = Array.from(new Set(maintainers))
@@ -128,7 +133,51 @@ export default async function dependabotNudge ({
       if (alerts.length > 0) {
         if (debug) { console.log(`alerts len: ${alerts.length}`) }
 
-        let msg = `[${org}/${repo.name}](https://github.com/${org}/${repo.name}) has \`${alerts.length}\` open security issue(s) in depedencies`
+        // Assign maintainers to each alert via the
+        // GitHub Dependabot alert assignees API.
+        if (assignMaintainers && uniqueGithubMaintainers.length > 0) {
+          for (const alert of alerts) {
+            try {
+              if (debug) {
+                console.log(
+                  'Would assign ' +
+                  uniqueGithubMaintainers.join(', ') +
+                  ` to alert #${alert.number}` +
+                  ` in ${org}/${repo.name}`
+                )
+              } else {
+                await github.request(
+                  'PATCH /repos/{owner}/{repo}' +
+                  '/dependabot/alerts/{alert_number}',
+                  {
+                    owner: org,
+                    repo: repo.name,
+                    alert_number: alert.number,
+                    assignees: uniqueGithubMaintainers,
+                    headers: {
+                      'X-GitHub-Api-Version':
+                        '2022-11-28'
+                    }
+                  }
+                )
+                // Small delay to avoid hitting
+                // GitHub secondary rate limits.
+                await new Promise(
+                  resolve => setTimeout(resolve, 200)
+                )
+              }
+            } catch (assignErr) {
+              console.error(
+                'Failed to assign maintainers to' +
+                ` alert #${alert.number}` +
+                ` in ${org}/${repo.name}:` +
+                ` ${assignErr.message}`
+              )
+            }
+          }
+        }
+
+        let msg = `[${org}/${repo.name}](https://github.com/${org}/${repo.name}) has \`${alerts.length}\` open security issue(s) in dependencies`
         const critLen = alerts.filter(s => Severity[s.severity] >= Severity.critical).length
         if (critLen > 0) {
           msg += `, **\`${critLen}\` of which are critical**`
@@ -165,12 +214,12 @@ export default async function dependabotNudge ({
           msg += `**No maintainers listed for the given vulnerabilities, consider migrating and archiving this repository** - ${defaultContact.map(c => `@${c}`).join(', ')}`
         }
 
-        messages.push(msg)
+        messages.push({ repo: `${org}/${repo.name}`, message: msg })
       }
     } catch (e) {
       console.error(e)
     }
   }
 
-  if (debug || singleOutputMessage) { return messages.join('\n\n') } else { return messages }
+  if (debug || singleOutputMessage) { return messages.map(m => m.message).join('\n\n') } else { return messages }
 }

--- a/src/reconcileNudgeMessages.js
+++ b/src/reconcileNudgeMessages.js
@@ -1,0 +1,147 @@
+// Reconciliation: find nudge messages for repos that
+// no longer have any qualifying open Dependabot alerts
+// (e.g. fixed manually, auto-closed, or dismissed in
+// a prior run) and delete the stale Slack messages.
+
+import {
+  DEFAULT_SKIP_HOTWORDS,
+  nudgeSeverityForToday,
+  severityKeysAbove
+} from './dependabotConstants.js'
+
+// Check a single repo for qualifying open alerts.
+// Returns true if the repo has zero qualifying alerts
+// (i.e. its nudge message is stale).
+async function isRepoStale (
+  github, repoFullName, severityKeys, skipHotwords, debug
+) {
+  const [repoOrg, repoName] = repoFullName.split('/')
+  if (!repoOrg || !repoName) return false
+
+  try {
+    const alerts = await github.paginate(
+      'GET /repos/{owner}/{repo}/dependabot/alerts',
+      {
+        owner: repoOrg,
+        repo: repoName,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28'
+        },
+        sort: 'updated',
+        state: 'open',
+        severity: severityKeys.join(',')
+      }
+    )
+
+    // Apply the same post-filters as nudge:
+    // - skip hotword matches
+    // - require a patched version
+    const qualifying = alerts.filter(a => {
+      const summary =
+        a.security_advisory.summary.toLowerCase()
+      if (skipHotwords.some(h =>
+        summary.includes(h)
+      )) {
+        return false
+      }
+      const patched =
+        a.security_vulnerability
+          ?.first_patched_version?.identifier
+      return !!patched
+    })
+
+    if (qualifying.length === 0) {
+      if (debug) {
+        console.log(
+          `reconcile: ${repoFullName} has 0` +
+          ' qualifying alerts, marking stale'
+        )
+      }
+      return true
+    }
+    return false
+  } catch (err) {
+    // Repo may have been archived/deleted/no access.
+    // Treat as stale so the nudge message is removed.
+    if (debug) {
+      console.log(
+        'reconcile: error checking ' +
+        `${repoFullName}: ${err.message}`
+      )
+    }
+    return true
+  }
+}
+
+// Reconcile nudge messages: find repos whose nudge
+// messages are stale and delete them.
+//
+// @param {object} opts
+// @param {object} opts.github          - Octokit instance
+// @param {string} opts.slackToken      - Slack bot token
+// @param {string} opts.channel         - Slack channel
+// @param {string[]} opts.dismissedRepos - Repos already
+//   cleaned up by the dismiss step (skip these)
+// @param {boolean} [opts.debug]
+// @param {string[]} [opts.skipHotwords]
+// @param {Function} opts.listSlackMessageRepos
+// @param {Function} opts.deleteSlackMessages
+// @returns {Promise<string[]>} List of stale repo names
+export default async function reconcileNudgeMessages ({
+  github,
+  slackToken,
+  channel,
+  dismissedRepos = [],
+  debug = false,
+  skipHotwords = DEFAULT_SKIP_HOTWORDS,
+  listSlackMessageRepos,
+  deleteSlackMessages
+}) {
+  debug = debug === 'true' || debug === true
+
+  const nudgeUsername = 'dependabot'
+
+  const minlevel = nudgeSeverityForToday()
+  const severityKeys = severityKeysAbove(minlevel)
+
+  const nudgedRepos = await listSlackMessageRepos({
+    token: slackToken,
+    channel,
+    username: nudgeUsername,
+    debug
+  })
+
+  // Exclude repos we already cleaned up.
+  const toReconcile = nudgedRepos.filter(
+    r => !dismissedRepos.includes(r)
+  )
+
+  const staleRepos = []
+
+  for (const repoFullName of toReconcile) {
+    const stale = await isRepoStale(
+      github, repoFullName, severityKeys,
+      skipHotwords, debug
+    )
+    if (stale) staleRepos.push(repoFullName)
+  }
+
+  if (staleRepos.length > 0) {
+    if (debug) {
+      console.log(
+        'reconcile: cleaning up nudge messages' +
+        ` for ${staleRepos.length} stale ` +
+        `repo(s): ${staleRepos.join(', ')}`
+      )
+    }
+    await deleteSlackMessages({
+      debug,
+      token: slackToken,
+      channel,
+      username: nudgeUsername,
+      repos: staleRepos
+    })
+  }
+
+  return staleRepos
+}

--- a/src/reconcileNudgeMessages.test.js
+++ b/src/reconcileNudgeMessages.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for reconcileNudgeMessages module
+ */
+import { strict as assert } from 'assert'
+import reconcileNudgeMessages from './reconcileNudgeMessages.js'
+
+console.log('Testing reconcileNudgeMessages...')
+
+// Helper: create a mock GitHub client
+function mockGithub (alertsByRepo) {
+  return {
+    paginate: async (url, opts) => {
+      const key = `${opts.owner}/${opts.repo}`
+      return alertsByRepo[key] || []
+    }
+  }
+}
+
+// Helper: create a mock listSlackMessageRepos
+function mockListRepos (repos) {
+  return async () => repos
+}
+
+// Helper: create a mock deleteSlackMessages that
+// records calls
+function mockDeleteMessages () {
+  const calls = []
+  return {
+    fn: async (opts) => { calls.push(opts) },
+    calls
+  }
+}
+
+// Test: stale repos (no qualifying alerts) get cleaned
+{
+  const github = mockGithub({
+    'org/repo1': [],
+    'org/repo2': []
+  })
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos(['org/repo1', 'org/repo2']),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, ['org/repo1', 'org/repo2'])
+  assert.equal(del.calls.length, 1, 'Should call delete once')
+  assert.deepEqual(
+    del.calls[0].repos,
+    ['org/repo1', 'org/repo2']
+  )
+}
+console.log('  stale repos get cleaned')
+
+// Test: repos with qualifying alerts are kept
+{
+  const github = mockGithub({
+    'org/repo1': [{
+      security_advisory: { summary: 'XSS vulnerability' },
+      security_vulnerability: {
+        first_patched_version: { identifier: '1.0.1' }
+      }
+    }]
+  })
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos(['org/repo1']),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, [])
+  assert.equal(del.calls.length, 0, 'Should not delete')
+}
+console.log('  repos with qualifying alerts are kept')
+
+// Test: hotword-matching alerts are filtered out
+{
+  const github = mockGithub({
+    'org/repo1': [{
+      security_advisory: {
+        summary: 'Denial of Service in package'
+      },
+      security_vulnerability: {
+        first_patched_version: { identifier: '2.0.0' }
+      }
+    }]
+  })
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos(['org/repo1']),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, ['org/repo1'])
+  assert.equal(del.calls.length, 1)
+}
+console.log('  hotword alerts are filtered out')
+
+// Test: alerts without patched version are filtered
+{
+  const github = mockGithub({
+    'org/repo1': [{
+      security_advisory: { summary: 'Real vulnerability' },
+      security_vulnerability: {
+        first_patched_version: null
+      }
+    }]
+  })
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos(['org/repo1']),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, ['org/repo1'])
+}
+console.log('  alerts without patched version are filtered')
+
+// Test: already-dismissed repos are excluded
+{
+  const github = mockGithub({
+    'org/repo2': []
+  })
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: ['org/repo1'],
+    debug: false,
+    listSlackMessageRepos: mockListRepos([
+      'org/repo1', 'org/repo2'
+    ]),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, ['org/repo2'])
+  // repo1 should not be in the delete call
+  assert.ok(!del.calls[0].repos.includes('org/repo1'))
+}
+console.log('  already-dismissed repos are excluded')
+
+// Test: API errors mark repo as stale
+{
+  const github = {
+    paginate: async () => {
+      throw new Error('Not Found')
+    }
+  }
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos(['org/deleted-repo']),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, ['org/deleted-repo'])
+}
+console.log('  API errors mark repo as stale')
+
+// Test: no nudged repos means no work done
+{
+  const github = mockGithub({})
+  const del = mockDeleteMessages()
+
+  const stale = await reconcileNudgeMessages({
+    github,
+    slackToken: 'xoxb-test',
+    channel: '#test',
+    dismissedRepos: [],
+    debug: false,
+    listSlackMessageRepos: mockListRepos([]),
+    deleteSlackMessages: del.fn
+  })
+
+  assert.deepEqual(stale, [])
+  assert.equal(del.calls.length, 0)
+}
+console.log('  no nudged repos = no work')
+
+console.log('\n✅ All reconcileNudgeMessages tests passed!')

--- a/src/sendSlackMessage.js
+++ b/src/sendSlackMessage.js
@@ -1,21 +1,6 @@
-async function findChannelId (web, name) {
-  let cursor = null
-
-  while (true) {
-    const r = await web.conversations.list({ cursor })
-    const f = r.channels.find(c => c.name === name || c.name === name.substring(1))
-
-    if (f) {
-      return f.id
-    }
-
-    if (!r.response_metadata.next_cursor) {
-      throw new Error('channel not found')
-    }
-
-    cursor = r.response_metadata.next_cursor
-  }
-}
+import {
+  findChannelId
+} from './slackUtils.js'
 
 const colorCodes = {
   black: '#000000',
@@ -36,7 +21,8 @@ export default async function sendSlackMessage ({
   message = null,
   debug = false,
   color = null,
-  username = 'github-actions'
+  username = 'github-actions',
+  eventPayload = {}
 }) {
   if (!token) {
     throw new Error('token is required!')
@@ -135,7 +121,7 @@ export default async function sendSlackMessage ({
     }
   }
 
-  const metadata = { event_type: hashHex, event_payload: { } }
+  const metadata = { event_type: hashHex, event_payload: eventPayload }
 
   // send the message
   const result = await web.chat.postMessage({

--- a/src/slackUtils.js
+++ b/src/slackUtils.js
@@ -1,0 +1,93 @@
+// Shared Slack utilities used across multiple modules.
+
+// Resolve a Slack channel name (e.g. '#secops-hotspots'
+// or 'secops-hotspots') to its channel ID.
+export async function findChannelId (web, name) {
+  let cursor = null
+
+  while (true) {
+    const r = await web.conversations.list({ cursor })
+    const f = r.channels.find(
+      c => c.name === name ||
+        c.name === name.substring(1)
+    )
+
+    if (f) return f.id
+
+    if (!r.response_metadata.next_cursor) {
+      throw new Error('channel not found')
+    }
+
+    cursor = r.response_metadata.next_cursor
+  }
+}
+
+// Fetch all messages from a channel within a lookback
+// window (in days). Paginates automatically.
+export async function fetchMessages (
+  web, channelId, lookbackDays
+) {
+  const oldest =
+    Date.now() / 1000 - 60 * 60 * 24 * lookbackDays
+  const messages = []
+  let cursor = null
+
+  while (true) {
+    const response = await web.conversations.history({
+      channel: channelId,
+      oldest,
+      limit: 200,
+      cursor
+    })
+
+    messages.push(...response.messages)
+
+    const next =
+      response.response_metadata?.next_cursor
+    if (!response.has_more || !next) break
+
+    cursor = next
+  }
+
+  return messages
+}
+
+// Delete Slack messages with rate-limit-safe delays.
+// In debug mode, logs what would be deleted and returns
+// the count without actually deleting.
+export async function deleteMessages (
+  web, channelId, msgs, debug
+) {
+  if (debug) {
+    for (const m of msgs) {
+      const repo =
+        m.metadata?.event_payload?.repo ||
+        '(text match)'
+      console.log(
+        `  would delete ts=${m.ts} repo=${repo}`
+      )
+    }
+    return msgs.length
+  }
+
+  let deleted = 0
+  for (const m of msgs) {
+    try {
+      await web.chat.delete({
+        channel: channelId, ts: m.ts
+      })
+      deleted++
+
+      if (msgs.length > 1) {
+        await new Promise(resolve => setTimeout(resolve, 1200))
+      }
+    } catch (err) {
+      console.error(
+        'deleteSlackMessages: failed to delete ' +
+        `ts=${m.ts}: ${err.message}`
+      )
+    }
+  }
+
+  return deleted
+}

--- a/src/slackUtils.test.js
+++ b/src/slackUtils.test.js
@@ -1,0 +1,213 @@
+/**
+ * Tests for slackUtils module
+ */
+import { strict as assert } from 'assert'
+import { findChannelId, fetchMessages, deleteMessages } from './slackUtils.js'
+
+// ---- findChannelId ----
+
+console.log('Testing findChannelId...')
+
+// Test: finds channel on first page
+{
+  const mockWeb = {
+    conversations: {
+      list: async () => ({
+        channels: [
+          { name: 'general', id: 'C001' },
+          { name: 'secops-hotspots', id: 'C002' }
+        ],
+        response_metadata: { next_cursor: '' }
+      })
+    }
+  }
+  const id = await findChannelId(mockWeb, '#secops-hotspots')
+  assert.equal(id, 'C002', 'Should resolve #secops-hotspots to C002')
+}
+console.log('  findChannelId: found on first page')
+
+// Test: finds channel without # prefix
+{
+  const mockWeb = {
+    conversations: {
+      list: async () => ({
+        channels: [{ name: 'secops-hotspots', id: 'C002' }],
+        response_metadata: { next_cursor: '' }
+      })
+    }
+  }
+  const id = await findChannelId(mockWeb, 'secops-hotspots')
+  assert.equal(id, 'C002', 'Should resolve without # prefix')
+}
+console.log('  findChannelId: found without # prefix')
+
+// Test: paginates to find channel
+{
+  let callCount = 0
+  const mockWeb = {
+    conversations: {
+      list: async ({ cursor }) => {
+        callCount++
+        if (!cursor) {
+          return {
+            channels: [{ name: 'general', id: 'C001' }],
+            response_metadata: { next_cursor: 'page2' }
+          }
+        }
+        return {
+          channels: [{ name: 'secops-hotspots', id: 'C002' }],
+          response_metadata: { next_cursor: '' }
+        }
+      }
+    }
+  }
+  const id = await findChannelId(mockWeb, '#secops-hotspots')
+  assert.equal(id, 'C002', 'Should find after pagination')
+  assert.equal(callCount, 2, 'Should have made 2 API calls')
+}
+console.log('  findChannelId: paginates correctly')
+
+// Test: throws when channel not found
+{
+  const mockWeb = {
+    conversations: {
+      list: async () => ({
+        channels: [{ name: 'general', id: 'C001' }],
+        response_metadata: { next_cursor: '' }
+      })
+    }
+  }
+  await assert.rejects(
+    () => findChannelId(mockWeb, '#nonexistent'),
+    { message: 'channel not found' }
+  )
+}
+console.log('  findChannelId: throws on not found')
+
+// ---- fetchMessages ----
+
+console.log('\nTesting fetchMessages...')
+
+// Test: fetches single page
+{
+  const mockWeb = {
+    conversations: {
+      history: async () => ({
+        messages: [
+          { ts: '1', text: 'hello' },
+          { ts: '2', text: 'world' }
+        ],
+        has_more: false,
+        response_metadata: {}
+      })
+    }
+  }
+  const msgs = await fetchMessages(mockWeb, 'C001', 7)
+  assert.equal(msgs.length, 2, 'Should return 2 messages')
+}
+console.log('  fetchMessages: single page')
+
+// Test: paginates multiple pages
+{
+  let callCount = 0
+  const mockWeb = {
+    conversations: {
+      history: async ({ cursor }) => {
+        callCount++
+        if (!cursor) {
+          return {
+            messages: [{ ts: '1', text: 'page1' }],
+            has_more: true,
+            response_metadata: { next_cursor: 'page2' }
+          }
+        }
+        return {
+          messages: [{ ts: '2', text: 'page2' }],
+          has_more: false,
+          response_metadata: {}
+        }
+      }
+    }
+  }
+  const msgs = await fetchMessages(mockWeb, 'C001', 7)
+  assert.equal(msgs.length, 2, 'Should combine both pages')
+  assert.equal(callCount, 2, 'Should make 2 API calls')
+}
+console.log('  fetchMessages: multi-page pagination')
+
+// Test: passes oldest timestamp
+{
+  let receivedOldest
+  const mockWeb = {
+    conversations: {
+      history: async ({ oldest }) => {
+        receivedOldest = oldest
+        return {
+          messages: [],
+          has_more: false,
+          response_metadata: {}
+        }
+      }
+    }
+  }
+  await fetchMessages(mockWeb, 'C001', 3)
+  const expectedMin = Date.now() / 1000 - 60 * 60 * 24 * 3 - 5
+  const expectedMax = Date.now() / 1000 - 60 * 60 * 24 * 3 + 5
+  assert.ok(
+    receivedOldest >= expectedMin && receivedOldest <= expectedMax,
+    'Should pass correct oldest timestamp for 3 day lookback'
+  )
+}
+console.log('  fetchMessages: correct oldest timestamp')
+
+// ---- deleteMessages ----
+
+console.log('\nTesting deleteMessages...')
+
+// Test: debug mode returns count without deleting
+{
+  let deleteCalled = false
+  const mockWeb = {
+    chat: {
+      delete: async () => { deleteCalled = true }
+    }
+  }
+  const msgs = [
+    { ts: '1', metadata: { event_payload: { repo: 'org/repo1' } } },
+    { ts: '2', metadata: { event_payload: { repo: 'org/repo2' } } }
+  ]
+  const count = await deleteMessages(mockWeb, 'C001', msgs, true)
+  assert.equal(count, 2, 'Debug mode should return count')
+  assert.equal(deleteCalled, false, 'Debug mode should not call delete')
+}
+console.log('  deleteMessages: debug mode skips deletion')
+
+// Test: deletes messages and returns count
+{
+  const deleted = []
+  const mockWeb = {
+    chat: {
+      delete: async ({ channel, ts }) => { deleted.push({ channel, ts }) }
+    }
+  }
+  const msgs = [{ ts: '1' }]
+  const count = await deleteMessages(mockWeb, 'C001', msgs, false)
+  assert.equal(count, 1, 'Should delete 1 message')
+  assert.deepEqual(deleted, [{ channel: 'C001', ts: '1' }])
+}
+console.log('  deleteMessages: deletes and returns count')
+
+// Test: handles delete errors gracefully
+{
+  const mockWeb = {
+    chat: {
+      delete: async () => { throw new Error('rate_limited') }
+    }
+  }
+  const msgs = [{ ts: '1' }, { ts: '2' }]
+  const count = await deleteMessages(mockWeb, 'C001', msgs, false)
+  assert.equal(count, 0, 'Should return 0 when all deletes fail')
+}
+console.log('  deleteMessages: handles errors gracefully')
+
+console.log('\n✅ All slackUtils tests passed!')


### PR DESCRIPTION
Slack message lifecycle management
- dependabot-auto-dismiss now deletes stale dependabot-nudge Slack
  messages for repos whose alerts were dismissed in the current run
- New reconciliation step: after dismiss, checks all remaining nudged
  repos for qualifying open alerts and removes messages for repos that
  no longer have any (fixed manually, auto-closed, or dismissed earlier)
- Reconciliation logic extracted into src/reconcileNudgeMessages.js with
  shared severity/hotword constants in src/dependabotConstants.js
- New src/deleteSlackMessages.js utility: finds and deletes Slack
  messages by username and repo (metadata or text fallback), with 8-day
  lookback and rate-limit-safe 1.2s delay between deletions
- New src/cleanupSecurityActionMessages.js: deletes stale
  security-action messages from #secops-hotspots based on review
  completion signals (checkmark/thumbsup reactions from /cc'd users,
  label removal by assignee, or all review threads resolved by assignee)
- Shared Slack helpers (findChannelId, fetchMessages, deleteMessages)
  extracted into src/slackUtils.js; sendSlackMessage refactored to use it

Dependabot alert assignment
- dependabotNudge assigns repo maintainers to each alert via the GitHub
  Dependabot alert assignees API (GA as of 2026-03-03), opt-in via
  assignMaintainers param (defaults true)
- dependabotNudge returns structured { repo, message } objects; nudge
  action passes eventPayload: { repo } to sendSlackMessage for reliable
  Slack message-to-repo association via metadata

API contract changes
- dependabotDismiss returns { message, dismissedRepos } instead of a
  plain string
- sendSlackMessage accepts an eventPayload param stored in Slack message
  metadata for downstream lookups

Code quality
- Extracted shared Severity enum and DEFAULT_SKIP_HOTWORDS into
  src/dependabotConstants.js to eliminate duplication between nudge,
  dismiss, and reconciliation modules
- Replaced hardcoded '#secops-hotspots' with channel variables across
  all action handlers (main, nudge, dismiss)
- Fixed non-paginated message fetch in cleanupSecurityActionMessages
  (was limited to 100 messages; now uses paginated fetchMessages)
- Fixed severity filter in reconciliation to match nudge action's
  date-based logic and pass comma-joined string to the REST API
- Fixed deleteSlackMessages to reuse extractRepoFromMessage() helper
  instead of duplicating text-extraction logic
- Fixed typo: "depedencies" -> "dependencies" in nudge message text

Testing & documentation
- Added tests for slackUtils, deleteSlackMessages,
  cleanupSecurityActionMessages, dependabotConstants, and
  reconcileNudgeMessages (38 test cases total)
- Added dotenv as devDependency; run.js auto-loads .env when present