### PR TITLE
sources_gni: fix false positive on .html.ts files

### DIFF
--- a/assets/opengrep_rules/client/sources_gni.gni
+++ b/assets/opengrep_rules/client/sources_gni.gni
@@ -5,6 +5,11 @@ brave_chrome_browser_sources = [
   "brave_browser_features.h",
 ]
 
+brave_settings_ts_files = [
+  # ok:sources_gni
+  "brave_settings_app.html.ts",
+]
+
 brave_chrome_browser_deps = [
   # ok:sources_gni
   "//base",

--- a/assets/opengrep_rules/client/sources_gni.yaml
+++ b/assets/opengrep_rules/client/sources_gni.yaml
@@ -20,8 +20,8 @@ rules:
       https://github.com/brave/brave-core/blob/master/docs/gni_sources.md for
       details
     pattern-either:
-      - pattern-regex: .*\.h
-      - pattern-regex: .*\.cc
-      - pattern-regex: .*\.mm
-      - pattern-regex: .*\.cpp
-      - pattern-regex: .*\.hpp
+      - pattern-regex: '.*\.h"'
+      - pattern-regex: '.*\.cc"'
+      - pattern-regex: '.*\.mm"'
+      - pattern-regex: '.*\.cpp"'
+      - pattern-regex: '.*\.hpp"'


### PR DESCRIPTION
From my understanding, this rule was not meant to catch .html.ts files.