### PR TITLE
feat: set published rules to Comment mode via Semgrep API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ GITHUB_TOKEN=ghp_your_github_token
 # =============================================================================
 # PYPI_INDEX_URL=https://pypi.org/simple
 # PYPI_INSECURE_HOSTS=
+
+# =============================================================================
+# Semgrep App Token (Required for semgrep publish and policy management)
+# Get from: https://semgrep.dev/orgs/-/settings/tokens
+# Needs "Web API" access for policy mode management
+# =============================================================================
+# SEMGREP_APP_TOKEN=your_semgrep_app_token_here

--- a/.github/workflows/semgrep-publish.yml
+++ b/.github/workflows/semgrep-publish.yml
@@ -21,3 +21,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: semgrep publish --visibility=org_private assets/opengrep_rules/client/
       - run: semgrep publish --visibility=org_private assets/opengrep_rules/services/
+      - name: Set published rules to Comment mode
+        run: >
+          python3 scripts/semgrep-set-policy-mode.py --mode MODE_COMMENT
+          assets/opengrep_rules/client/ assets/opengrep_rules/services/

--- a/.github/workflows/semgrep-publish.yml
+++ b/.github/workflows/semgrep-publish.yml
@@ -19,9 +19,17 @@ jobs:
       image: returntocorp/semgrep
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - run: semgrep publish --visibility=org_private assets/opengrep_rules/client/
-      - run: semgrep publish --visibility=org_private assets/opengrep_rules/services/
+      - name: Publish client rules
+        id: publish-client
+        run: |
+          output=$(semgrep publish --visibility=org_private assets/opengrep_rules/client/ 2>&1)
+          echo "$output"
+          slug=$(echo "$output" | sed -n 's|.*semgrep.dev/r/\([^.]*\)\..*|\1|p' | head -1)
+          echo "org_slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Publish services rules
+        run: semgrep publish --visibility=org_private assets/opengrep_rules/services/
       - name: Set published rules to Comment mode
         run: >
           python3 scripts/semgrep-set-policy-mode.py --mode MODE_COMMENT
+          --org-slug "${{ steps.publish-client.outputs.org_slug }}"
           assets/opengrep_rules/client/ assets/opengrep_rules/services/

--- a/.github/workflows/semgrep-publish.yml
+++ b/.github/workflows/semgrep-publish.yml
@@ -28,8 +28,13 @@ jobs:
           echo "org_slug=$slug" >> "$GITHUB_OUTPUT"
       - name: Publish services rules
         run: semgrep publish --visibility=org_private assets/opengrep_rules/services/
-      - name: Set published rules to Comment mode
+      - name: Set policy modes for published rules
         run: >
-          python3 scripts/semgrep-set-policy-mode.py --mode MODE_COMMENT
+          python3 scripts/semgrep-set-policy-mode.py
           --org-slug "${{ steps.publish-client.outputs.org_slug }}"
+          --blocklist assets/opengrep_rules/blocklist.txt
+          --blocklist assets/opengrep_rules/blocklist-static.txt
+          --blocklist assets/opengrep_rules/blocklist-brave-core.txt
+          --blocklist assets/opengrep_rules/blocklist-internal.txt
+          --blocklist assets/opengrep_rules/blocklist-bsg.txt
           assets/opengrep_rules/client/ assets/opengrep_rules/services/

--- a/scripts/semgrep-set-policy-mode.py
+++ b/scripts/semgrep-set-policy-mode.py
@@ -1,47 +1,68 @@
 #!/usr/bin/env python3
-"""Set published Semgrep rules to a specified policy mode via the Semgrep API.
+"""Set Semgrep policy modes for all rules in a deployment.
 
-Only updates rules whose IDs match those found in the given YAML directories.
-Constructs rule paths as '<org_slug>.<rule_id>' and calls the UpdatePolicy API
-for each one, which adds the rule to the policy if not already present.
+- Custom rules (published from local YAML): always MODE_COMMENT
+- Official rules matching blocklist: MODE_MONITOR
+- Official rules not matching blocklist: MODE_COMMENT
 
 Usage:
   SEMGREP_APP_TOKEN=<token> python3 semgrep-set-policy-mode.py \
