### PR TITLE
chore(deps): Bump opengrep to 1.16.5

### DIFF
--- a/.github/workflows/opengrep-self-test.yml
+++ b/.github/workflows/opengrep-self-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.opengrep
-          key: opengrep-v1.11.5-${{ runner.os }}
+          key: opengrep-v1.16.5-${{ runner.os }}
       - name: Install opengrep
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/actions/main/action.yml
+++ b/actions/main/action.yml
@@ -136,7 +136,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.opengrep
-        key: opengrep-v1.11.5-${{ runner.os }}
+        key: opengrep-v1.16.5-${{ runner.os }}
     - if: ${{ steps.reviewdog-enabled.outputs.result == 'true' }}
       name: Install opengrep
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/actions/opengrep-compare/action.yml
+++ b/actions/opengrep-compare/action.yml
@@ -48,7 +48,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.opengrep
-        key: opengrep-v1.11.5-${{ runner.os }}
+        key: opengrep-v1.16.5-${{ runner.os }}
 
     - name: Install Opengrep
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/src/installOpengrep.js
+++ b/src/installOpengrep.js
@@ -11,9 +11,9 @@ import os from 'os'
 import path from 'path'
 
 // Configuration
-const OPENGREP_VERSION = 'v1.11.5'
+const OPENGREP_VERSION = 'v1.16.5'
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/opengrep/opengrep/refs/tags/${OPENGREP_VERSION}/install.sh`
-const EXPECTED_SHA256 = 'a74388d0aec282eddf15fc8d42884de6531e1fc5a7bdc3ac31863c854e974eee'
+const EXPECTED_SHA256 = '5e5fdd35d0fff5fb7a7141b45e1f167abc7d1026b43bd2d31fa6611c515fd649'
 
 /**
  * Download content from URL


### PR DESCRIPTION
The recent workaround with the 1.11.5 bump (see #942) no longer works, as the Opengrep team released a few new versions in the meantime, so 1.11.5 is gone from the first page of release results.

Note that the issue has been fixed upstream: https://github.com/opengrep/opengrep/pull/796

The `1.11.5..1.16.5` [changes](https://github.com/opengrep/opengrep/blob/main/CHANGELOG.md) seem fairly light, so the upgrade looks safe at first glace.

Failing GH Action: https://github.com/brave/devops/actions/runs/32727176086/job/97430981950#step:3:488