### PR TITLE
fix(rules): anchor action-pin regex to word boundary

### DIFF
--- a/assets/opengrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
+++ b/assets/opengrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.test.yaml
@@ -63,6 +63,9 @@ jobs:
       # ruleid: brave-third-party-action-not-pinned-to-commit-sha
         uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486
 
+      # ok: brave-third-party-action-not-pinned-to-commit-sha
+      - statuses: 2.0.2
+
   build2:
     name: Build and test using a local workflow
     # ok: brave-third-party-action-not-pinned-to-commit-sha

--- a/assets/opengrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
+++ b/assets/opengrep_rules/services/brave-third-party-action-not-pinned-to-commit-sha.yaml
@@ -19,7 +19,7 @@ rules:
 
       [GHA Policies](https://github.com/brave/internal/wiki/Pull-request-security-audit-checklist)
     patterns:
-      - pattern-regex: "uses:\\s+(?<USES>.*)\\s*$"
+      - pattern-regex: "\\buses:\\s+(?<USES>.*)\\s*$"
       - metavariable-pattern:
           metavariable: $USES
           language: generic


### PR DESCRIPTION
## Problem

`brave-third-party-action-not-pinned-to-commit-sha` rule used an unanchored regex `uses:\s+(?<USES>.*)\s*$`. In pnpm lockfiles (and potentially other yaml), `statuses: 2.0.2` contains the substring `uses: 2.0.2`, which matches and triggers false positives for "unpinned third-party action".

Example: https://github.com/brave-experiments/email-template-builder/pull/89#discussion_r3313662392

## Fix

Added `\b` word boundary anchor before `uses:` in the regex. This prevents matching substrings like `statuses`, `causes`, `abuses`, etc., while still matching all legitimate GitHub Actions `uses:` keys (which are always preceded by whitespace or start-of-line).

## Verification

- `opengrep test --strict .`: 60/60 ✓ All tests passed (includes new regression case)
- `opengrep --config ... tmp/pnpm-lock-sample.yaml`: 0 findings (was 4 false positives)
- `npm run lint-rules`: ✓ All rule files have correct metadata
- `ruby generate-compound.rb`: regenerated `compound.yaml` with updated regex