-    --mode MODE_COMMENT \
+    --org-slug brave_intl \
+    --blocklist assets/opengrep_rules/blocklist.txt \
+    --blocklist assets/opengrep_rules/blocklist-static.txt \
     assets/opengrep_rules/client/ assets/opengrep_rules/services/
 
 Requires: Python 3.x with stdlib only (no pip dependencies).
 """
+import concurrent.futures
 import glob
 import json
 import os
 import re
 import sys
+import threading
+import time
 import urllib.request
 import urllib.error
 
 BASE_URL = "https://semgrep.dev/api/v1"
-DEFAULT_MODE = "MODE_COMMENT"
+MODE_COMMENT = "MODE_COMMENT"
+MODE_MONITOR = "MODE_MONITOR"
+MAX_RETRIES = 5
+INITIAL_BACKOFF = 1.0  # seconds
 
 
 def api(method, path, token, body=None):
     url = f"{BASE_URL}{path}"
     data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(
-        url, data=data, method=method,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        body_text = e.read().decode() if e.fp else ""
-        print(f"HTTP {e.code} on {method} {url}: {body_text}", file=sys.stderr)
-        raise
+    for attempt in range(MAX_RETRIES + 1):
+        req = urllib.request.Request(
+            url, data=data, method=method,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode() if e.fp else ""
+            if e.code in (429, 500, 502, 503, 504) and attempt < MAX_RETRIES:
+                backoff = INITIAL_BACKOFF * (2 ** attempt)
+                print(f"HTTP {e.code} on {method} {url} (attempt {attempt + 1}/{MAX_RETRIES + 1}), retrying in {backoff:.1f}s", file=sys.stderr)
+                time.sleep(backoff)
+                continue
+            print(f"HTTP {e.code} on {method} {url}: {body_text}", file=sys.stderr)
+            raise
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+            if attempt < MAX_RETRIES:
+                backoff = INITIAL_BACKOFF * (2 ** attempt)
+                print(f"Network error on {method} {url} (attempt {attempt + 1}/{MAX_RETRIES + 1}): {e}, retrying in {backoff:.1f}s", file=sys.stderr)
+                time.sleep(backoff)
+                continue
+            raise
 
 
 def collect_rule_ids(directories):
@@ -56,6 +77,28 @@ def collect_rule_ids(directories):
                 rule_id = match.group(1).strip()
                 rule_ids.add(rule_id)
     return rule_ids
+
+
+def load_blocklist_paths(blocklist_files):
+    """Load blocklist files, return set of semgrep rule paths.
+
+    Only extracts semgrep.dev/r/<path> entries (official rules).
+    GitHub URLs are ignored (those reference custom rule sources).
+    """
+    paths = set()
+    for bl_path in blocklist_files:
+        if not os.path.exists(bl_path):
+            print(f"Warning: blocklist not found: {bl_path}", file=sys.stderr)
+            continue
+        with open(bl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                m = re.search(r"semgrep\.dev/r/(.+)$", line)
+                if m:
+                    paths.add(m.group(1))
+    return paths
 
 
 def get_deployment(token):
@@ -75,6 +118,23 @@ def get_policies(token, deployment_id):
     return policies
 
 
+def get_rules(token, deployment_id, policy_id, page_size=2000):
+    """Fetch all rules in a policy, handling pagination."""
+    all_rules = []
+    cursor = None
+    while True:
+        path = f"/deployments/{deployment_id}/policies/{policy_id}?pageSize={page_size}"
+        if cursor:
+            path += f"&cursor={cursor}"
+        data = api("GET", path, token)
+        rules = data.get("rules", [])
+        all_rules.extend(rules)
+        cursor = data.get("cursor")
+        if not cursor or not rules:
+            break
+    return all_rules
+
+
 def set_rule_mode(token, deployment_id, policy_id, rule_path, mode):
     body = {"rulePath": rule_path, "policyMode": mode}
     return api("PUT", f"/deployments/{deployment_id}/policies/{policy_id}", token, body)
@@ -86,21 +146,21 @@ def main():
         print("Error: SEMGREP_APP_TOKEN not set", file=sys.stderr)
         sys.exit(1)
 
-    target_mode = DEFAULT_MODE
     directories = []
+    blocklist_files = []
     dry_run = False
     org_slug = None
     args = sys.argv[1:]
     i = 0
     while i < len(args):
-        if args[i] == "--mode" and i + 1 < len(args):
-            target_mode = args[i + 1]
-            i += 2
-        elif args[i] == "--dry-run":
+        if args[i] == "--dry-run":
             dry_run = True
             i += 1
         elif args[i] == "--org-slug" and i + 1 < len(args):
             org_slug = args[i + 1]
+            i += 2
+        elif args[i] == "--blocklist" and i + 1 < len(args):
+            blocklist_files.append(args[i + 1])
             i += 2
         else:
             directories.append(args[i])
@@ -108,35 +168,36 @@ def main():
 
     if not directories:
         print("Error: no rule directories specified", file=sys.stderr)
-        print("Usage: semgrep-set-policy-mode.py [--mode MODE] [--org-slug SLUG] [--dry-run] <dir> [<dir>...]",
+        print("Usage: semgrep-set-policy-mode.py [--org-slug SLUG] [--blocklist FILE ...] [--dry-run] <dir> [<dir>...]",
               file=sys.stderr)
         sys.exit(1)
 
+    # Collect custom rule IDs from local YAML files
     local_ids = collect_rule_ids(directories)
-    if not local_ids:
-        print("Warning: no rule IDs found in specified directories", file=sys.stderr)
-        sys.exit(0)
+    print(f"Local custom rule IDs: {len(local_ids)}")
 
-    print(f"Target mode: {target_mode}{' (dry run)' if dry_run else ''}")
-    print(f"Local rule IDs ({len(local_ids)}): {', '.join(sorted(local_ids))}")
+    # Load blocklist (official rule paths only)
+    blocklist = load_blocklist_paths(blocklist_files)
+    print(f"Blocklist entries (official rules): {len(blocklist)}")
 
+    # Get deployment
     deployment = get_deployment(token)
     deployment_id = deployment["id"]
-
-    # Use deployment slug as org slug if not explicitly provided
     if not org_slug:
         org_slug = deployment.get("slug", "")
     if not org_slug:
-        print("Error: could not determine org slug from deployment", file=sys.stderr)
+        print("Error: could not determine org slug", file=sys.stderr)
         sys.exit(1)
     print(f"Org slug: {org_slug}")
 
+    # Build set of custom rule paths for matching
+    custom_paths = {f"{org_slug}.{rid}" for rid in local_ids}
+
+    # Get SAST policy
     policies = get_policies(token, deployment_id)
-    # Use the first SAST policy (Global Policy), skip secrets policies
     sast_policies = [p for p in policies if p.get("productType", "") != "PRODUCT_TYPE_SECRETS"]
     if not sast_policies:
-        sast_policies = policies[:1]  # fallback to first policy
-
+        sast_policies = policies[:1]
     if not sast_policies:
         print("Error: no policies found", file=sys.stderr)
         sys.exit(1)
@@ -146,32 +207,106 @@ def main():
     policy_name = policy.get("name", policy_id)
     print(f"Using policy: {policy_name} (id={policy_id})")
 
-    updated = 0
-    skipped = 0
-    errors = 0
+    # Fetch all existing rules in the policy
+    print("Fetching all rules in policy...")
+    all_rules = get_rules(token, deployment_id, policy_id)
+    print(f"Total rules in policy: {len(all_rules)}")
 
-    for rule_id in sorted(local_ids):
-        rule_path = f"{org_slug}.{rule_id}"
-        if dry_run:
-            print(f"  [DRY RUN] {rule_path} -> {target_mode}")
-            updated += 1
-            continue
+    # Also add custom rules that aren't in the policy yet
+    existing_paths = {r["path"] for r in all_rules}
+    missing_custom = custom_paths - existing_paths
+    if missing_custom:
+        print(f"Custom rules not yet in policy: {len(missing_custom)}")
+        for path in missing_custom:
+            all_rules.append({"path": path, "policyMode": "UNKNOWN", "source": "SOURCE_CUSTOM"})
+
+    # Classify each rule
+    to_update = []  # (rule_path, current_mode, target_mode)
+    counts = {"custom_comment": 0, "official_comment": 0, "official_monitor": 0, "already_correct": 0}
+
+    for rule in all_rules:
+        path = rule["path"]
+        current_mode = rule.get("policyMode", "UNKNOWN")
+
+        if path in custom_paths or rule.get("source") == "SOURCE_CUSTOM":
+            # Custom rules -> always MODE_COMMENT
+            target = MODE_COMMENT
+            if current_mode != target:
+                to_update.append((path, current_mode, target))
+                counts["custom_comment"] += 1
+            else:
+                counts["already_correct"] += 1
+        elif path in blocklist:
+            # Official rules in blocklist -> MODE_MONITOR
+            target = MODE_MONITOR
+            if current_mode != target:
+                to_update.append((path, current_mode, target))
+                counts["official_monitor"] += 1
+            else:
+                counts["already_correct"] += 1
+        else:
+            # Official rules not in blocklist -> MODE_COMMENT
+            target = MODE_COMMENT
+            if current_mode != target:
+                to_update.append((path, current_mode, target))
+                counts["official_comment"] += 1
+            else:
+                counts["already_correct"] += 1
+
+    print(f"\nClassification:")
+    print(f"  Custom rules -> COMMENT: {counts['custom_comment']}")
+    print(f"  Official blocklisted -> MONITOR: {counts['official_monitor']}")
+    print(f"  Official not blocklisted -> COMMENT: {counts['official_comment']}")
+    print(f"  Already correct: {counts['already_correct']}")
+    print(f"  Total to update: {len(to_update)}")
+
+    if dry_run:
+        print("\n[DRY RUN] No changes made")
+        for path, current, target in to_update:
+            print(f"  {path}: {current} -> {target}")
+        return
+
+    # Apply updates in parallel
+    updated = 0
+    not_found = 0
+    errors = 0
+    max_workers = 5
+
+    def update_rule(item):
+        path, current, target = item
         try:
-            set_rule_mode(token, deployment_id, policy_id, rule_path, target_mode)
-            print(f"  {rule_path}: -> {target_mode}")
-            updated += 1
+            set_rule_mode(token, deployment_id, policy_id, path, target)
+            return ("ok", path, current, target)
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                print(f"  {rule_path}: not found in registry (skipped)")
-                skipped += 1
-            else:
-                print(f"  ERROR {rule_path}: HTTP {e.code}", file=sys.stderr)
-                errors += 1
+                return ("not_found", path, current, target)
+            return ("error", path, f"HTTP {e.code}", target)
         except Exception as e:
-            print(f"  ERROR {rule_path}: {e}", file=sys.stderr)
-            errors += 1
+            return ("error", path, str(e), target)
 
-    print(f"\nDone: {updated} updated, {skipped} skipped, {errors} errors")
+    print(f"\nApplying {len(to_update)} updates ({max_workers} workers)...", flush=True)
+    t0 = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(update_rule, item): item for item in to_update}
+        done = 0
+        for future in concurrent.futures.as_completed(futures):
+            done += 1
+            status, path, prev, target = future.result()
+            if status == "ok":
+                updated += 1
+            elif status == "not_found":
+                not_found += 1
+            else:
+                print(f"  ERROR {path}: {prev}", file=sys.stderr, flush=True)
+                errors += 1
+            if done % 50 == 0:
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed > 0 else 0
+                eta = (len(to_update) - done) / rate if rate > 0 else 0
+                print(f"  Progress: {done}/{len(to_update)} ({rate:.1f}/s, ETA {eta:.0f}s) | ok={updated} err={errors} 404={not_found}", flush=True)
+
+    elapsed = time.time() - t0
+    print(f"\nDone in {elapsed:.0f}s: {updated} updated, {not_found} not found, {errors} errors")
     if errors:
         sys.exit(1)
 

--- a/scripts/semgrep-set-policy-mode.py
+++ b/scripts/semgrep-set-policy-mode.py
@@ -14,13 +14,11 @@ Usage:
 
 Requires: Python 3.x with stdlib only (no pip dependencies).
 """
