### PR TITLE
refactor(nudge): extract shared thread helpers

### DIFF
--- a/actions/dependabot-nudge/action.cjs
+++ b/actions/dependabot-nudge/action.cjs
@@ -37,8 +37,6 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
   await postNudgeThreads({
     web,
     channelId,
-    channel,
-    token: inputs.slack_token,
     org: context.repo.owner,
     messages,
     nudges,

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -110,6 +110,21 @@ export async function buildParentBlocks ({
   return blocks
 }
 
+// Extract the cc line from a thread parent's blocks: appended
+// inline to the summary ('... (cc <@U1>)') by buildParentBlocks
+// above, or in its own 'cc ...' section on threads written
+// before the inline change. Lives next to the producer so the
+// format has a single owner.
+export function parentCcLine (blocks) {
+  for (const block of blocks || []) {
+    if (block.text?.type !== 'mrkdwn') continue
+    if (block.text.text.startsWith('cc ')) return block.text.text
+    const inline = block.text.text.match(/\((cc [^)]+)\)\s*$/)
+    if (inline) return inline[1]
+  }
+  return ''
+}
+
 export default async function dependabotNudge ({
   org,
   githubToken = null,

--- a/src/dependabotNudge.test.js
+++ b/src/dependabotNudge.test.js
@@ -6,7 +6,8 @@ import {
   buildRepoMessage,
   buildParentText,
   buildCcLine,
-  buildParentBlocks
+  buildParentBlocks,
+  parentCcLine
 } from './dependabotNudge.js'
 
 function makeAlert (n, severity = 'high') {
@@ -133,5 +134,46 @@ console.log('  buildCcLine: tags maintainers')
   )
 }
 console.log('  buildParentBlocks: summary with inline cc, no findings')
+
+{
+  const blocks = await buildParentBlocks({
+    repo: 'brave/foo',
+    total: 3,
+    critical: 1,
+    cc: 'cc <@U1> <@U2>'
+  })
+  assert.equal(
+    parentCcLine(blocks), 'cc <@U1> <@U2>',
+    'parentCcLine must read back exactly what buildParentBlocks writes'
+  )
+}
+console.log('  parentCcLine: round-trips the inline cc')
+
+{
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '[brave/foo](https://github.com/brave/foo) has `2` open Dependabot issues'
+      }
+    },
+    { type: 'section', text: { type: 'mrkdwn', text: 'cc <@U1>' } }
+  ]
+  assert.equal(
+    parentCcLine(blocks), 'cc <@U1>',
+    'Should read the standalone cc section of pre-inline threads'
+  )
+}
+console.log('  parentCcLine: reads the legacy cc section')
+
+assert.equal(
+  parentCcLine([{
+    type: 'section',
+    text: { type: 'mrkdwn', text: 'no cc anywhere' }
+  }]), '',
+  'Should return empty when the parent carries no cc'
+)
+console.log('  parentCcLine: empty when no cc')
 
 console.log('\n✅ All dependabotNudge builder tests passed!')

--- a/src/nudgeThread.js
+++ b/src/nudgeThread.js
@@ -1,0 +1,45 @@
+// Shared identity and write helpers for the weekly Dependabot
+// nudge threads. Both the posting path (postNudgeThreads.js)
+// and the refresh path (refreshNudgeThread.js) build threads
+// through these, so the metadata contract and the reply shape
+// have a single owner.
+
+import { messageToBlocks } from './sendSlackMessage.js'
+
+export const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
+export const ALERTS_EVENT_TYPE = 'dependabot-nudge-alerts'
+
+// Find the newest nudge parent for a repo among messages
+// already fetched from the channel. When weekId is given,
+// only that week's parent matches.
+export function findRepoParent (messages, repoFullName, weekId = null) {
+  return messages
+    .filter(m =>
+      m.metadata?.event_type === PARENT_EVENT_TYPE &&
+      m.metadata?.event_payload?.repo === repoFullName &&
+      (weekId === null ||
+        m.metadata?.event_payload?.weekId === weekId))
+    .sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts))[0]
+}
+
+// Post one findings chunk as a thread reply. Used by both the
+// posting path and the refresh path so an appended reply is
+// shaped exactly like one from the original run.
+export async function postAlertReply (
+  web, channelId, parentTs, chunk, repoFullName
+) {
+  return web.chat.postMessage({
+    channel: channelId,
+    thread_ts: parentTs,
+    username: 'dependabot',
+    text: 'dependabot alert',
+    link_names: true,
+    unfurl_links: true,
+    unfurl_media: true,
+    blocks: await messageToBlocks(chunk),
+    metadata: {
+      event_type: ALERTS_EVENT_TYPE,
+      event_payload: { repo: repoFullName, kind: 'alerts' }
+    }
+  })
+}

