### PR TITLE
fix: add include_all_metadata to Slack history calls for nudge message deletion

### DIFF
--- a/src/sendSlackMessage.js
+++ b/src/sendSlackMessage.js
@@ -109,7 +109,8 @@ export default async function sendSlackMessage ({
   const history = await web.conversations.history({
     channel: channelId,
     limit: 50,
-    oldest: Date.now() / 1000 - 60 * 60 * 24 // a day ago
+    oldest: Date.now() / 1000 - 60 * 60 * 24, // a day ago
+    include_all_metadata: true
   })
 
   // debounce messages if the same message was sent in the last day

--- a/src/slackUtils.js
+++ b/src/slackUtils.js
@@ -37,7 +37,8 @@ export async function fetchMessages (
       channel: channelId,
       oldest,
       limit: 200,
-      cursor
+      cursor,
+      include_all_metadata: true
     })
 
     messages.push(...response.messages)

--- a/src/slackUtils.test.js
+++ b/src/slackUtils.test.js
@@ -160,6 +160,29 @@ console.log('  fetchMessages: multi-page pagination')
 }
 console.log('  fetchMessages: correct oldest timestamp')
 
+// Test: passes include_all_metadata: true
+{
+  let receivedParams
+  const mockWeb = {
+    conversations: {
+      history: async (params) => {
+        receivedParams = params
+        return {
+          messages: [],
+          has_more: false,
+          response_metadata: {}
+        }
+      }
+    }
+  }
+  await fetchMessages(mockWeb, 'C001', 7)
+  assert.equal(
+    receivedParams.include_all_metadata, true,
+    'Should request metadata so downstream consumers can read event_payload'
+  )
+}
+console.log('  fetchMessages: requests metadata')
+
 // ---- deleteMessages ----
 
 console.log('\nTesting deleteMessages...')


### PR DESCRIPTION
## Summary

- Slack's `conversations.history` does not return message `metadata` by default — `include_all_metadata: true` must be passed explicitly
- Without this flag, `extractRepoFromMessage()` could never resolve repos via `metadata.event_payload.repo`, breaking nudge message cleanup in `deleteSlackMessages`/`reconcileNudgeMessages` and message deduplication in `sendSlackMessage`
- Added `include_all_metadata: true` to both `fetchMessages()` in `slackUtils.js` and the dedup history fetch in `sendSlackMessage.js`, plus a test asserting the flag is present