-import concurrent.futures
 import glob
 import json
 import os
 import re
 import sys
-import threading
 import time
 import urllib.request
 import urllib.error
@@ -266,44 +264,40 @@ def main():
             print(f"  {path}: {current} -> {target}")
         return
 
-    # Apply updates in parallel
+    # Apply updates sequentially with a gap between calls.
+    # Semgrep's UpdatePolicyRule has a race condition: concurrent PUT calls
+    # read-modify-write the entire rules JSON array, so concurrent writers
+    # clobber each other (HTTP 200 but changes lost). Serializing with a
+    # small delay avoids the race until a batch endpoint is available.
+    CALL_GAP = 0.05  # 50ms between calls
     updated = 0
     not_found = 0
     errors = 0
-    max_workers = 5
 
-    def update_rule(item):
-        path, current, target = item
+    print(f"\nApplying {len(to_update)} updates (sequential, {CALL_GAP * 1000:.0f}ms gap)...", flush=True)
+    t0 = time.time()
+    for done, (path, current, target) in enumerate(to_update, 1):
         try:
             set_rule_mode(token, deployment_id, policy_id, path, target)
-            return ("ok", path, current, target)
+            updated += 1
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                return ("not_found", path, current, target)
-            return ("error", path, f"HTTP {e.code}", target)
-        except Exception as e:
-            return ("error", path, str(e), target)
-
-    print(f"\nApplying {len(to_update)} updates ({max_workers} workers)...", flush=True)
-    t0 = time.time()
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(update_rule, item): item for item in to_update}
-        done = 0
-        for future in concurrent.futures.as_completed(futures):
-            done += 1
-            status, path, prev, target = future.result()
-            if status == "ok":
-                updated += 1
-            elif status == "not_found":
                 not_found += 1
             else:
