### PR TITLE
feat: add standalone slack cleanup action

### DIFF
--- a/actions/cleanup/action.cjs
+++ b/actions/cleanup/action.cjs
@@ -1,0 +1,36 @@
+const ASSIGNEES = `thypon
+kdenhartog`
+
+module.exports = async ({
+  github, context, inputs, actionPath, core,
+  debug = false
+}) => {
+  const debugLog = (...args) => {
+    if (debug) console.log(...args)
+  }
+
+  const channel = inputs.channel || '#secops-hotspots'
+  const assignees = (inputs.assignees || ASSIGNEES)
+    .split('\n')
+    .map(a => a.trim())
+    .filter(Boolean)
+
+  const { default: cleanupMessages } =
+    await import(
+      `${actionPath}/src/cleanupSecurityActionMessages.js`
+    )
+
+  const cleaned = await cleanupMessages({
+    token: inputs.slack_token,
+    github,
+    channel,
+    debug,
+    defaultAssignees: assignees
+  })
+
+  debugLog('Cleaned up stale messages:', cleaned)
+
+  if (cleaned) {
+    core.setOutput('cleaned', JSON.stringify(cleaned))
+  }
+}

--- a/actions/cleanup/action.yml
+++ b/actions/cleanup/action.yml
@@ -1,0 +1,44 @@
+name: slack-cleanup
+description: >
+  Clean up stale security-action Slack messages.
+  Designed to run on a schedule (e.g. every 6 hours)
+  rather than on every PR scan.
+inputs:
+  github_token:
+    description: 'GitHub Token'
+    required: true
+  slack_token:
+    description: 'Slack Token'
+    required: true
+  channel:
+    description: 'Slack channel to clean up'
+    required: false
+  assignees:
+    description: >
+      Newline-separated list of GitHub usernames
+      considered security assignees
+    required: false
+  debug:
+    description: 'Debug mode'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '24.x'
+    - id: npm
+      run: cd ${{ github.action_path }}/../..; npm ci
+      shell: bash
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        DEBUG: ${{ (inputs.debug == 'true' || runner.debug) && 'true' || 'false'}}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const actionPath = '${{ github.action_path }}/../../'
+          const inputs = ${{ toJson(inputs) }}
+
+          const script = require('${{ github.action_path }}/action.cjs')
+          await script({github, context, inputs, actionPath, core,
+            debug: process.env.DEBUG === 'true'})


### PR DESCRIPTION
## Summary
- Adds `actions/cleanup/` as a standalone composite action for cleaning up stale security-action Slack messages
- Designed to run on a schedule (e.g. every 6 hours via cron) instead of on every PR scan, avoiding the stampeding herd problem from PR #923
- Accepts `channel`, `assignees`, and `debug` inputs, with sensible defaults
- Follows the same pattern as other standalone actions (`dependabot-auto-dismiss`, `dependabot-nudge`, etc.)

Companion PR in `workflows` repo will add the scheduled workflow.