### PR TITLE
feat: add sveltekit-event-fetch-path-traversal opengrep rule

### DIFF
--- a/assets/opengrep_rules/client/sveltekit-event-fetch-path-traversal.ts
+++ b/assets/opengrep_rules/client/sveltekit-event-fetch-path-traversal.ts
@@ -1,0 +1,86 @@
+import { type RequestEvent, fail } from '@sveltejs/kit';
+
+function validateURLParam(value: string, name?: string): string {
+  return encodeURIComponent(value);
+}
+
+// ---- TRUE POSITIVES: should trigger ----
+
+async function unsafeUpdate(event: RequestEvent) {
+  const data = await event.request.formData();
+  const usageLimitId = data.get('usage_limit_id') as string;
+  // ruleid: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/usage-limits/${usageLimitId}`, {
+    method: 'PATCH',
+  });
+}
+
+async function unsafeDelete(event: RequestEvent) {
+  const data = await event.request.formData();
+  const usageLimitId = data.get('usage_limit_id') as string;
+  // ruleid: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/usage-limits/${usageLimitId}`, {
+    method: 'DELETE',
+  });
+}
+
+async function unsafeSessionCheck(event: RequestEvent) {
+  const sessionId = event.url.searchParams.get('session_id');
+  // ruleid: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/activity-session/status/${sessionId}`);
+}
+
+async function unsafeQueryParam(event: RequestEvent) {
+  const data = await event.request.formData();
+  const tokenId = data.get('token_id') as string;
+  // ruleid: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/auth/subscription-tokens?token_id=${tokenId}`, {
+    method: 'DELETE',
+  });
+}
+
+// ---- TRUE NEGATIVES: should NOT trigger ----
+
+async function safeWithSanitizePathParam(event: RequestEvent) {
+  const data = await event.request.formData();
+  const usageLimitId = validateURLParam(data.get('usage_limit_id') as string, 'usage_limit_id');
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/usage-limits/${usageLimitId}`, {
+    method: 'PATCH',
+  });
+}
+
+async function safeWithEncodeURIComponent(event: RequestEvent) {
+  const data = await event.request.formData();
+  const planId = encodeURIComponent(data.get('plan_id') as string);
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/plans/${planId}`);
+}
+
+async function safeInlineSanitize(event: RequestEvent) {
+  const sessionId = event.url.searchParams.get('session_id');
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/activity-session/status/${validateURLParam(sessionId!, 'session_id')}`);
+}
+
+async function safeInlineEncode(event: RequestEvent) {
+  const data = await event.request.formData();
+  const tokenId = data.get('token_id') as string;
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/auth/subscription-tokens?token_id=${encodeURIComponent(tokenId)}`, {
+    method: 'DELETE',
+  });
+}
+
+async function safeStaticPath(event: RequestEvent) {
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch('/api/plans');
+}
+
+async function safeNoUserInput(event: RequestEvent) {
+  const operation = 'update';
+  // ok: sveltekit-event-fetch-path-traversal
+  const response = await event.fetch(`/api/billing/payment-method?action=${operation}`, {
+    method: 'POST',
+  });
+}

--- a/assets/opengrep_rules/client/sveltekit-event-fetch-path-traversal.yaml
+++ b/assets/opengrep_rules/client/sveltekit-event-fetch-path-traversal.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: sveltekit-event-fetch-path-traversal
+    metadata:
+      author: Andrea Brancaleoni <abc@pompel.me>
+      confidence: MEDIUM
+      source: https://github.com/brave/security-action/blob/main/assets/opengrep_rules/client/sveltekit-event-fetch-path-traversal.yaml
+      category: security
+      references:
+        - https://cwe.mitre.org/data/definitions/22.html
+        - https://owasp.org/www-community/attacks/Path_Traversal
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+    message: >
+      User-supplied parameter is interpolated into an `event.fetch()`
+      URL without sanitization. An attacker can inject `../` sequences to reach
+      arbitrary internal API endpoints. Wrap the value with
+      `validateURLParam()` or `encodeURIComponent()` before interpolation.
+    severity: WARNING
+    languages:
+      - ts
+      - js
+    paths:
+      include:
+        - "*.server.ts"
+        - "*.server.js"
+        - sveltekit-event-fetch-path-traversal.ts
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: $DATA.get('...') as $TYPE
+              - pattern: $DATA.get('...')
+              - pattern: $EVENT.url.searchParams.get('...')
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern: validateURLParam(...)
+              - pattern: encodeURIComponent(...)
+    pattern-sinks:
+      - pattern: event.fetch(`...${...}...`, ...)


### PR DESCRIPTION
Detect unsanitized user input interpolated into event.fetch() URLs in SvelteKit server files, which can lead to path traversal attacks (CWE-22). The rule recognizes sanitizePathParam() and encodeURIComponent() as safe sanitizers.