-                print(f"  ERROR {path}: {prev}", file=sys.stderr, flush=True)
+                print(f"  ERROR {path}: HTTP {e.code}", file=sys.stderr, flush=True)
                 errors += 1
-            if done % 50 == 0:
-                elapsed = time.time() - t0
-                rate = done / elapsed if elapsed > 0 else 0
-                eta = (len(to_update) - done) / rate if rate > 0 else 0
-                print(f"  Progress: {done}/{len(to_update)} ({rate:.1f}/s, ETA {eta:.0f}s) | ok={updated} err={errors} 404={not_found}", flush=True)
+        except Exception as e:
+            print(f"  ERROR {path}: {e}", file=sys.stderr, flush=True)
+            errors += 1
+
+        if done % 50 == 0:
+            elapsed = time.time() - t0
+            rate = done / elapsed if elapsed > 0 else 0
+            eta = (len(to_update) - done) / rate if rate > 0 else 0
+            print(f"  Progress: {done}/{len(to_update)} ({rate:.1f}/s, ETA {eta:.0f}s) | ok={updated} err={errors} 404={not_found}", flush=True)
+
+        if done < len(to_update):
+            time.sleep(CALL_GAP)
 
     elapsed = time.time() - t0
     print(f"\nDone in {elapsed:.0f}s: {updated} updated, {not_found} not found, {errors} errors")