--- a/src/nudgeThread.test.js
+++ b/src/nudgeThread.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for the shared nudge thread helpers
+ */
+import { strict as assert } from 'assert'
+import {
+  findRepoParent,
+  postAlertReply,
+  PARENT_EVENT_TYPE,
+  ALERTS_EVENT_TYPE
+} from './nudgeThread.js'
+
+const parentMsg = {
+  ts: '100.0',
+  metadata: {
+    event_type: PARENT_EVENT_TYPE,
+    event_payload: { org: 'brave', repo: 'brave/foo', weekId: '2026-W34' }
+  }
+}
+
+// ---- findRepoParent ----
+
+console.log('Testing findRepoParent...')
+
+{
+  const messages = [
+    parentMsg,
+    {
+      ts: '200.0',
+      metadata: {
+        event_type: PARENT_EVENT_TYPE,
+        event_payload: { repo: 'brave/bar' }
+      }
+    }
+  ]
+  assert.equal(
+    findRepoParent(messages, 'brave/foo')?.ts, '100.0',
+    'Should find the parent for the requested repo'
+  )
+  assert.equal(
+    findRepoParent(messages, 'brave/nope'), undefined,
+    'Should return undefined when the repo has no thread'
+  )
+}
+console.log('  findRepoParent: matches on repo metadata')
+
+{
+  const messages = [
+    parentMsg,
+    {
+      ts: '300.0',
+      metadata: {
+        event_type: PARENT_EVENT_TYPE,
+        event_payload: { repo: 'brave/foo' }
+      }
+    }
+  ]
+  assert.equal(
+    findRepoParent(messages, 'brave/foo').ts, '300.0',
+    'Should prefer the newest parent'
+  )
+}
+console.log('  findRepoParent: prefers the newest thread')
+
+{
+  const messages = [
+    parentMsg,
+    {
+      ts: '50.0',
+      metadata: {
+        event_type: PARENT_EVENT_TYPE,
+        event_payload: { repo: 'brave/foo', weekId: '2026-W33' }
+      }
+    }
+  ]
+  assert.equal(
+    findRepoParent(messages, 'brave/foo', '2026-W33')?.ts, '50.0',
+    'Should match the requested week'
+  )
+  assert.equal(
+    findRepoParent(messages, 'brave/foo', '2026-W99'), undefined,
+    'Should not match another week'
+  )
+  assert.equal(
+    findRepoParent(messages, 'brave/foo')?.ts, '100.0',
+    'Without a weekId the newest parent still matches'
+  )
+}
+console.log('  findRepoParent: filters by weekId when given')
+
+// ---- postAlertReply ----
+
+console.log('\nTesting postAlertReply...')
+
+{
+  const calls = []
+  const web = {
+    chat: {
+      postMessage: async (p) => {
+        calls.push(p)
+        return { ok: true, ts: '101.0' }
+      }
+    }
+  }
+  const chunk = '`pkg-1` by `CVE-2026-0001` with a `high` severity *Vulnerability 1*'
+
+  const result = await postAlertReply(
+    web, 'C001', '100.0', chunk, 'brave/foo'
+  )
+
+  assert.equal(result.ts, '101.0', 'Should return the posted reply')
+  assert.equal(calls.length, 1, 'Should post exactly one reply')
+  assert.equal(calls[0].channel, 'C001', 'Should target the channel')
+  assert.equal(
+    calls[0].thread_ts, '100.0',
+    'The reply belongs to the parent thread'
+  )
+  assert.equal(
+    calls[0].username, 'dependabot',
+    'The reply is posted as the dependabot user'
+  )
+  assert.equal(
+    calls[0].metadata.event_type, ALERTS_EVENT_TYPE,
+    'The reply is tagged with the alerts event type'
+  )
+  assert.equal(
+    calls[0].metadata.event_payload.kind, 'alerts',
+    'The reply payload is tagged as findings'
+  )
+  assert.equal(
+    calls[0].metadata.event_payload.repo, 'brave/foo',
+    'The reply payload carries the repo'
+  )
+  assert.ok(
+    JSON.stringify(calls[0].blocks).includes('pkg-1'),
+    'The chunk is rendered as blocks'
+  )
+}
+console.log('  postAlertReply: posts one chunk as an alerts-tagged thread reply')
+
+console.log('\n✅ All nudgeThread tests passed!')

--- a/src/postNudgeThreads.js
+++ b/src/postNudgeThreads.js
@@ -10,12 +10,13 @@
 // added later by editing do not, and the replies never carry
 // mentions at all.
 
-import sendSlackMessage from './sendSlackMessage.js'
 import { buildParentBlocks } from './dependabotNudge.js'
