### PR TITLE
fix(opengrep): Pin `install.sh` to fixed upstream commit

### DIFF
--- a/src/installOpengrep.js
+++ b/src/installOpengrep.js
@@ -1,6 +1,7 @@
 /**
  * Secure Opengrep installer
- * Downloads install.sh from pinned tag, verifies SHA256 hash, and executes it
+ * Downloads install.sh from a pinned upstream commit, verifies SHA256, and
+ * executes it with the desired Opengrep version.
  */
 
 import https from 'https'
@@ -11,9 +12,13 @@ import os from 'os'
 import path from 'path'
 
 // Configuration
+// install.sh pinned to commit 0b44519 (opengrep/opengrep#796): tag scripts
+// reject versions past the first releases API page (opengrep/opengrep#792).
+// TODO: drop the pin once opengrep >=v1.28.0 ships the fixed script in a tag.
 const OPENGREP_VERSION = 'v1.11.5'
-const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/opengrep/opengrep/refs/tags/${OPENGREP_VERSION}/install.sh`
-const EXPECTED_SHA256 = 'a74388d0aec282eddf15fc8d42884de6531e1fc5a7bdc3ac31863c854e974eee'
+const INSTALL_SCRIPT_COMMIT = '0b445193f95b14b828bc3ede8fea9725feb45e64'
+const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/opengrep/opengrep/${INSTALL_SCRIPT_COMMIT}/install.sh`
+const EXPECTED_SHA256 = '4643968d05a2d5f9d4130c0c170fc096d6adf8131aca002ba2fd0e482ac52d0d'
 
 /**
  * Download content from URL

--- a/src/updateOpengrepVersion.js
+++ b/src/updateOpengrepVersion.js
@@ -2,7 +2,11 @@
  * Update opengrep version in installOpengrep.js
  * This script fetches the latest opengrep release and updates:
  * - OPENGREP_VERSION constant
- * - EXPECTED_SHA256 hash of the install.sh script
+ * - EXPECTED_SHA256 hash of the pinned install.sh script
+ *
+ * install.sh is pinned to a fixed upstream commit (not the tag) because old tags
+ * ship an install.sh that rejects versions via the unpaginated GitHub API
+ * (opengrep/opengrep#792). New versions install via that pinned script.
  */
 
 import https from 'https'
@@ -139,9 +143,11 @@ export default async function updateOpengrepVersion () {
 
     console.log(`Updating from ${currentVersion} to ${latestVersion}...`)
 
-    // Download install script and calculate hash
-    const installScriptUrl = `https://raw.githubusercontent.com/opengrep/opengrep/refs/tags/${latestVersion}/install.sh`
-    console.log(`Downloading install script from ${installScriptUrl}...`)
+    // Download the pinned install script and calculate its hash.
+    // The script is pinned to a specific commit instead of the tag; see
+    // src/installOpengrep.js for the rationale.
+    const installScriptUrl = 'https://raw.githubusercontent.com/opengrep/opengrep/0b445193f95b14b828bc3ede8fea9725feb45e64/install.sh'
+    console.log(`Downloading pinned install script from ${installScriptUrl}...`)
 
     const scriptContent = await downloadFile(installScriptUrl)
     const sha256Hash = calculateSHA256(scriptContent)


### PR DESCRIPTION
Replaces #950

## Why

Opengrep's `install.sh` used to rely on the first page of release search results (the newest releases show up first), which broke installations of older `opengrep` versions (see [issue #792](https://github.com/opengrep/opengrep/issues/792), plus [a failure example](https://github.com/brave/devops/actions/runs/32727176086/job/97430981950#step:3:488)). The issue has been fixed in [#796](https://github.com/opengrep/opengrep/pull/796), but at the time of writing the fix hasn't been released yet.

## What

Use the patched `install.sh` to install any version (a long-term fix).