--- a/scripts/semgrep-set-policy-mode.py
+++ b/scripts/semgrep-set-policy-mode.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Set published Semgrep rules to a specified policy mode via the Semgrep API.
+
+Only updates rules whose IDs match those found in the given YAML directories.
+
+Usage:
+  SEMGREP_APP_TOKEN=<token> python3 semgrep-set-policy-mode.py \
+    --mode MODE_COMMENT \
+    assets/opengrep_rules/client/ assets/opengrep_rules/services/
+
+Requires: Python 3.x with stdlib only (no pip dependencies).
+"""
+import glob
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+
+BASE_URL = "https://semgrep.dev/api/v1"
+DEFAULT_MODE = "MODE_COMMENT"
+
+
+def api(method, path, token, body=None):
+    url = f"{BASE_URL}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"HTTP {e.code} on {method} {url}: {body_text}", file=sys.stderr)
+        raise
+
+
+def collect_rule_ids(directories):
+    """Parse rule IDs from all YAML files in the given directories."""
+    rule_ids = set()
+    id_pattern = re.compile(r"^\s*-\s*id:\s*(.+)$", re.MULTILINE)
+    for directory in directories:
+        for yaml_path in glob.glob(os.path.join(directory, "**", "*.yaml"), recursive=True):
+            with open(yaml_path) as f:
+                content = f.read()
+            for match in id_pattern.finditer(content):
+                rule_id = match.group(1).strip()
+                rule_ids.add(rule_id)
+    return rule_ids
+
+
+def matches_local_rule(rule_path, local_ids):
+    """Check if a remote rule path corresponds to one of our local rule IDs.
+
+    Published rules have paths like 'org-slug.rule-id'. We match if the
+    path itself is a known ID, or the part after the last '.' is a known ID.
+    """
+    if rule_path in local_ids:
+        return True
+    # org-slug.rule-id format
+    dot_idx = rule_path.find(".")
+    if dot_idx != -1:
+        suffix = rule_path[dot_idx + 1:]
+        if suffix in local_ids:
+            return True
+    return False
+
+
+def get_deployment_id(token):
+    data = api("GET", "/deployments", token)
+    deployments = data.get("deployments", [])
+    if not deployments:
+        raise RuntimeError("No deployments found")
+    dep_id = deployments[0]["id"]
+    dep_name = deployments[0].get("name", "")
+    print(f"Deployment: {dep_name} (id={dep_id})")
+    return dep_id
+
+
+def get_policies(token, deployment_id):
+    data = api("GET", f"/deployments/{deployment_id}/policies", token)
+    policies = data.get("policies", [])
+    print(f"Found {len(policies)} policies")
+    return policies
+
+
+def get_rules(token, deployment_id, policy_id, page_size=2000):
+    """Fetch all rules in a policy, handling pagination."""
+    all_rules = []
+    cursor = None
+    while True:
+        path = f"/deployments/{deployment_id}/policies/{policy_id}?pageSize={page_size}"
+        if cursor:
+            path += f"&cursor={cursor}"
+        data = api("GET", path, token)
+        rules = data.get("rules", [])
+        all_rules.extend(rules)
+        cursor = data.get("cursor")
+        if not cursor or not rules:
+            break
+    return all_rules
+
+
+def set_rule_mode(token, deployment_id, policy_id, rule_path, mode):
+    body = {"rulePath": rule_path, "policyMode": mode}
+    api("PUT", f"/deployments/{deployment_id}/policies/{policy_id}", token, body)
+
+
+def main():
+    token = os.environ.get("SEMGREP_APP_TOKEN")
+    if not token:
+        print("Error: SEMGREP_APP_TOKEN not set", file=sys.stderr)
+        sys.exit(1)
+
+    target_mode = DEFAULT_MODE
+    directories = []
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--mode" and i + 1 < len(args):
+            target_mode = args[i + 1]
+            i += 2
+        else:
+            directories.append(args[i])
+            i += 1
+
+    if not directories:
+        print("Error: no rule directories specified", file=sys.stderr)
+        print("Usage: semgrep-set-policy-mode.py [--mode MODE] <dir> [<dir>...]", file=sys.stderr)
+        sys.exit(1)
+
+    local_ids = collect_rule_ids(directories)
+    if not local_ids:
+        print("Warning: no rule IDs found in specified directories", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Target mode: {target_mode}")
+    print(f"Local rule IDs ({len(local_ids)}): {', '.join(sorted(local_ids))}")
+
+    deployment_id = get_deployment_id(token)
+    policies = get_policies(token, deployment_id)
+
+    updated = 0
+    skipped = 0
+    ignored = 0
+    errors = 0
+
+    for policy in policies:
+        policy_id = policy["id"]
+        policy_name = policy.get("name", policy_id)
+        print(f"\nPolicy: {policy_name} (id={policy_id})")
+
+        rules = get_rules(token, deployment_id, policy_id)
+        print(f"  Total rules: {len(rules)}")
+
+        for rule in rules:
+            path = rule["path"]
+            if not matches_local_rule(path, local_ids):
+                ignored += 1
+                continue
+            current_mode = rule.get("policyMode", "UNKNOWN")
+            if current_mode == target_mode:
+                skipped += 1
+                continue
+            try:
+                set_rule_mode(token, deployment_id, policy_id, path, target_mode)
+                print(f"  {path}: {current_mode} -> {target_mode}")
+                updated += 1
+            except Exception as e:
+                print(f"  ERROR {path}: {e}", file=sys.stderr)
+                errors += 1
+
+    print(f"\nDone: {updated} updated, {skipped} already correct, {ignored} not ours, {errors} errors")
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/semgrep-set-policy-mode.py
+++ b/scripts/semgrep-set-policy-mode.py
@@ -2,6 +2,8 @@
 """Set published Semgrep rules to a specified policy mode via the Semgrep API.
 
 Only updates rules whose IDs match those found in the given YAML directories.
