### PR TITLE
fix: await createComment calls and fix unverified-commits label compa…

### DIFF
--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -159,15 +159,19 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     const { default: unverifiedCommits } = await import(`${actionPath}/src/steps/unverifiedCommits.js`)
 
     // add unverified-commits label step
-    const unverifiedCommitsSteps = await unverifiedCommits({ context, github })
-    if (unverifiedCommitsSteps === '"UNVERIFIED-CHANGED"') {
-      await github.rest.issues.addLabels({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: context.issue.number,
-        labels: ['unverified-commits']
-      })
-      debugLog('Added unverified-commits label')
+    try {
+      const unverifiedCommitsSteps = await unverifiedCommits({ context, github })
+      if (unverifiedCommitsSteps === 'UNVERIFIED-CHANGED') {
+        await github.rest.issues.addLabels({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: context.issue.number,
+          labels: ['unverified-commits']
+        })
+        debugLog('Added unverified-commits label')
+      }
+    } catch (e) {
+      console.error('Unverified commits check failed:', e.message)
     }
 
     // run-reviewdog-pr step

--- a/src/steps/hotwords.js
+++ b/src/steps/hotwords.js
@@ -50,7 +50,7 @@ export default async function hotwords ({
     const messages = (await github.graphql(pullRequestCommentsQuery, variables)).repository.pullRequest.comments.nodes.map(node => node.body)
 
     if (!messages.includes(m)) {
-      github.rest.issues.createComment({
+      await github.rest.issues.createComment({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: context.issue.number,

--- a/src/steps/unverifiedCommits.js
+++ b/src/steps/unverifiedCommits.js
@@ -53,7 +53,7 @@ export default async function unverifiedCommits ({
     }
     if (!commentExists) {
       console.log('Creating new comment')
-      github.rest.issues.createComment({
+      await github.rest.issues.createComment({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: context.issue.number,


### PR DESCRIPTION
…rison

- Add missing await on createComment in unverifiedCommits.js and hotwords.js to prevent unhandled promise rejections on 403 errors
- Fix string comparison bug: '"UNVERIFIED-CHANGED"' -> 'UNVERIFIED-CHANGED' so the unverified-commits label is actually applied
- Wrap unverified commits step in try/catch so permission errors don't crash the entire security scan