### PR TITLE
feat(dependabot-nudge): group weekly alerts into one Slack thread

### DIFF
--- a/actions/cleanup/action.cjs
+++ b/actions/cleanup/action.cjs
@@ -1,4 +1,4 @@
-const ASSIGNEES = `thypon`
+const ASSIGNEES = 'thypon'
 
 module.exports = async ({
   github, context, inputs, actionPath, core,

--- a/actions/dependabot-nudge/action.cjs
+++ b/actions/dependabot-nudge/action.cjs
@@ -1,6 +1,9 @@
 module.exports = async ({ github, context, inputs, actionPath, core, debug = false }) => {
   const { default: sendSlackMessage } = await import(`${actionPath}/src/sendSlackMessage.js`)
   const { default: dependabotNudge } = await import(`${actionPath}/src/dependabotNudge.js`)
+  const { default: isoWeekId } = await import(`${actionPath}/src/isoWeekId.js`)
+  const { findChannelId, fetchMessages } = await import(`${actionPath}/src/slackUtils.js`)
+  const { WebClient } = await import('@slack/web-api')
 
   let githubToSlack = {}
   try {
@@ -19,11 +22,65 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
 
   const messages = await dependabotNudge({ debug, org: context.repo.owner, github, minlevel, githubToSlack, actionPath })
 
+  // Nothing to nudge about: skip creating a thread entirely.
+  if (messages.length === 0) {
+    if (debug) { console.log('no dependabot alerts to nudge about; skipping thread') }
+    return
+  }
+
   const channel = inputs.slack_channel || '#secops-hotspots'
+  const token = inputs.slack_token
+  const org = context.repo.owner
+  const weekId = isoWeekId(today)
+
+  const parentEventType = 'dependabot-nudge-weekly-parent'
+  const parentPayload = { org, weekId }
+
+  const web = new WebClient(token)
+  const channelId = await findChannelId(web, channel)
+
+  const recent = await fetchMessages(web, channelId, 7)
+  const parent = recent
+    .filter(m =>
+      m.metadata?.event_type === parentEventType &&
+      m.metadata?.event_payload?.org === org &&
+      m.metadata?.event_payload?.weekId === weekId)
+    .sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts))[0]
+
+  let parentTs = parent?.ts
+
+  if (!parentTs) {
+    if (debug) { console.log(`creating new weekly parent thread for ${org} ${weekId}`) }
+    const parentResult = await sendSlackMessage({
+      debug,
+      username: 'dependabot',
+      text: `Weekly Dependabot Nudge — ${weekId}`,
+      channel,
+      token,
+      eventType: parentEventType,
+      eventPayload: parentPayload
+    })
+    parentTs = parentResult?.ts
+  } else {
+    if (debug) { console.log(`reusing weekly parent thread ${parentTs} for ${org} ${weekId}`) }
+  }
+
+  if (!parentTs) {
+    console.error('failed to obtain parent thread ts; aborting replies')
+    return
+  }
 
   for (const { repo, message } of messages) {
     try {
-      await sendSlackMessage({ debug, username: 'dependabot', message, channel, token: inputs.slack_token, eventPayload: { repo } })
+      await sendSlackMessage({
+        debug,
+        username: 'dependabot',
+        message,
+        channel,
+        token,
+        threadTs: parentTs,
+        eventPayload: { repo }
+      })
     } catch (error) {
       if (debug) { console.log(error) }
     }

--- a/actions/dependabot-nudge/action.yml
+++ b/actions/dependabot-nudge/action.yml
@@ -10,6 +10,10 @@ inputs:
   gh_to_slack_user_map:
     description: 'JSON map of github usernames to slack usernames'
     required: false
+  slack_channel:
+    description: 'Slack channel to post the weekly nudge thread to'
+    required: false
+    default: '#secops-hotspots'
   debug:
     description: 'Debug mode'
     required: false

--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -5,7 +5,7 @@ const CONSOLE_BLUE = '\x1B[0;34m'
 const CONSOLE_RED = '\x1b[0;31m'
 const RESET_CONSOLE_COLOR = '\x1b[0m'
 
-const ASSIGNEES = `thypon`
+const ASSIGNEES = 'thypon'
 const HOTWORDS = `password
 cryptography
 login

--- a/src/isoWeekId.js
+++ b/src/isoWeekId.js
@@ -1,0 +1,20 @@
+// Compute the ISO 8601 week identifier (e.g. "2026-W29")
+// for a given Date. Uses UTC internally so the result is
+// stable across timezones.
+export default function isoWeekId (date) {
+  const t = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  )
+  // ISO weeks start on Monday. Shift so Mon=0.
+  const day = (t.getUTCDay() + 6) % 7
+  // Thursday of this ISO week determines the year.
+  t.setUTCDate(t.getUTCDate() - day + 3)
+  const year = t.getUTCFullYear()
+  // First Thursday of that year.
+  const firstThu = new Date(Date.UTC(year, 0, 4))
+  const firstThuDay = (firstThu.getUTCDay() + 6) % 7
+  const week = 1 + Math.round(
+    ((t - firstThu) / 86400000 - 3 + firstThuDay) / 7
+  )
+  return `${year}-W${String(week).padStart(2, '0')}`
+}

--- a/src/isoWeekId.test.js
+++ b/src/isoWeekId.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import isoWeekId from './isoWeekId.js'
+
+test('isoWeekId: regular mid-year date', () => {
+  // 2026-07-17 is a Friday in ISO week 29.
+  assert.strictEqual(isoWeekId(new Date('2026-07-17')), '2026-W29')
+})
+
+test('isoWeekId: Monday starts the week', () => {
+  // 2026-07-13 is a Monday, still week 29.
+  assert.strictEqual(isoWeekId(new Date('2026-07-13')), '2026-W29')
+})
+
+test('isoWeekId: year boundary - late December rolls into next year W01', () => {
+  // 2025-12-29 is a Monday and belongs to ISO week 2026-W01.
+  assert.strictEqual(isoWeekId(new Date('2025-12-29')), '2026-W01')
+})
+
+test('isoWeekId: Jan 1 of non-week-1 year', () => {
+  // 2026-01-01 is a Thursday -> ISO week 2026-W01.
+  assert.strictEqual(isoWeekId(new Date('2026-01-01')), '2026-W01')
+})
+
+test('isoWeekId: Jan 1 belonging to previous year week', () => {
+  // 2027-01-01 is a Friday -> ISO week 2026-W53.
+  assert.strictEqual(isoWeekId(new Date('2027-01-01')), '2026-W53')
+})
+
+test('isoWeekId: Sunday wraps correctly', () => {
+  // 2026-07-19 is a Sunday, still week 29.
+  assert.strictEqual(isoWeekId(new Date('2026-07-19')), '2026-W29')
+})

--- a/src/sendSlackMessage.js
+++ b/src/sendSlackMessage.js
@@ -22,7 +22,11 @@ export default async function sendSlackMessage ({
   debug = false,
   color = null,
   username = 'github-actions',
-  eventPayload = {}
+  eventPayload = {},
+  threadTs = null,
+  eventType = null,
+  _web = null,
+  _findChannelId = null
 }) {
   if (!token) {
     throw new Error('token is required!')
@@ -48,16 +52,18 @@ export default async function sendSlackMessage ({
 
   if (debug) { console.log(`token.length: ${token.length}, channel: ${channel}, message: ${message}`) }
 
-  const { WebClient } = await import('@slack/web-api')
-
-  const web = new WebClient(token)
+  let web = _web
+  if (!web) {
+    const { WebClient } = await import('@slack/web-api')
+    web = new WebClient(token)
+  }
 
   // calculate the sha256 hash of the message
   const crypto = await import('crypto')
   const hash = crypto.createHash('sha256')
   if (text !== null) hash.update(text)
-  if (filteredMessage !== null) hash.update(filteredMessage)
-  if (color !== null) hash.update(color)
+  if (filteredMessage != null) hash.update(filteredMessage)
+  if (color != null) hash.update(color)
   const hashHex = hash.digest('hex')
 
   const blocks = []
@@ -103,15 +109,27 @@ export default async function sendSlackMessage ({
   }
 
   // get the channel id
-  const channelId = await findChannelId(web, channel)
+  const channelId = _findChannelId
+    ? await _findChannelId(web, channel)
+    : await findChannelId(web, channel)
 
-  // get last 50 messages from the channel, in the last day
-  const history = await web.conversations.history({
-    channel: channelId,
-    limit: 50,
-    oldest: Date.now() / 1000 - 60 * 60 * 24, // a day ago
-    include_all_metadata: true
-  })
+  // When posting into a thread, dedup by scanning the
+  // thread's replies instead of the channel history.
+  // conversations.history only returns top-level messages
+  // and would miss threaded replies.
+  const history = threadTs
+    ? await web.conversations.replies({
+      channel: channelId,
+      ts: threadTs,
+      limit: 200,
+      include_all_metadata: true
+    })
+    : await web.conversations.history({
+      channel: channelId,
+      limit: 50,
+      oldest: Date.now() / 1000 - 60 * 60 * 24, // a day ago
+      include_all_metadata: true
+    })
 
   // debounce messages if the same message was sent in the last day
   if (history.messages.some(m => m.metadata?.event_type === hashHex)) {
@@ -122,7 +140,7 @@ export default async function sendSlackMessage ({
     }
   }
 
-  const metadata = { event_type: hashHex, event_payload: eventPayload }
+  const metadata = { event_type: eventType ?? hashHex, event_payload: eventPayload }
 
   // send the message
   const result = await web.chat.postMessage({
@@ -134,7 +152,8 @@ export default async function sendSlackMessage ({
     unfurl_media: true,
     blocks,
     attachments,
-    metadata
+    metadata,
+    ...(threadTs ? { thread_ts: threadTs } : {})
   })
 
   if (debug) { console.log(`result: ${JSON.stringify(result)}`) }

--- a/src/sendSlackMessage.thread.test.js
+++ b/src/sendSlackMessage.thread.test.js
@@ -1,0 +1,133 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+// Shared fake Slack client capturing calls.
+function buildFakeWeb ({ repliesMessages = [], historyMessages = [] } = {}) {
+  const calls = {
+    postMessage: [],
+    history: [],
+    replies: []
+  }
+  const web = {
+    chat: {
+      postMessage: async (params) => {
+        calls.postMessage.push(params)
+        return { ok: true, ts: '1234.5678', channel: 'C1' }
+      }
+    },
+    conversations: {
+      history: async (params) => {
+        calls.history.push(params)
+        return { messages: historyMessages }
+      },
+      replies: async (params) => {
+        calls.replies.push(params)
+        return { messages: repliesMessages }
+      }
+    }
+  }
+  const findChannelId = async () => 'C1'
+  return { web, findChannelId, calls }
+}
+
+test('sendSlackMessage: threadTs is forwarded to chat.postMessage', async () => {
+  const { web, findChannelId, calls } = buildFakeWeb()
+  const { default: sendSlackMessage } = await import('./sendSlackMessage.js')
+
+  await sendSlackMessage({
+    token: 'xoxb-test',
+    channel: '#test',
+    text: 'hello thread',
+    threadTs: '9999.0000',
+    _web: web,
+    _findChannelId: findChannelId
+  })
+
+  assert.strictEqual(calls.postMessage.length, 1)
+  assert.strictEqual(calls.postMessage[0].thread_ts, '9999.0000')
+  assert.strictEqual(calls.replies.length, 1)
+  assert.strictEqual(calls.replies[0].ts, '9999.0000')
+  assert.strictEqual(calls.history.length, 0)
+})
+
+test('sendSlackMessage: no threadTs uses channel history, omits thread_ts', async () => {
+  const { web, findChannelId, calls } = buildFakeWeb()
+  const { default: sendSlackMessage } = await import('./sendSlackMessage.js')
+
+  await sendSlackMessage({
+    token: 'xoxb-test',
+    channel: '#test',
+    text: 'top-level msg',
+    _web: web,
+    _findChannelId: findChannelId
+  })
+
+  assert.strictEqual(calls.postMessage.length, 1)
+  assert.strictEqual(calls.postMessage[0].thread_ts, undefined)
+  assert.strictEqual(calls.history.length, 1)
+  assert.strictEqual(calls.replies.length, 0)
+})
+
+test('sendSlackMessage: eventType overrides metadata.event_type', async () => {
+  const { web, findChannelId, calls } = buildFakeWeb()
+  const { default: sendSlackMessage } = await import('./sendSlackMessage.js')
+
+  await sendSlackMessage({
+    token: 'xoxb-test',
+    channel: '#test',
+    text: 'parent',
+    eventType: 'dependabot-nudge-weekly-parent',
+    eventPayload: { org: 'brave', weekId: '2026-W29' },
+    _web: web,
+    _findChannelId: findChannelId
+  })
+
+  assert.strictEqual(
+    calls.postMessage[0].metadata.event_type,
+    'dependabot-nudge-weekly-parent'
+  )
+  assert.deepStrictEqual(calls.postMessage[0].metadata.event_payload, {
+    org: 'brave',
+    weekId: '2026-W29'
+  })
+})
+
+test('sendSlackMessage: default event_type stays as message hash', async () => {
+  const { web, findChannelId, calls } = buildFakeWeb()
+  const { default: sendSlackMessage } = await import('./sendSlackMessage.js')
+
+  await sendSlackMessage({
+    token: 'xoxb-test',
+    channel: '#test',
+    text: 'hashed',
+    _web: web,
+    _findChannelId: findChannelId
+  })
+
+  // Default event_type is the sha256 of the text.
+  assert.match(calls.postMessage[0].metadata.event_type, /^[0-9a-f]{64}$/)
+})
+
+test('sendSlackMessage: dedup via thread replies skips duplicate', async () => {
+  const crypto = await import('crypto')
+  const hash = crypto.createHash('sha256')
+  hash.update('dup text')
+  const hashHex = hash.digest('hex')
+
+  const { web, findChannelId } = buildFakeWeb({
+    repliesMessages: [{ metadata: { event_type: hashHex } }]
+  })
+  const { default: sendSlackMessage } = await import('./sendSlackMessage.js')
+
+  const result = await sendSlackMessage({
+    token: 'xoxb-test',
+    channel: '#test',
+    text: 'dup text',
+    threadTs: '5555.0000',
+    _web: web,
+    _findChannelId: findChannelId
+  })
+
+  // Dedup returns undefined and never posts.
+  assert.strictEqual(result, undefined)
+})


### PR DESCRIPTION
## What

Dependabot nudges now post as replies under a single weekly parent thread per org, instead of spamming the channel with one top-level message per repo.

## Why

Weekly runs produced N top-level messages (one per repo with alerts), flooding `#secops-hotspots`. Grouping into one thread per org+ISO week keeps the channel readable while preserving per-repo detail as replies.

## How

- **`actions/dependabot-nudge/action.cjs`**: after collecting nudges, look up an existing parent message from the last 7 days matching `dependabot-nudge-weekly-parent` metadata + `org` + ISO `weekId`. Reuse it if found; otherwise post a minimal parent (`Weekly Dependabot Nudge — <weekId>`). Each repo nudge is sent as a reply (`threadTs`). Skips entirely when there are no alerts. Multi-org safe: each org gets its own parent in a shared channel.
- **`src/sendSlackMessage.js`**: new optional params
  - `threadTs` — forwarded to `chat.postMessage.thread_ts`; when set, dedup switches from `conversations.history` to `conversations.replies` so 24h dedup still works inside threads.
  - `eventType` — overrides `metadata.event_type` (defaults to existing sha256 hash, no regression for current callers).
  - Test-only `_web` / `_findChannelId` injection points.
  - Fix latent null-check bug in `hash.update` where omitted `message`/`color` (undefined, not null) caused a `TypeError`.
- **`src/isoWeekId.js`** (new): UTC-stable ISO 8601 week id (`YYYY-Www`).
- **`actions/dependabot-nudge/action.yml`**: declare optional `slack_channel` input (default `#secops-hotspots`).

## Tests

- `src/isoWeekId.test.js` — 6 cases incl. year boundaries.
- `src/sendSlackMessage.thread.test.js` — 5 cases: `threadTs` forwarded, history-vs-replies dedup path, `eventType` override, default hash, dedup skip.

```
npx standard --ignore assets/opengrep_rules   # clean
npm test                                       # all pass
```

## Backward compatibility

`sendSlackMessage` defaults preserve existing behavior for all current callers (`threadTs`/`eventType` default to `null`).