+Constructs rule paths as '<org_slug>.<rule_id>' and calls the UpdatePolicy API
+for each one, which adds the rule to the policy if not already present.
 
 Usage:
   SEMGREP_APP_TOKEN=<token> python3 semgrep-set-policy-mode.py \
@@ -56,32 +58,14 @@ def collect_rule_ids(directories):
     return rule_ids
 
 
-def matches_local_rule(rule_path, local_ids):
-    """Check if a remote rule path corresponds to one of our local rule IDs.
-
-    Published rules have paths like 'org-slug.rule-id'. We match if the
-    path itself is a known ID, or the part after the last '.' is a known ID.
-    """
-    if rule_path in local_ids:
-        return True
-    # org-slug.rule-id format
-    dot_idx = rule_path.find(".")
-    if dot_idx != -1:
-        suffix = rule_path[dot_idx + 1:]
-        if suffix in local_ids:
-            return True
-    return False
-
-
-def get_deployment_id(token):
+def get_deployment(token):
     data = api("GET", "/deployments", token)
     deployments = data.get("deployments", [])
     if not deployments:
         raise RuntimeError("No deployments found")
-    dep_id = deployments[0]["id"]
-    dep_name = deployments[0].get("name", "")
-    print(f"Deployment: {dep_name} (id={dep_id})")
-    return dep_id
+    dep = deployments[0]
+    print(f"Deployment: {dep.get('name', '')} (id={dep['id']}, slug={dep.get('slug', '')})")
+    return dep
 
 
 def get_policies(token, deployment_id):
