### PR TITLE
fix(nudge): drop duplicate cc reply, one alert per reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "glob": "^12.0.0",
     "js-yaml": "^4.1.1",
     "json5": "^2.2.3",
-    "markdown-to-txt": "^2.0.1"
+    "markdown-to-txt": "^2.0.1",
+    "octokit": "^5.0.5"
   },
   "devDependencies": {
     "dotenv": "^17.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       markdown-to-txt:
         specifier: ^2.0.1
         version: 2.0.1
+      octokit:
+        specifier: ^5.0.5
+        version: 5.0.5
     devDependencies:
       dotenv:
         specifier: ^17.3.1
@@ -93,28 +96,133 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@octokit/app@16.1.4':
+    resolution: {integrity: sha512-g70WONQyGoBgqIJtv4O0MUEfOF1iJpTfFt3qAW7HaiwiJ6k607xg/gBezCa4tuq6BpO6qXn7qvq8v9tjWtgGQg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-app@8.3.0':
+    resolution: {integrity: sha512-/UaKmJCsOc5XBZwhnFiGNdLH/FkDF8lYtBn1QlKxtX7IpgaRB/XOXjixFtERAknyUZHxp3oDuoiG0En4VptJSg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.4':
+    resolution: {integrity: sha512-Pe3du5LrC6dlv10b0RbarBlJtIT1Urq8BFoQklK8WmBw8YKnGgrANn7cQmHiA1v8AVihgi7YutV8MncP57I4og==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.4':
+    resolution: {integrity: sha512-M/+34rmkxMvUnnTo/uqNeVRCXJoJ+5N34eNTbL1KMtIyJpedCTsu/iFL1cWdL+w5hQMlYt6xzXoyux2gn0OVnw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.3':
+    resolution: {integrity: sha512-t4OKUhrI5britmpRiSzPAz1TJPyUN/Hw1HEE3Hz/uElxcmnf/YCRSKtFRNc5gy4yJFTlXgk34H1lvxiotQJQvQ==}
+    engines: {node: '>= 20'}
+
   '@octokit/auth-token@5.1.2':
     resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
     engines: {node: '>= 18'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-unauthenticated@7.0.4':
+    resolution: {integrity: sha512-j4zgVdP8C8C53PNsj4LLI+WFtoykaQARwwrIBILTdxwZ2Ljaa9YUxb1yQ7/seGVnmWPdC3OBefX3LLbh28gKtw==}
+    engines: {node: '>= 20'}
 
   '@octokit/core@6.1.6':
     resolution: {integrity: sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==}
     engines: {node: '>= 18'}
 
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
   '@octokit/endpoint@10.1.4':
     resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
     engines: {node: '>= 18'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
 
   '@octokit/graphql@8.2.2':
     resolution: {integrity: sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==}
     engines: {node: '>= 18'}
 
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-app@8.0.4':
+    resolution: {integrity: sha512-Ji5JpRwAJcbOJkO4ij0tW6+GrQ8efpICnAca3o5xI8/HUNjqJu3hhG4cCZdXAHMKaOaQTFX0Yl+cpu61Rsx94A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.4':
+    resolution: {integrity: sha512-96RsnxS7Hk/BQhUA1Qo2pmcYP6LWQRWMdo7bVbNE7ZCkFLhSUYBXVUj9tVnvhl4jzbwHYt/dcIG+ioY427b2sg==}
+    engines: {node: '>= 20'}
+
   '@octokit/openapi-types@25.0.0':
     resolution: {integrity: sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/openapi-webhooks-types@12.1.0':
+    resolution: {integrity: sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==}
+
+  '@octokit/plugin-paginate-graphql@6.0.0':
+    resolution: {integrity: sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@15.0.0':
+    resolution: {integrity: sha512-lw9A9YL5s4VPj+VEx8uMxaxQm2YTgrPDkrLEuZuu18R8TK3oPcXF4K6t52nx6xn1RcogZC9i188sAr/4XYJaQQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.1':
+    resolution: {integrity: sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.5':
+    resolution: {integrity: sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
 
   '@octokit/request-error@6.1.8':
     resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
     engines: {node: '>= 18'}
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.14':
+    resolution: {integrity: sha512-bgWgiSfFS689/AxQDarU+b3Qu1FYewfVr5vI/jhV84s7GQ3C2OsdRxukGGYKB37MCgwcS50UrfBLlHzhiG13sw==}
+    engines: {node: '>= 20'}
 
   '@octokit/request@9.2.3':
     resolution: {integrity: sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==}
@@ -122,6 +230,20 @@ packages:
 
   '@octokit/types@14.0.0':
     resolution: {integrity: sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.2.0':
+    resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
+    engines: {node: '>= 20'}
 
   '@slack/logger@4.0.0':
     resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
@@ -137,6 +259,9 @@ packages:
 
   '@tryfabric/mack@1.2.1':
     resolution: {integrity: sha512-qQKj3l4x/7fWPHyk3zO3hPK2NUTH8AINJnVbdBYforWpm+6RDzp22gFIE66BJd2z7EFmt7F9aUOyZTKwmxiXrA==}
+
+  '@types/aws-lambda@8.10.162':
+    resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -239,6 +364,12 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
@@ -278,6 +409,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -837,6 +972,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -956,6 +1094,10 @@ packages:
   object.values@1.2.0:
     resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
     engines: {node: '>= 0.4'}
+
+  octokit@5.0.5:
+    resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
+    engines: {node: '>= 20'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1217,6 +1359,10 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  toad-cache@3.7.4:
+    resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
+    engines: {node: '>=20'}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -1253,6 +1399,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
 
   universal-user-agent@7.0.2:
     resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
@@ -1371,7 +1520,58 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@octokit/app@16.1.4':
+    dependencies:
+      '@octokit/auth-app': 8.3.0
+      '@octokit/auth-unauthenticated': 7.0.4
+      '@octokit/core': 7.0.7
+      '@octokit/oauth-app': 8.0.4
+      '@octokit/plugin-paginate-rest': 15.0.0(@octokit/core@7.0.7)
+      '@octokit/types': 17.0.0
+      '@octokit/webhooks': 14.2.0
+
+  '@octokit/auth-app@8.3.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.4
+      '@octokit/auth-oauth-user': 6.0.3
+      '@octokit/request': 10.0.14
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      toad-cache: 3.7.4
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.2
+
+  '@octokit/auth-oauth-app@9.0.4':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.4
+      '@octokit/auth-oauth-user': 6.0.3
+      '@octokit/request': 10.0.14
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.2
+
+  '@octokit/auth-oauth-device@8.0.4':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.4
+      '@octokit/request': 10.0.14
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.2
+
+  '@octokit/auth-oauth-user@6.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.4
+      '@octokit/oauth-methods': 6.0.4
+      '@octokit/request': 10.0.14
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.2
+
   '@octokit/auth-token@5.1.2': {}
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/auth-unauthenticated@7.0.4':
+    dependencies:
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
 
   '@octokit/core@6.1.6':
     dependencies:
@@ -1383,9 +1583,24 @@ snapshots:
       before-after-hook: 3.0.2
       universal-user-agent: 7.0.2
 
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.14
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.2
+
   '@octokit/endpoint@10.1.4':
     dependencies:
       '@octokit/types': 14.0.0
+      universal-user-agent: 7.0.2
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
       universal-user-agent: 7.0.2
 
   '@octokit/graphql@8.2.2':
@@ -1394,11 +1609,88 @@ snapshots:
       '@octokit/types': 14.0.0
       universal-user-agent: 7.0.2
 
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.14
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.2
+
+  '@octokit/oauth-app@8.0.4':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.4
+      '@octokit/auth-oauth-user': 6.0.3
+      '@octokit/auth-unauthenticated': 7.0.4
+      '@octokit/core': 7.0.7
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/oauth-methods': 6.0.4
+      '@types/aws-lambda': 8.10.162
+      universal-user-agent: 7.0.2
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.4':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.14
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+
   '@octokit/openapi-types@25.0.0': {}
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/openapi-webhooks-types@12.1.0': {}
+
+  '@octokit/plugin-paginate-graphql@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-paginate-rest@15.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 17.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.1.1(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.5(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
 
   '@octokit/request-error@6.1.8':
     dependencies:
       '@octokit/types': 14.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.14':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.1.0
+      json-with-bigint: 3.5.12
+      universal-user-agent: 7.0.2
 
   '@octokit/request@9.2.3':
     dependencies:
@@ -1411,6 +1703,22 @@ snapshots:
   '@octokit/types@14.0.0':
     dependencies:
       '@octokit/openapi-types': 25.0.0
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.2.0':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.1.0
+      '@octokit/request-error': 7.1.1
+      '@octokit/webhooks-methods': 6.0.0
 
   '@slack/logger@4.0.0':
     dependencies:
@@ -1441,6 +1749,8 @@ snapshots:
       '@slack/types': 2.11.0
       fast-xml-parser: 5.7.2
       marked: 4.3.0
+
+  '@types/aws-lambda@8.10.162': {}
 
   '@types/json5@0.0.29': {}
 
@@ -1570,6 +1880,10 @@ snapshots:
 
   before-after-hook@3.0.2: {}
 
+  before-after-hook@4.0.0: {}
+
+  bottleneck@2.19.5: {}
+
   brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
@@ -1614,6 +1928,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
+
+  content-type@2.1.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2288,6 +2604,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-with-bigint@3.5.12: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -2408,6 +2726,20 @@ snapshots:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  octokit@5.0.5:
+    dependencies:
+      '@octokit/app': 16.1.4
+      '@octokit/core': 7.0.7
+      '@octokit/oauth-app': 8.0.4
+      '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-retry': 8.1.1(@octokit/core@7.0.7)
+      '@octokit/plugin-throttling': 11.0.5(@octokit/core@7.0.7)
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 16.0.0
+      '@octokit/webhooks': 14.2.0
 
   once@1.4.0:
     dependencies:
@@ -2699,6 +3031,8 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  toad-cache@3.7.4: {}
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -2754,6 +3088,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.2: {}
 

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -90,9 +90,11 @@ export function buildCcLine (maintainers, defaultContact = []) {
   return `cc ${fallback} - *No maintainers listed for the given vulnerabilities, consider migrating and archiving this repository*`
 }
 
-// Parent blocks: markdown summary, plus a raw mrkdwn cc
-// section so Slack mention pills show in the channel
-// without going through markdown escaping.
+// Parent blocks: the cc is appended inline to the summary
+// line, as raw mrkdwn, so the Slack mention pills render in
+// the channel overview. It is appended after the markdown-
+// to-blocks conversion, which would otherwise escape the
+// <@U123> mentions into &lt;@U123&gt;.
 export async function buildParentBlocks ({
   repo, total, critical, cc = ''
 }) {
@@ -100,10 +102,10 @@ export async function buildParentBlocks ({
     buildParentText({ repo, total, critical })
   )
   if (cc) {
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: cc }
-    })
+    const section = blocks.find(b => b.type === 'section')
+    if (section) {
+      section.text.text += ` (${cc})`
+    }
   }
   return blocks
 }

--- a/src/dependabotNudge.test.js
+++ b/src/dependabotNudge.test.js
@@ -110,15 +110,28 @@ console.log('  buildCcLine: tags maintainers')
     critical: 1,
     cc: 'cc <@U1>'
   })
-  const body = JSON.stringify(blocks)
-  assert.ok(body.includes('open Dependabot issues'))
-  assert.ok(body.includes('(*1 critical*)'))
-  assert.ok(body.includes('cc <@U1>'))
+  const sections = blocks.filter(b => b.type === 'section')
+  assert.equal(
+    sections.length, 1,
+    'The cc must join the summary, not add a section'
+  )
   assert.ok(
-    !body.includes('pkg-'),
+    sections[0].text.text.includes('open Dependabot issues'),
+    'Summary stays on the line'
+  )
+  assert.ok(
+    sections[0].text.text.includes('(*1 critical*)'),
+    'Critical count stays on the line'
+  )
+  assert.ok(
+    sections[0].text.text.endsWith(' (cc <@U1>)'),
+    'cc is inline at the end of the summary line'
+  )
+  assert.ok(
+    !JSON.stringify(blocks).includes('pkg-'),
     'Parent blocks must not include finding details'
   )
 }
-console.log('  buildParentBlocks: summary plus cc, no findings')
+console.log('  buildParentBlocks: summary with inline cc, no findings')
 
 console.log('\n✅ All dependabotNudge builder tests passed!')

--- a/src/postNudgeThreads.js
+++ b/src/postNudgeThreads.js
@@ -3,24 +3,15 @@
 // orchestration is unit-testable without spinning GitHub
 // Actions.
 //
-// One thread per repo: the parent carries the counts, the
-// replies carry the findings, and the maintainers are tagged
-// in the very last reply. Slack has no way to post a reply
-// without notifying, and a mention added by editing a
-// message notifies nobody, so mentioning once at the end is
-// what keeps it to a single ping.
-//
-// The cc reply doubles as the completion marker for the
-// week: it is only posted once every other write of the
-// thread is known to have succeeded, so a partial failure
-// stays recoverable on the next run instead of being
-// permanently marked complete.
+// One thread per repo: the parent carries the counts and the
+// maintainer mentions inline, and each alert gets its own
+// reply. Posting the parent is the thread's single
+// notification: mentions in a posted message notify, mentions
+// added later by editing do not, and the replies never carry
+// mentions at all.
 
 import sendSlackMessage from './sendSlackMessage.js'
-import {
-  buildParentText,
-  buildParentBlocks
-} from './dependabotNudge.js'
+import { buildParentBlocks } from './dependabotNudge.js'
 import refreshNudgeThread, {
   findRepoParent,
   PARENT_EVENT_TYPE
@@ -28,12 +19,10 @@ import refreshNudgeThread, {
 import {
   chunkNudgeMessage,
   fetchMessages,
-  fetchThreadReplies,
-  nudgeThreadProgress,
   pace
 } from './slackUtils.js'
 
-// Post (or finish, or refresh) the weekly nudge threads.
+// Post (or refresh) the weekly nudge threads.
 //
 // @param {object} opts
 // @param {object} opts.web        - Slack WebClient
@@ -87,28 +76,11 @@ export default async function postNudgeThreads ({
         }
       }
 
-      let parentTs = parent?.ts
-      let skipChunks = false
-
-      // The cc reply is the completion marker. A parent
-      // with some replies may still be a partial failure
-      // (findings posted, cc never sent). Refresh rewrites
-      // those findings from the current alert list so we
-      // do not resume by chunk count after alerts change.
-      if (parentTs && parent.reply_count > 0) {
-        const thread = await fetchThreadReplies(
-          web, channelId, parentTs
-        )
-        const progress = nudgeThreadProgress(thread, parentTs)
-        if (progress.complete) {
-          if (debug) {
-            console.log(
-              'already posted this week, skipping ' +
-              `${repo} ${weekId} (thread ${parentTs})`
-            )
-          }
-          continue
-        }
+      // Existing thread: bring it in line with the current
+      // alerts. The refresh rewrites the findings, corrects
+      // the counts, and drops the legacy cc reply; editing
+      // never re-notifies, so refreshing every run is free.
+      if (parent) {
         const { ok } = await refreshNudgeThread({
           web,
           channelId,
@@ -118,89 +90,56 @@ export default async function postNudgeThreads ({
           debug
         })
         if (!ok) {
-          // Never mark a half-written thread complete: the
-          // next run refreshes and finishes it.
+          // Leave the thread as-is: the next run retries.
           console.error(
             `refresh failed for ${repo}; leaving thread ` +
-            `${parentTs} incomplete for retry`
+            `${parent.ts} for retry`
           )
-          continue
         }
-        skipChunks = true
-        if (alerts.length === 0) continue
-        await pace()
+        continue
       }
 
-      if (!parentTs) {
-        if (debug) { console.log(`creating thread for ${repo} ${weekId}`) }
+      if (debug) { console.log(`creating thread for ${repo} ${weekId}`) }
 
-        // The parent is the summary and nothing else: the
-        // findings go in the replies below it. Mentions are
-        // added later via chat.update so they show in the
-        // channel without a second notification.
-        const parentResult = await sendSlackMessage({
-          ...slack,
-          debug,
-          message: buildParentText({ repo, total, critical }),
-          eventType: PARENT_EVENT_TYPE,
-          eventPayload: { org, repo, weekId }
-        })
-        parentTs = parentResult?.ts
-        await pace()
-      } else {
-        if (debug) { console.log(`finishing thread ${parentTs} for ${repo} ${weekId}`) }
-      }
-
+      // The parent is posted with the mentions already in
+      // place: this post is the one notification the thread
+      // sends. The blocks are built directly rather than from
+      // markdown so the <@U123> mention pills survive
+      // unescaped.
+      const parentResult = await web.chat.postMessage({
+        channel: channelId,
+        username: 'dependabot',
+        text: 'dependabot alert',
+        link_names: true,
+        unfurl_links: true,
+        unfurl_media: true,
+        blocks: await buildParentBlocks({
+          repo, total, critical, cc
+        }),
+        metadata: {
+          event_type: PARENT_EVENT_TYPE,
+          event_payload: { org, repo, weekId }
+        }
+      })
+      const parentTs = parentResult?.ts
       if (!parentTs) {
         console.error(`failed to obtain thread ts for ${repo}; skipping replies`)
         continue
       }
+      await pace()
 
-      if (!skipChunks) {
-        for (const chunk of chunkNudgeMessage(message)) {
-          await sendSlackMessage({
-            ...slack,
-            debug,
-            message: chunk,
-            threadTs: parentTs,
-            eventPayload: { repo, kind: 'alerts' }
-          })
-          await pace()
-        }
-      }
-
-      // The parent is finalized before the cc reply: the
-      // mentions it adds notify nobody, and the thread must
-      // not be marked complete while this write can still
-      // fail.
-      try {
-        await web.chat.update({
-          channel: channelId,
-          ts: parentTs,
-          text: 'dependabot alert',
-          blocks: await buildParentBlocks({
-            repo, total, critical, cc
-          })
+      // One reply per alert; none of them mention anyone, so
+      // the thread stays at a single notification.
+      for (const chunk of chunkNudgeMessage(message)) {
+        await sendSlackMessage({
+          ...slack,
+          debug,
+          message: chunk,
+          threadTs: parentTs,
+          eventPayload: { repo, kind: 'alerts' }
         })
-      } catch (err) {
-        console.error(
-          `failed to add maintainers to parent for ${repo}: ${err.message}`
-        )
-        continue
+        await pace()
       }
-      await pace()
-
-      // Sent as `text` rather than `message`: the
-      // markdown-to-blocks conversion escapes `<@U123>`
-      // mentions, which silently drops the notification.
-      await sendSlackMessage({
-        ...slack,
-        debug,
-        text: cc,
-        threadTs: parentTs,
-        eventPayload: { repo, kind: 'cc' }
-      })
-      await pace()
     } catch (error) {
       console.error(`failed to nudge ${repo}: ${error.message}`)
       if (debug) { console.log(error) }

--- a/src/postNudgeThreads.test.js
+++ b/src/postNudgeThreads.test.js
@@ -111,8 +111,9 @@ function run (web, messages, opts = {}) {
 
 console.log('Testing postNudgeThreads...')
 
-// Test: a fresh repo gets a parent, findings replies, the
-// parent edit, and the cc completion marker last
+// Test: a fresh repo gets a parent carrying the cc inline
+// (the thread's only notification), then one reply per
+// alert, and never a cc reply or a parent edit
 {
   const { web, calls } = buildMockWeb()
   await run(web, [])
@@ -129,61 +130,43 @@ console.log('Testing postNudgeThreads...')
     parentPost.metadata.event_payload.weekId, '2026-W34',
     'The parent should be tagged with the week'
   )
+  const parentText = parentPost.blocks[0].text.text
+  assert.ok(
+    parentText.includes('open Dependabot issues'),
+    'The parent carries the summary'
+  )
+  assert.ok(
+    parentText.endsWith(`(${ccText})`),
+    'The parent carries the cc inline: its post is the single notification'
+  )
 
   const chunkPosts = calls.posted.filter(
     p => p.metadata?.event_payload?.kind === 'alerts'
   )
-  assert.equal(chunkPosts.length, 1, 'Should post the findings chunk')
   assert.equal(
-    chunkPosts[0].thread_ts, PARENT_TS,
-    'Findings belong in the thread'
+    chunkPosts.length, alerts.length,
+    'One reply per alert, not one aggregated message'
   )
-
-  const ccPost = calls.posted.find(
-    p => p.metadata?.event_payload?.kind === 'cc'
-  )
-  assert.ok(ccPost, 'Should post the cc reply')
-  assert.equal(ccPost.thread_ts, PARENT_TS, 'The cc is a thread reply')
-  assert.equal(ccPost.text, ccText, 'The cc is sent as raw text')
+  for (const post of chunkPosts) {
+    assert.equal(
+      post.thread_ts, PARENT_TS,
+      'Findings belong in the thread'
+    )
+  }
 
   assert.ok(
-    calls.updated.some(u => u.ts === PARENT_TS),
-    'Should edit the parent with the maintainer line'
-  )
-  assert.ok(
-    calls.sequence.indexOf(`update:${PARENT_TS}`) <
-      calls.sequence.indexOf('post:cc'),
-    'The parent must be finalized before the cc marker'
+    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'No duplicate cc reply: the parent already shows it'
   )
   assert.equal(
-    calls.sequence[calls.sequence.length - 1], 'post:cc',
-    'The cc completion marker is the last write'
+    calls.updated.length, 0,
+    'The parent is complete at post time, no edit needed'
   )
 }
-console.log('  postNudgeThreads: posts parent, chunks, parent edit, cc last')
+console.log('  postNudgeThreads: parent with inline cc, one reply per alert')
 
-// Test: a thread whose cc marker already exists is skipped
-{
-  const parent = { ...parentMessage(), reply_count: 1 }
-  const { web, calls } = buildMockWeb({
-    channelMessages: [parent],
-    thread: [
-      parent,
-      {
-        ts: '201.1',
-        text: ccText,
-        metadata: { event_payload: { repo: 'brave/foo', kind: 'cc' } }
-      }
-    ]
-  })
-  await run(web, [parent])
-  assert.equal(calls.posted.length, 0, 'Should not re-post a complete thread')
-  assert.equal(calls.updated.length, 0, 'Should not edit a complete thread')
-}
-console.log('  postNudgeThreads: skips threads completed this week')
-
-// Test: an incomplete thread is refreshed, chunks are not
-// re-posted, and the cc lands after the refresh
+// Test: an existing thread is refreshed in place, never
+// re-posted or re-pinged
 {
   const parent = { ...parentMessage(), reply_count: 1 }
   const { web, calls } = buildMockWeb({
@@ -197,24 +180,19 @@ console.log('  postNudgeThreads: skips threads completed this week')
     ]
   })
   await run(web, [parent])
-
-  assert.ok(
-    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'alerts'),
-    'A refreshed thread must not re-post findings chunks'
-  )
-  const ccPost = calls.posted.find(
-    p => p.metadata?.event_payload?.kind === 'cc'
-  )
-  assert.ok(ccPost, 'Should complete the refreshed thread with the cc')
   assert.equal(
-    calls.sequence[calls.sequence.length - 1], 'post:cc',
-    'The cc is still the last write'
+    calls.posted.filter(p => p.metadata?.event_type === PARENT_EVENT_TYPE).length, 0,
+    'Should not post a second parent'
+  )
+  assert.ok(
+    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'No cc reply is ever posted'
   )
 }
-console.log('  postNudgeThreads: completes a refreshed thread')
+console.log('  postNudgeThreads: refreshes an existing thread in place')
 
 // Test: when the refresh reports a failure the thread is
-// left incomplete so the next run retries it
+// left as-is so the next run retries it
 {
   const parent = { ...parentMessage(), reply_count: 1 }
   const { web, calls } = buildMockWeb({
@@ -229,29 +207,12 @@ console.log('  postNudgeThreads: completes a refreshed thread')
     updateFail: ['201.1']
   })
   await run(web, [parent])
-
-  assert.ok(
-    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
-    'A failed refresh must not be marked complete'
+  assert.equal(
+    calls.posted.filter(p => p.metadata?.event_type === PARENT_EVENT_TYPE).length, 0,
+    'A failed refresh must not fall back to posting a new thread'
   )
 }
-console.log('  postNudgeThreads: no cc after a failed refresh')
-
-// Test: a failed parent edit keeps the cc marker away too
-{
-  const { web, calls } = buildMockWeb({ updateFail: [PARENT_TS] })
-  await run(web, [])
-
-  assert.ok(
-    calls.posted.some(p => p.metadata?.event_payload?.kind === 'alerts'),
-    'Findings are posted before the parent edit'
-  )
-  assert.ok(
-    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
-    'A failed parent edit must not be marked complete'
-  )
-}
-console.log('  postNudgeThreads: no cc after a failed parent edit')
+console.log('  postNudgeThreads: leaves a failed refresh for the next run')
 
 // Test: a parent from an earlier week does not satisfy the
 // current week's nudge
@@ -267,8 +228,7 @@ console.log('  postNudgeThreads: no cc after a failed parent edit')
       oldParent,
       {
         ts: '101.1',
-        text: ccText,
-        metadata: { event_payload: { repo: 'brave/foo', kind: 'cc' } }
+        metadata: { event_payload: { repo: 'brave/foo', kind: 'alerts' } }
       }
     ]
   })
@@ -297,7 +257,7 @@ console.log('  postNudgeThreads: posts a new thread for a new week')
   const chunkPosts = calls.posted.filter(
     p => p.metadata?.event_payload?.kind === 'alerts'
   )
-  assert.ok(chunkPosts.length > 0, 'Should still post the findings')
+  assert.ok(chunkPosts.length > 0, 'Should still fill in the findings')
   assert.equal(
     chunkPosts[0].thread_ts, PARENT_TS,
     'Findings belong to the adopted thread'

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -29,6 +29,20 @@ import {
 export const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
 export const ALERTS_EVENT_TYPE = 'dependabot-nudge-alerts'
 
+// Extract the cc line from a thread parent: appended
+// inline to the summary ('... (cc <@U1>)') since the
+// summary-line change, or in its own 'cc ...' section on
+// threads written before it.
+function parentCcLine (blocks) {
+  for (const block of blocks || []) {
+    if (block.text?.type !== 'mrkdwn') continue
+    if (block.text.text.startsWith('cc ')) return block.text.text
+    const inline = block.text.text.match(/\((cc [^)]+)\)\s*$/)
+    if (inline) return inline[1]
+  }
+  return ''
+}
+
 // Compare rendered content, ignoring the block_id values
 // Slack assigns on post, so unchanged threads are left
 // alone instead of being rewritten on every run.
@@ -182,14 +196,10 @@ export default async function refreshNudgeThread ({
     m.ts !== parent.ts &&
     m.metadata?.event_payload?.kind === 'cc'
   )
-  // The parent keeps its cc section until the cc reply
-  // lands: reuse it when the reply is missing so the retry
-  // does not strip the mentions from the summary.
-  const parentCc = parent.blocks?.find(block =>
-    block.text?.type === 'mrkdwn' &&
-    block.text.text.startsWith('cc ')
-  )?.text.text || ''
-  const cc = ccReply?.text || parentCc
+  // The parent keeps its cc until the cc reply lands: reuse
+  // it when the reply is missing so the retry does not strip
+  // the mentions from the summary.
+  const cc = ccReply?.text || parentCcLine(parent.blocks)
 
   if (debug) {
     console.log(

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -184,10 +184,11 @@ export default async function refreshNudgeThread ({
     })
   }
 
-  // Only the detail replies are rewritten. The cc reply is
-  // left alone: it carries the mentions and its content
-  // does not depend on which alerts are still open. Human
-  // replies in the thread are ignored the same way.
+  // Only the detail replies are rewritten. A legacy cc reply
+  // is handled after the parent update below: it carries the
+  // mentions, so it must survive until the parent shows
+  // them. Human replies in the thread are ignored the same
+  // way.
   const details = thread.filter(m =>
     m.ts !== parent.ts &&
     m.metadata?.event_payload?.kind === 'alerts'
@@ -292,30 +293,47 @@ export default async function refreshNudgeThread ({
   // Correct the count on the thread parent and keep the
   // maintainers visible in the channel overview. Editing
   // does not re-notify.
+  let parentOk = true
   try {
     const parentBlocks = await buildParentBlocks({
       repo: repoFullName, total, critical, cc
     })
-    if (
-      blocksSignature(parentBlocks) ===
-      blocksSignature(parent.blocks)
-    ) {
-      return { touched, ok }
+    if (blocksSignature(parentBlocks) !== blocksSignature(parent.blocks)) {
+      await web.chat.update({
+        channel: channelId,
+        ts: parent.ts,
+        text: 'dependabot alert',
+        blocks: parentBlocks
+      })
+      touched++
     }
-
-    await web.chat.update({
-      channel: channelId,
-      ts: parent.ts,
-      text: 'dependabot alert',
-      blocks: parentBlocks
-    })
-    touched++
   } catch (err) {
+    parentOk = false
     ok = false
     console.error(
       `refresh: failed to update parent ts=${parent.ts}: ` +
       err.message
     )
+  }
+
+  // Threads posted before the parent carried the cc inline
+  // end with a 'cc' reply. It duplicates the parent's
+  // mentions now, so drop it once the parent is known to
+  // show them; keep it when the parent write failed so the
+  // mentions are never lost.
+  if (ccReply && cc && parentOk) {
+    try {
+      await web.chat.delete({
+        channel: channelId, ts: ccReply.ts
+      })
+      touched++
+    } catch (err) {
+      ok = false
+      console.error(
+        `refresh: failed to delete cc reply ts=${ccReply.ts}: ` +
+        err.message
+      )
+    }
   }
 
   return { touched, ok }

--- a/src/refreshNudgeThread.test.js
+++ b/src/refreshNudgeThread.test.js
@@ -44,7 +44,8 @@ const parentMsg = {
   }
 }
 
-// Parent, two detail replies, and the cc reply last.
+// Parent, two detail replies, and the cc reply last: the
+// shape threads had before the parent carried the cc inline.
 function threadReplies () {
   return [
     parentMsg,
@@ -157,10 +158,12 @@ console.log('  findRepoParent: filters by weekId when given')
 
 console.log('\nTesting refreshNudgeThread...')
 
-// Test: resolved alerts disappear and the count is corrected
+// Test: resolved alerts disappear, new ones are appended,
+// and the count is corrected
 {
   const { web, calls } = buildMockWeb()
-  // 12 alerts became 3, so 2 detail replies become 1.
+  // Two multi-alert replies become one reply per alert, and
+  // the legacy cc reply is dropped once the parent shows it.
   await refreshNudgeThread({
     web,
     channelId: 'C001',
@@ -185,19 +188,26 @@ console.log('\nTesting refreshNudgeThread...')
     'Should copy maintainers onto the parent for channel overview'
   )
 
-  const detailUpdate = calls.updated.find(u => u.ts === '101.0')
-  assert.ok(detailUpdate, 'Should rewrite the first detail reply')
-  const body = JSON.stringify(detailUpdate.blocks)
-  assert.ok(body.includes('pkg-1'), 'Should keep remaining alerts')
-  assert.ok(!body.includes('pkg-9'), 'Should not mention resolved alerts')
-
-  assert.deepEqual(
-    calls.deleted, ['102.0'],
-    'Should delete the detail reply that is no longer needed'
+  const firstUpdate = calls.updated.find(u => u.ts === '101.0')
+  assert.ok(firstUpdate, 'Should rewrite the first detail reply')
+  const firstBody = JSON.stringify(firstUpdate.blocks)
+  assert.ok(firstBody.includes('pkg-1'), 'Should carry the first alert alone')
+  assert.ok(!firstBody.includes('pkg-2'), 'Only one alert per reply')
+  assert.ok(
+    !firstBody.includes('pkg-9'),
+    'Should not mention resolved alerts'
   )
   assert.ok(
-    !calls.deleted.includes('103.0'),
-    'Should never delete the cc reply while alerts remain'
+    calls.updated.some(u => u.ts === '102.0'),
+    'Should rewrite the second detail reply too'
+  )
+  assert.equal(
+    calls.posted.length, 1,
+    'The third alert needs a new reply'
+  )
+  assert.deepEqual(
+    calls.deleted, ['103.0'],
+    'Should drop the legacy cc reply once the parent shows it'
   )
   assert.ok(
     !calls.updated.some(u => u.ts === '103.0'),
@@ -281,6 +291,10 @@ console.log('  refreshNudgeThread: omits criticals when none are left')
     calls.posted[0].metadata.event_payload.kind, 'alerts',
     'Appended replies must be tagged as findings, not a parent'
   )
+  assert.ok(
+    calls.deleted.includes('103.0'),
+    'The legacy cc reply is dropped once the parent shows the mentions'
+  )
 }
 console.log('  refreshNudgeThread: appends when alerts grew')
 
@@ -353,11 +367,11 @@ console.log('  refreshNudgeThread: debug mode is read-only')
     alerts
   })).touched
 
-  assert.equal(touched, 0, 'Should not touch an up-to-date thread')
+  assert.equal(touched, 1, 'Only the redundant cc reply is touched')
   assert.equal(calls.updated.length, 0, 'Should issue no updates')
-  assert.equal(calls.deleted.length, 0, 'Should issue no deletes')
+  assert.deepEqual(calls.deleted, ['103.0'], 'Should drop the legacy cc reply')
 }
-console.log('  refreshNudgeThread: skips an up-to-date thread')
+console.log('  refreshNudgeThread: skips an up-to-date thread, dedupes the cc')
 
 // Test: a missing cc reply must not strip the existing parent
 // mentions before postNudgeThreads retries the reply.
@@ -422,6 +436,64 @@ console.log('  refreshNudgeThread: preserves parent cc pending reply retry')
   )
 }
 console.log('  refreshNudgeThread: preserves legacy parent cc')
+
+// Test: when the parent update fails, the legacy cc reply
+// must survive: it is the only place the mentions notify
+// from until the parent write succeeds.
+{
+  const { web, calls } = buildMockWeb()
+  web.chat.update = async (p) => {
+    if (p.ts === '100.0') throw new Error('rate_limited')
+    calls.updated.push(p)
+    return { ok: true }
+  }
+  await refreshNudgeThread({
+    web,
+    channelId: 'C001',
+    messages: [parentMsg],
+    repoFullName: 'brave/foo',
+    alerts: [makeAlert(1)]
+  })
+  assert.ok(
+    !calls.deleted.includes('103.0'),
+    'The cc reply must stay while the parent update fails'
+  )
+}
+console.log('  refreshNudgeThread: keeps the cc reply when the parent write fails')
+
+// Test: a thread already in the current format (inline cc
+// parent, one reply per alert, no cc reply) is left alone
+{
+  const alerts = [makeAlert(1), makeAlert(2)]
+  const { message, total, critical } = buildRepoMessage({ alerts })
+  const chunks = chunkNudgeMessage(message)
+  const freshParent = {
+    ...parentMsg,
+    blocks: await buildParentBlocks({
+      repo: 'brave/foo', total, critical, cc: ccText
+    })
+  }
+  const { web, calls } = buildMockWeb([
+    freshParent,
+    ...await Promise.all(chunks.map(async (c, i) => ({
+      ts: `10${i + 1}.0`,
+      blocks: await messageToBlocks(c),
+      metadata: { event_payload: { repo: 'brave/foo', kind: 'alerts' } }
+    })))
+  ])
+  const { touched, ok } = await refreshNudgeThread({
+    web,
+    channelId: 'C001',
+    messages: [freshParent],
+    repoFullName: 'brave/foo',
+    alerts
+  })
+  assert.equal(ok, true)
+  assert.equal(touched, 0, 'A current-format thread is untouched')
+  assert.equal(calls.updated.length, 0)
+  assert.equal(calls.deleted.length, 0)
+}
+console.log('  refreshNudgeThread: leaves a current-format thread alone')
 
 // Test: zero remaining alerts deletes the thread, replies
 // first so Slack does not leave placeholders

--- a/src/refreshNudgeThread.test.js
+++ b/src/refreshNudgeThread.test.js
@@ -390,6 +390,39 @@ console.log('  refreshNudgeThread: skips an up-to-date thread')
 }
 console.log('  refreshNudgeThread: preserves parent cc pending reply retry')
 
+// Test: threads written before the inline-cc format carry the
+// mentions in a standalone section block; refresh must still
+// extract and preserve them.
+{
+  const legacyParent = {
+    ...parentMsg,
+    blocks: [
+      { type: 'section', text: { type: 'mrkdwn', text: '[brave/foo](https://github.com/brave/foo) has `2` open Dependabot issues' } },
+      { type: 'section', text: { type: 'mrkdwn', text: ccText } }
+    ]
+  }
+  const { web, calls } = buildMockWeb([
+    legacyParent,
+    {
+      ts: '101.0',
+      metadata: { event_payload: { repo: 'brave/foo', kind: 'alerts' } }
+    }
+  ])
+  await refreshNudgeThread({
+    web,
+    channelId: 'C001',
+    messages: [legacyParent],
+    repoFullName: 'brave/foo',
+    alerts: [makeAlert(1)]
+  })
+  const parentUpdate = calls.updated.find(u => u.ts === legacyParent.ts)
+  assert.ok(
+    parentSummary(parentUpdate).includes(ccText),
+    'Should preserve legacy-format parent mentions'
+  )
+}
+console.log('  refreshNudgeThread: preserves legacy parent cc')
+
 // Test: zero remaining alerts deletes the thread, replies
 // first so Slack does not leave placeholders
 {

--- a/src/slackUtils.js
+++ b/src/slackUtils.js
@@ -108,13 +108,14 @@ export async function fetchThreadReplies (web, channelId, ts) {
   return messages
 }
 
-// Split a repo nudge findings message into thread-sized
-// chunks on the '\n\n---\n\n' alert separator. Slack caps a
-// message at 50 blocks and each alert renders as ~4 blocks,
-// so chunking keeps long repos from being truncated. The
-// parent summary and cc line are posted separately.
+// Split a repo nudge findings message into one chunk per
+// alert on the '\n\n---\n\n' separator, so each finding
+// lands as its own thread reply instead of one super-long
+// message. Slack caps a message at 50 blocks and each alert
+// renders as ~4 blocks, so one alert per reply also keeps
+// long repos from being truncated.
 export function chunkNudgeMessage (
-  message, maxAlertsPerMessage = 10
+  message, maxAlertsPerMessage = 1
 ) {
   const separator = '\n\n---\n\n'
   const parts = message
@@ -147,21 +148,6 @@ export function isBotOwned (message, botId = null) {
   }
 
   return Boolean(tagged)
-}
-
-// Whether a weekly nudge thread finished posting. The cc
-// reply is the completion marker: findings chunks can land
-// before it, so reply_count alone is not enough.
-export function nudgeThreadProgress (thread, parentTs) {
-  const replies = (thread || []).filter(m => m.ts !== parentTs)
-  return {
-    complete: replies.some(
-      m => m.metadata?.event_payload?.kind === 'cc'
-    ),
-    postedAlerts: replies.filter(
-      m => m.metadata?.event_payload?.kind === 'alerts'
-    ).length
-  }
 }
 
 // Collect the timestamps to delete for a message: its own,

--- a/src/slackUtils.test.js
+++ b/src/slackUtils.test.js
@@ -2,7 +2,7 @@
  * Tests for slackUtils module
  */
 import { strict as assert } from 'assert'
-import { findChannelId, fetchMessages, fetchThreadReplies, deleteMessages, chunkNudgeMessage, isBotOwned, nudgeThreadProgress, createSlackClient, prepareSlackContext, pace } from './slackUtils.js'
+import { findChannelId, fetchMessages, fetchThreadReplies, deleteMessages, chunkNudgeMessage, isBotOwned, createSlackClient, prepareSlackContext, pace } from './slackUtils.js'
 
 // Keep the suite fast: cap every rate-limit delay.
 const realSetTimeout = globalThis.setTimeout
@@ -289,32 +289,6 @@ assert.equal(
 )
 console.log('  isBotOwned: compares against the owning bot identity')
 
-// ---- nudgeThreadProgress ----
-
-console.log('\nTesting nudgeThreadProgress...')
-
-{
-  const progress = nudgeThreadProgress([
-    { ts: '1' },
-    { ts: '1.1', metadata: { event_payload: { kind: 'alerts' } } },
-    { ts: '1.2', metadata: { event_payload: { kind: 'alerts' } } }
-  ], '1')
-  assert.equal(progress.complete, false, 'Missing cc means incomplete')
-  assert.equal(progress.postedAlerts, 2, 'Should count findings replies')
-}
-console.log('  nudgeThreadProgress: incomplete without cc')
-
-{
-  const progress = nudgeThreadProgress([
-    { ts: '1' },
-    { ts: '1.1', metadata: { event_payload: { kind: 'alerts' } } },
-    { ts: '1.2', metadata: { event_payload: { kind: 'cc' } } }
-  ], '1')
-  assert.equal(progress.complete, true, 'cc reply is the completion marker')
-  assert.equal(progress.postedAlerts, 1)
-}
-console.log('  nudgeThreadProgress: complete once cc is present')
-
 // ---- deleteMessages ----
 
 console.log('\nTesting deleteMessages...')
@@ -529,14 +503,18 @@ function buildNudgeMessage (alertCount) {
   return parts.join('\n\n---\n\n') + '\n\n---\n\n'
 }
 
-// Test: short message stays in a single chunk
+// Test: the default is one alert per chunk so each finding
+// lands as its own thread reply
 {
   const chunks = chunkNudgeMessage(buildNudgeMessage(3))
-  assert.equal(chunks.length, 1, 'Should not split a short message')
+  assert.equal(
+    chunks.length, 4,
+    'Header and three alerts are four chunks'
+  )
   assert.ok(chunks[0].includes('org/repo has alerts'), 'Should keep the header')
-  assert.ok(chunks[0].includes('alert 3'), 'Should keep the last alert')
+  assert.equal(chunks[1], 'alert 1', 'Each alert is its own chunk')
 }
-console.log('  chunkNudgeMessage: short message is one chunk')
+console.log('  chunkNudgeMessage: one alert per chunk by default')
 
 // Test: long message splits and keeps every alert
 {


### PR DESCRIPTION
## Problem

Weekly dependabot nudge threads had two issues:

1. The cc line was duplicated: mentions appeared inline on the parent summary **and** again as the last thread reply.
2. All alerts were packed into one super-long reply (up to 10 alerts per message) instead of one message per alert.

## Changes

- **Parent carries the cc at post time.** The parent is posted with the maintainer mentions already inline — that post is the thread's single notification (mentions added later via `chat.update` never notify). No more cc reply, no more parent edit after posting.
- **One alert per reply.** `chunkNudgeMessage` now defaults to one alert per message, so each finding (with its "Handle this alert at …" link) is its own thread reply.
- **Existing threads migrate on refresh.** `refreshNudgeThread` rewrites multi-alert replies into per-alert replies, and drops the legacy cc reply once the parent is known to show the mentions. If the parent write fails, the cc reply is kept so the mentions are never lost.
- **Simpler completion model.** The cc-reply-as-completion-marker is gone (`nudgeThreadProgress` removed); an existing thread is simply refreshed idempotently every run.

## Other commits in this PR

- `build(deps)`: add `octokit` — `src/dependabotNudge.js` imports it but only `@octokit/core` was declared, breaking local `run.js` runs.
- `feat(nudge)`: inline cc on the nudge parent summary line (prerequisite for this fix).

## Test plan

- [x] `node --test 'src/**/*.test.js'` — 22/22 pass
- [x] `standard --fix` clean
- [x] Live-verified the inline-cc parent format in #secops-hotspots (18 threads migrated via `chat.update`, no notifications sent)