-import refreshNudgeThread, {
+import refreshNudgeThread from './refreshNudgeThread.js'
+import {
   findRepoParent,
+  postAlertReply,
   PARENT_EVENT_TYPE
-} from './refreshNudgeThread.js'
+} from './nudgeThread.js'
 import {
   chunkNudgeMessage,
   fetchMessages,
@@ -27,8 +28,6 @@ import {
 // @param {object} opts
 // @param {object} opts.web        - Slack WebClient
 // @param {string} opts.channelId  - Slack channel ID
-// @param {string} opts.channel    - Channel name, for posts
-// @param {string} opts.token      - Slack bot token
 // @param {string} opts.org        - GitHub org name
 // @param {object[]} opts.messages - Channel history
 // @param {object[]} opts.nudges   - dependabotNudge() output
@@ -39,8 +38,6 @@ import {
 export default async function postNudgeThreads ({
   web,
   channelId,
-  channel,
-  token,
   org,
   messages = [],
   nudges = [],
@@ -48,14 +45,6 @@ export default async function postNudgeThreads ({
   lookbackDays = 7,
   debug = false
 }) {
-  const slack = {
-    channel,
-    channelId,
-    token,
-    username: 'dependabot',
-    _web: web
-  }
-
   for (const { repo, message, cc, total, critical, alerts } of nudges) {
     try {
       let parent = findRepoParent(messages, repo, weekId)
@@ -131,13 +120,7 @@ export default async function postNudgeThreads ({
       // One reply per alert; none of them mention anyone, so
       // the thread stays at a single notification.
       for (const chunk of chunkNudgeMessage(message)) {
-        await sendSlackMessage({
-          ...slack,
-          debug,
-          message: chunk,
-          threadTs: parentTs,
-          eventPayload: { repo, kind: 'alerts' }
-        })
+        await postAlertReply(web, channelId, parentTs, chunk, repo)
         await pace()
       }
     } catch (error) {

--- a/src/postNudgeThreads.test.js
+++ b/src/postNudgeThreads.test.js
@@ -3,7 +3,7 @@
  */
 import { strict as assert } from 'assert'
 import postNudgeThreads from './postNudgeThreads.js'
-import { PARENT_EVENT_TYPE } from './refreshNudgeThread.js'
+import { PARENT_EVENT_TYPE } from './nudgeThread.js'
 import { buildRepoMessage } from './dependabotNudge.js'
 
 // Keep the suite fast: cap every rate-limit delay.
@@ -99,8 +99,6 @@ function run (web, messages, opts = {}) {
   return postNudgeThreads({
     web,
     channelId: 'C001',
-    channel: '#secops-hotspots',
-    token: 'xoxb-test',
     messages,
     nudges,
     weekId: '2026-W34',

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -16,32 +16,17 @@
 
 import {
   buildRepoMessage,
-  buildParentBlocks
+  buildParentBlocks,
+  parentCcLine
 } from './dependabotNudge.js'
 import { messageToBlocks } from './sendSlackMessage.js'
+import { findRepoParent, postAlertReply } from './nudgeThread.js'
 import {
   chunkNudgeMessage,
   fetchThreadReplies,
   isBotOwned,
   pace
 } from './slackUtils.js'
-
-export const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
-export const ALERTS_EVENT_TYPE = 'dependabot-nudge-alerts'
-
-// Extract the cc line from a thread parent: appended
-// inline to the summary ('... (cc <@U1>)') since the
-// summary-line change, or in its own 'cc ...' section on
-// threads written before it.
-function parentCcLine (blocks) {
-  for (const block of blocks || []) {
-    if (block.text?.type !== 'mrkdwn') continue
-    if (block.text.text.startsWith('cc ')) return block.text.text
-    const inline = block.text.text.match(/\((cc [^)]+)\)\s*$/)
-    if (inline) return inline[1]
-  }
-  return ''
-}
 
 // Compare rendered content, ignoring the block_id values
 // Slack assigns on post, so unchanged threads are left
@@ -50,19 +35,6 @@ function blocksSignature (blocks) {
   return (blocks || [])
     .map(b => `${b.type}:${b.text?.text || ''}`)
     .join('\n')
-}
-
-// Find the newest nudge parent for a repo among messages
-// already fetched from the channel. When weekId is given,
-// only that week's parent matches.
-export function findRepoParent (messages, repoFullName, weekId = null) {
-  return messages
-    .filter(m =>
-      m.metadata?.event_type === PARENT_EVENT_TYPE &&
-      m.metadata?.event_payload?.repo === repoFullName &&
-      (weekId === null ||
-        m.metadata?.event_payload?.weekId === weekId))
-    .sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts))[0]
 }
 
 // Tear down a thread whose alerts are all gone. Bot replies
@@ -249,17 +221,9 @@ export default async function refreshNudgeThread ({
   // is hidden behind a count that claims otherwise.
   for (let i = details.length; i < chunks.length; i++) {
     try {
-      await web.chat.postMessage({
-        channel: channelId,
-        thread_ts: parent.ts,
-        username: 'dependabot',
-        text: 'dependabot alert',
-        blocks: await messageToBlocks(chunks[i]),
-        metadata: {
-          event_type: ALERTS_EVENT_TYPE,
-          event_payload: { repo: repoFullName, kind: 'alerts' }
-        }
-      })
+      await postAlertReply(
+        web, channelId, parent.ts, chunks[i], repoFullName
+      )
       touched++
       await pace()
     } catch (err) {

--- a/src/refreshNudgeThread.test.js
+++ b/src/refreshNudgeThread.test.js
@@ -2,7 +2,8 @@
  * Tests for refreshNudgeThread module
  */
 import { strict as assert } from 'assert'
-import refreshNudgeThread, { findRepoParent, PARENT_EVENT_TYPE } from './refreshNudgeThread.js'
+import refreshNudgeThread from './refreshNudgeThread.js'
+import { PARENT_EVENT_TYPE } from './nudgeThread.js'
 import {
   buildRepoMessage,
   buildParentBlocks
@@ -83,76 +84,6 @@ function buildMockWeb (replies = threadReplies()) {
 function parentSummary (update) {
   return JSON.stringify(update.blocks)
 }
-
-// ---- findRepoParent ----
-
-console.log('Testing findRepoParent...')
-
-{
-  const messages = [
-    parentMsg,
-    {
-      ts: '200.0',
-      metadata: {
-        event_type: PARENT_EVENT_TYPE,
-        event_payload: { repo: 'brave/bar' }
-      }
-    }
-  ]
-  assert.equal(
-    findRepoParent(messages, 'brave/foo')?.ts, '100.0',
-    'Should find the parent for the requested repo'
-  )
-  assert.equal(
-    findRepoParent(messages, 'brave/nope'), undefined,
-    'Should return undefined when the repo has no thread'
-  )
-}
-console.log('  findRepoParent: matches on repo metadata')
-
-{
-  const messages = [
-    parentMsg,
-    {
-      ts: '300.0',
-      metadata: {
-        event_type: PARENT_EVENT_TYPE,
-        event_payload: { repo: 'brave/foo' }
-      }
-    }
-  ]
-  assert.equal(
-    findRepoParent(messages, 'brave/foo').ts, '300.0',
-    'Should prefer the newest parent'
-  )
-}
-console.log('  findRepoParent: prefers the newest thread')
-
-{
-  const messages = [
-    parentMsg,
-    {
-      ts: '50.0',
-      metadata: {
-        event_type: PARENT_EVENT_TYPE,
-        event_payload: { repo: 'brave/foo', weekId: '2026-W33' }
-      }
-    }
-  ]
-  assert.equal(
-    findRepoParent(messages, 'brave/foo', '2026-W33')?.ts, '50.0',
-    'Should match the requested week'
-  )
-  assert.equal(
-    findRepoParent(messages, 'brave/foo', '2026-W99'), undefined,
-    'Should not match another week'
-  )
-  assert.equal(
-    findRepoParent(messages, 'brave/foo')?.ts, '100.0',
-    'Without a weekId the newest parent still matches'
-  )
-}
-console.log('  findRepoParent: filters by weekId when given')
 
 // ---- refreshNudgeThread ----
 


### PR DESCRIPTION
## Summary

Follow-up to #947 fixing DRY/SoC nits from its review:

- **Thread identity in a neutral module**: `src/nudgeThread.js` now owns `PARENT_EVENT_TYPE`, `ALERTS_EVENT_TYPE`, and `findRepoParent`. `postNudgeThreads.js` no longer imports from `refreshNudgeThread.js` for shared identity concerns.
- **Single owner for the inline cc format**: `parentCcLine` moves to `dependabotNudge.js` next to `buildParentBlocks` (the producer), with a round-trip test plus legacy-section and empty cases.
- **One alert-reply implementation**: shared `postAlertReply` replaces the `sendSlackMessage` wrapper in `postNudgeThreads.js` and the raw `web.chat.postMessage` in `refreshNudgeThread.js`. Dedup wrapper was dead weight on a freshly created thread (refresh path reconciles).
- `postNudgeThreads` drops `channel`/`token` params; action call site updated.

## Test plan

- [x] `node --test 'src/**/*.test.js'` — 23/23 pass (new `nudgeThread.test.js` covers `findRepoParent` + `postAlertReply`)
- [x] `pnpm exec standard --ignore assets/opengrep_rules` — clean
- [ ] Weekly nudge run posts/refreshes threads unchanged