@@ -91,26 +75,9 @@ def get_policies(token, deployment_id):
     return policies
 
 
-def get_rules(token, deployment_id, policy_id, page_size=2000):
-    """Fetch all rules in a policy, handling pagination."""
-    all_rules = []
-    cursor = None
-    while True:
-        path = f"/deployments/{deployment_id}/policies/{policy_id}?pageSize={page_size}"
-        if cursor:
-            path += f"&cursor={cursor}"
-        data = api("GET", path, token)
-        rules = data.get("rules", [])
-        all_rules.extend(rules)
-        cursor = data.get("cursor")
-        if not cursor or not rules:
-            break
-    return all_rules
-
-
 def set_rule_mode(token, deployment_id, policy_id, rule_path, mode):
     body = {"rulePath": rule_path, "policyMode": mode}
-    api("PUT", f"/deployments/{deployment_id}/policies/{policy_id}", token, body)
+    return api("PUT", f"/deployments/{deployment_id}/policies/{policy_id}", token, body)
 
 
 def main():
@@ -121,11 +88,19 @@ def main():
 
     target_mode = DEFAULT_MODE
     directories = []
+    dry_run = False
+    org_slug = None
     args = sys.argv[1:]
     i = 0
     while i < len(args):
         if args[i] == "--mode" and i + 1 < len(args):
             target_mode = args[i + 1]
+            i += 2
+        elif args[i] == "--dry-run":
+            dry_run = True
+            i += 1
+        elif args[i] == "--org-slug" and i + 1 < len(args):
+            org_slug = args[i + 1]
             i += 2
         else:
             directories.append(args[i])
@@ -133,7 +108,8 @@ def main():
 
     if not directories:
         print("Error: no rule directories specified", file=sys.stderr)
