### PR TITLE
fix: prevent reconcileNudgeMessages from deleting all messages on API errors

### DIFF
--- a/src/reconcileNudgeMessages.js
+++ b/src/reconcileNudgeMessages.js
@@ -29,7 +29,7 @@ async function isRepoStale (
         },
         sort: 'updated',
         state: 'open',
-        severity: severityKeys.join(',')
+        severity: severityKeys
       }
     )
 
@@ -61,15 +61,15 @@ async function isRepoStale (
     }
     return false
   } catch (err) {
-    // Repo may have been archived/deleted/no access.
-    // Treat as stale so the nudge message is removed.
-    if (debug) {
-      console.log(
-        'reconcile: error checking ' +
-        `${repoFullName}: ${err.message}`
-      )
-    }
-    return true
+    // On any error (rate limit, transient 5xx,
+    // permissions, etc.) keep the message and retry
+    // on the next scheduled run.
+    console.log(
+      'reconcile: error checking ' +
+      `${repoFullName}: ${err.message}` +
+      ' — keeping message until next run'
+    )
+    return false
   }
 }
 
@@ -124,6 +124,14 @@ export default async function reconcileNudgeMessages ({
       skipHotwords, debug
     )
     if (stale) staleRepos.push(repoFullName)
+
+    // Delay between API calls to avoid secondary
+    // rate limits when checking many repos.
+    if (toReconcile.length > 1) {
+      await new Promise(resolve =>
+        setTimeout(resolve, 1000)
+      )
+    }
   }
 
   if (staleRepos.length > 0) {

--- a/src/reconcileNudgeMessages.test.js
+++ b/src/reconcileNudgeMessages.test.js
@@ -165,7 +165,7 @@ console.log('  alerts without patched version are filtered')
 }
 console.log('  already-dismissed repos are excluded')
 
-// Test: API errors mark repo as stale
+// Test: API errors keep the message (don't delete)
 {
   const github = {
     paginate: async () => {
@@ -184,9 +184,10 @@ console.log('  already-dismissed repos are excluded')
     deleteSlackMessages: del.fn
   })
 
-  assert.deepEqual(stale, ['org/deleted-repo'])
+  assert.deepEqual(stale, [])
+  assert.equal(del.calls.length, 0, 'Should not delete on error')
 }
-console.log('  API errors mark repo as stale')
+console.log('  API errors keep the message')
 
 // Test: no nudged repos means no work done
 {


### PR DESCRIPTION
## Summary

- **Bug 1**: `isRepoStale()` catch-all treated ALL API errors (rate limits, 5xx, permissions) as "stale" → `return true` → cascade delete of every nudge message on first run. Fixed to `return false` — keep message, retry next scheduled run.
- **Bug 2**: `severity` param passed as `severityKeys.join(',')` (string) instead of array. Octokit URL-encodes comma in strings → API may return empty results → all repos appear stale. Fixed to pass array, matching `dependabotNudge.js` and `dependabotDismiss.js`.
- **Rate limit protection**: Added 1s delay between per-repo Dependabot API calls to avoid secondary rate limits when checking many repos.

## Test changes

Updated `reconcileNudgeMessages.test.js`: API errors now assert message is **kept** (not deleted).