### PR TITLE
chore(deps): Bump Opengrep to 1.11.5

### DIFF
--- a/.github/workflows/opengrep-self-test.yml
+++ b/.github/workflows/opengrep-self-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.opengrep
-          key: opengrep-v1.11.2-${{ runner.os }}
+          key: opengrep-v1.11.5-${{ runner.os }}
       - name: Install opengrep
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/actions/main/action.yml
+++ b/actions/main/action.yml
@@ -123,7 +123,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.opengrep
-        key: opengrep-v1.11.2-${{ runner.os }}
+        key: opengrep-v1.11.5-${{ runner.os }}
     - if: ${{ steps.reviewdog-enabled.outputs.result == 'true' }}
       name: Install opengrep
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/actions/opengrep-compare/action.yml
+++ b/actions/opengrep-compare/action.yml
@@ -53,7 +53,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.opengrep
-        key: opengrep-v1.11.2-${{ runner.os }}
+        key: opengrep-v1.11.5-${{ runner.os }}
 
     - name: Install Opengrep
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/src/installOpengrep.js
+++ b/src/installOpengrep.js
@@ -11,7 +11,7 @@ import os from 'os'
 import path from 'path'
 
 // Configuration
-const OPENGREP_VERSION = 'v1.11.2'
+const OPENGREP_VERSION = 'v1.11.5'
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/opengrep/opengrep/refs/tags/${OPENGREP_VERSION}/install.sh`
 const EXPECTED_SHA256 = 'a74388d0aec282eddf15fc8d42884de6531e1fc5a7bdc3ac31863c854e974eee'
 


### PR DESCRIPTION
Related to https://github.com/opengrep/opengrep/issues/792

1.11.5 is available on the first result page:

```console
$ curl -s https://api.github.com/repos/opengrep/opengrep/releases | jq
'.[] | select(.tag_name == "v1.11.5").tag_name'
"v1.11.5"
```

A minimal version bump was intentionally used to avoid opengrep output surprises.

Failed job example: https://github.com/brave/devops/actions/runs/32031359139/job/95391886570#step:3