### PR TITLE
fix: default hotwords_enabled to false (opt-in instead of opt-out)

### DIFF
--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -63,7 +63,7 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     baseline_scan_only: 'true',
     assignees: ASSIGNEES,
     hotwords: HOTWORDS,
-    hotwords_enabled: 'true',
+    hotwords_enabled: 'false',
     codeowners_min_files: '50',
     codeowners_mode: 'groups'
   }, config, properties, inputs)


### PR DESCRIPTION
## Summary

- Changes the hardcoded default for `hotwords_enabled` from `'true'` to `'false'` in `actions/main/action.cjs`, making PR hotword scanning opt-in rather than opt-out.
- Previously, since neither `brave/brave-core` nor `brave/search` had `security_action_hotwords_enabled` set as a GitHub custom property or in `.github/security-action.json`, the hardcoded `'true'` default always won, causing hotword scanning to run on every PR.
- Repos that want hotword scanning must now explicitly enable it via a workflow input, repo config file, or GitHub custom property.