-        print("Usage: semgrep-set-policy-mode.py [--mode MODE] <dir> [<dir>...]", file=sys.stderr)
+        print("Usage: semgrep-set-policy-mode.py [--mode MODE] [--org-slug SLUG] [--dry-run] <dir> [<dir>...]",
+              file=sys.stderr)
         sys.exit(1)
 
     local_ids = collect_rule_ids(directories)
@@ -141,43 +117,61 @@ def main():
         print("Warning: no rule IDs found in specified directories", file=sys.stderr)
         sys.exit(0)
 
-    print(f"Target mode: {target_mode}")
+    print(f"Target mode: {target_mode}{' (dry run)' if dry_run else ''}")
     print(f"Local rule IDs ({len(local_ids)}): {', '.join(sorted(local_ids))}")
 
-    deployment_id = get_deployment_id(token)
+    deployment = get_deployment(token)
+    deployment_id = deployment["id"]
+
+    # Use deployment slug as org slug if not explicitly provided
+    if not org_slug:
+        org_slug = deployment.get("slug", "")
+    if not org_slug:
+        print("Error: could not determine org slug from deployment", file=sys.stderr)
+        sys.exit(1)
+    print(f"Org slug: {org_slug}")
+
     policies = get_policies(token, deployment_id)
+    # Use the first SAST policy (Global Policy), skip secrets policies
+    sast_policies = [p for p in policies if p.get("productType", "") != "PRODUCT_TYPE_SECRETS"]
+    if not sast_policies:
+        sast_policies = policies[:1]  # fallback to first policy
+
+    if not sast_policies:
+        print("Error: no policies found", file=sys.stderr)
+        sys.exit(1)
+
+    policy = sast_policies[0]
+    policy_id = policy["id"]
+    policy_name = policy.get("name", policy_id)
+    print(f"Using policy: {policy_name} (id={policy_id})")
 
     updated = 0
     skipped = 0
-    ignored = 0
     errors = 0
 
-    for policy in policies:
-        policy_id = policy["id"]
-        policy_name = policy.get("name", policy_id)
-        print(f"\nPolicy: {policy_name} (id={policy_id})")
-
-        rules = get_rules(token, deployment_id, policy_id)
-        print(f"  Total rules: {len(rules)}")
-
-        for rule in rules:
-            path = rule["path"]
-            if not matches_local_rule(path, local_ids):
-                ignored += 1
-                continue
-            current_mode = rule.get("policyMode", "UNKNOWN")
-            if current_mode == target_mode:
+    for rule_id in sorted(local_ids):
+        rule_path = f"{org_slug}.{rule_id}"
+        if dry_run:
+            print(f"  [DRY RUN] {rule_path} -> {target_mode}")
+            updated += 1
+            continue
+        try:
+            set_rule_mode(token, deployment_id, policy_id, rule_path, target_mode)
+            print(f"  {rule_path}: -> {target_mode}")
+            updated += 1
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                print(f"  {rule_path}: not found in registry (skipped)")
                 skipped += 1
-                continue
-            try:
-                set_rule_mode(token, deployment_id, policy_id, path, target_mode)
-                print(f"  {path}: {current_mode} -> {target_mode}")
-                updated += 1
-            except Exception as e:
-                print(f"  ERROR {path}: {e}", file=sys.stderr)
+            else:
+                print(f"  ERROR {rule_path}: HTTP {e.code}", file=sys.stderr)
                 errors += 1
+        except Exception as e:
+            print(f"  ERROR {rule_path}: {e}", file=sys.stderr)
+            errors += 1
 
-    print(f"\nDone: {updated} updated, {skipped} already correct, {ignored} not ours, {errors} errors")
+    print(f"\nDone: {updated} updated, {skipped} skipped, {errors} errors")
     if errors:
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

- Adds a post-publish workflow step that sets all published opengrep rules to `MODE_COMMENT` via the Semgrep API
- Script parses rule IDs from local YAML files and only updates matching remote rules, ignoring rules not published from this repo
- Stdlib-only Python (no pip dependencies), runs inside the `returntocorp/semgrep` container