### PR TITLE
fix(nudge): reintroduce cc reply, silent parent post

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,14 @@
 * @brave/sec-team
+
+# Dependabot nudge thread pipeline
+/src/dependabotNudge.js @brave/sec-team @mschfh
+/src/dependabotNudge.test.js @brave/sec-team @mschfh
+/src/nudgeThread.js @brave/sec-team @mschfh
+/src/nudgeThread.test.js @brave/sec-team @mschfh
+/src/postNudgeThreads.js @brave/sec-team @mschfh
+/src/postNudgeThreads.test.js @brave/sec-team @mschfh
+/src/refreshNudgeThread.js @brave/sec-team @mschfh
+/src/refreshNudgeThread.test.js @brave/sec-team @mschfh
+/src/reconcileNudgeMessages.js @brave/sec-team @mschfh
+/src/reconcileNudgeMessages.test.js @brave/sec-team @mschfh
+/actions/dependabot-nudge/ @brave/sec-team @mschfh

--- a/src/nudgeThread.js
+++ b/src/nudgeThread.js
@@ -8,6 +8,7 @@ import { messageToBlocks } from './sendSlackMessage.js'
 
 export const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
 export const ALERTS_EVENT_TYPE = 'dependabot-nudge-alerts'
+export const CC_EVENT_TYPE = 'dependabot-nudge-cc'
 
 // Find the newest nudge parent for a repo among messages
 // already fetched from the channel. When weekId is given,
@@ -40,6 +41,35 @@ export async function postAlertReply (
     metadata: {
       event_type: ALERTS_EVENT_TYPE,
       event_payload: { repo: repoFullName, kind: 'alerts' }
+    }
+  })
+}
+
+// Post the maintainer cc as the thread's final reply. The cc
+// is sent as raw mrkdwn text rather than through the
+// markdown-to-blocks conversion, which escapes '<@U123>'
+// mentions and silently drops the notification. The reply is
+// the thread's single notification and doubles as its
+// completion marker, so it only lands once every other write
+// is known to have succeeded.
+export async function postCcReply (
+  web, channelId, parentTs, cc, repoFullName
+) {
+  return web.chat.postMessage({
+    channel: channelId,
+    thread_ts: parentTs,
+    username: 'dependabot',
+    text: cc,
+    link_names: true,
+    unfurl_links: true,
+    unfurl_media: true,
+    blocks: [{
+      type: 'section',
+      text: { type: 'mrkdwn', text: cc }
+    }],
+    metadata: {
+      event_type: CC_EVENT_TYPE,
+      event_payload: { repo: repoFullName, kind: 'cc' }
     }
   })
 }

--- a/src/nudgeThread.test.js
+++ b/src/nudgeThread.test.js
@@ -5,8 +5,10 @@ import { strict as assert } from 'assert'
 import {
   findRepoParent,
   postAlertReply,
+  postCcReply,
   PARENT_EVENT_TYPE,
-  ALERTS_EVENT_TYPE
+  ALERTS_EVENT_TYPE,
+  CC_EVENT_TYPE
 } from './nudgeThread.js'
 
 const parentMsg = {
@@ -136,5 +138,63 @@ console.log('\nTesting postAlertReply...')
   )
 }
 console.log('  postAlertReply: posts one chunk as an alerts-tagged thread reply')
+
+// ---- postCcReply ----
+
+console.log('\nTesting postCcReply...')
+
+{
+  const calls = []
+  const web = {
+    chat: {
+      postMessage: async (p) => {
+        calls.push(p)
+        return { ok: true, ts: '103.0' }
+      }
+    }
+  }
+  const cc = 'cc <@U1> <@U2>'
+
+  const result = await postCcReply(
+    web, 'C001', '100.0', cc, 'brave/foo'
+  )
+
+  assert.equal(result.ts, '103.0', 'Should return the posted reply')
+  assert.equal(calls.length, 1, 'Should post exactly one reply')
+  assert.equal(calls[0].channel, 'C001', 'Should target the channel')
+  assert.equal(
+    calls[0].thread_ts, '100.0',
+    'The cc belongs to the parent thread'
+  )
+  assert.equal(
+    calls[0].username, 'dependabot',
+    'The cc is posted as the dependabot user'
+  )
+  assert.equal(
+    calls[0].text, cc,
+    'The cc is sent as raw mrkdwn text so mentions notify'
+  )
+  assert.equal(
+    JSON.stringify(calls[0].blocks),
+    JSON.stringify([{
+      type: 'section',
+      text: { type: 'mrkdwn', text: cc }
+    }]),
+    'The cc renders as a single mrkdwn section, unescaped'
+  )
+  assert.equal(
+    calls[0].metadata.event_type, CC_EVENT_TYPE,
+    'The reply is tagged with the cc event type'
+  )
+  assert.equal(
+    calls[0].metadata.event_payload.kind, 'cc',
+    'The reply payload is tagged as the completion marker'
+  )
+  assert.equal(
+    calls[0].metadata.event_payload.repo, 'brave/foo',
+    'The reply payload carries the repo'
+  )
+}
+console.log('  postCcReply: posts raw-text cc as the completing thread reply')
 
 console.log('\n✅ All nudgeThread tests passed!')

--- a/src/postNudgeThreads.js
+++ b/src/postNudgeThreads.js
@@ -3,18 +3,28 @@
 // orchestration is unit-testable without spinning GitHub
 // Actions.
 //
-// One thread per repo: the parent carries the counts and the
-// maintainer mentions inline, and each alert gets its own
-// reply. Posting the parent is the thread's single
-// notification: mentions in a posted message notify, mentions
-// added later by editing do not, and the replies never carry
-// mentions at all.
+// One thread per repo: the parent carries the counts, the
+// replies carry the findings, and the maintainers are tagged
+// in the final cc reply. Slack has no way to post a reply
+// without notifying, and a mention added by editing a
+// message notifies nobody, so the thread keeps to a single
+// ping: the parent is posted and the findings are laid down
+// without any mentions, the parent is then edited to show
+// the cc inline (edits never notify), and the cc reply is
+// posted last as the one notification.
+//
+// The cc reply doubles as the completion marker for the
+// week: it is only posted once every other write of the
+// thread is known to have succeeded, so a partial failure
+// stays recoverable on the next run instead of being
+// permanently marked complete.
 
 import { buildParentBlocks } from './dependabotNudge.js'
 import refreshNudgeThread from './refreshNudgeThread.js'
 import {
   findRepoParent,
   postAlertReply,
+  postCcReply,
   PARENT_EVENT_TYPE
 } from './nudgeThread.js'
 import {
@@ -67,8 +77,10 @@ export default async function postNudgeThreads ({
 
       // Existing thread: bring it in line with the current
       // alerts. The refresh rewrites the findings, corrects
-      // the counts, and drops the legacy cc reply; editing
-      // never re-notifies, so refreshing every run is free.
+      // the counts, and completes the thread by posting the
+      // cc reply when an earlier run failed to deliver it;
+      // editing never re-notifies, so refreshing every run
+      // is free.
       if (parent) {
         const { ok } = await refreshNudgeThread({
           web,
@@ -76,6 +88,7 @@ export default async function postNudgeThreads ({
           messages: [parent],
           repoFullName: repo,
           alerts,
+          providedCc: cc,
           debug
         })
         if (!ok) {
@@ -90,11 +103,9 @@ export default async function postNudgeThreads ({
 
       if (debug) { console.log(`creating thread for ${repo} ${weekId}`) }
 
-      // The parent is posted with the mentions already in
-      // place: this post is the one notification the thread
-      // sends. The blocks are built directly rather than from
-      // markdown so the <@U123> mention pills survive
-      // unescaped.
+      // The parent is posted as the summary and nothing else:
+      // no mentions, so the post notifies nobody. The mentions
+      // are added later by editing, which never re-notifies.
       const parentResult = await web.chat.postMessage({
         channel: channelId,
         username: 'dependabot',
@@ -103,7 +114,7 @@ export default async function postNudgeThreads ({
         unfurl_links: true,
         unfurl_media: true,
         blocks: await buildParentBlocks({
-          repo, total, critical, cc
+          repo, total, critical
         }),
         metadata: {
           event_type: PARENT_EVENT_TYPE,
@@ -123,6 +134,33 @@ export default async function postNudgeThreads ({
         await postAlertReply(web, channelId, parentTs, chunk, repo)
         await pace()
       }
+
+      // The parent is finalized before the cc reply: the
+      // mentions this edit adds notify nobody, but the thread
+      // must not be marked complete while this write can
+      // still fail.
+      try {
+        await web.chat.update({
+          channel: channelId,
+          ts: parentTs,
+          text: 'dependabot alert',
+          blocks: await buildParentBlocks({
+            repo, total, critical, cc
+          })
+        })
+      } catch (err) {
+        console.error(
+          `failed to add maintainers to parent for ${repo}: ${err.message}`
+        )
+        continue
+      }
+      await pace()
+
+      // Sent as raw text rather than blocks: the cc carries
+      // the mentions, so its post is the thread's single
+      // notification and its completion marker.
+      await postCcReply(web, channelId, parentTs, cc, repo)
+      await pace()
     } catch (error) {
       console.error(`failed to nudge ${repo}: ${error.message}`)
       if (debug) { console.log(error) }

--- a/src/postNudgeThreads.test.js
+++ b/src/postNudgeThreads.test.js
@@ -109,9 +109,10 @@ function run (web, messages, opts = {}) {
 
 console.log('Testing postNudgeThreads...')
 
-// Test: a fresh repo gets a parent carrying the cc inline
-// (the thread's only notification), then one reply per
-// alert, and never a cc reply or a parent edit
+// Test: a fresh repo gets a parent without the cc (no
+// notification), then one reply per alert, then the parent
+// is edited to show the cc (edits never notify), and the
+// raw-text cc reply lands last as the single notification
 {
   const { web, calls } = buildMockWeb()
   await run(web, [])
@@ -134,8 +135,8 @@ console.log('Testing postNudgeThreads...')
     'The parent carries the summary'
   )
   assert.ok(
-    parentText.endsWith(`(${ccText})`),
-    'The parent carries the cc inline: its post is the single notification'
+    !parentText.includes('cc <@'),
+    'The parent is posted without the cc: its post must not notify'
   )
 
   const chunkPosts = calls.posted.filter(
@@ -152,19 +153,50 @@ console.log('Testing postNudgeThreads...')
     )
   }
 
+  const parentEdit = calls.updated.find(u => u.ts === PARENT_TS)
+  assert.ok(parentEdit, 'Should edit the parent to show the cc inline')
   assert.ok(
-    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
-    'No duplicate cc reply: the parent already shows it'
+    JSON.stringify(parentEdit.blocks).includes(ccText),
+    'The parent edit carries the mentions for the channel overview'
   )
+
+  const ccPost = calls.posted.find(
+    p => p.metadata?.event_payload?.kind === 'cc'
+  )
+  assert.ok(ccPost, 'Should post the cc reply')
+  assert.equal(ccPost.thread_ts, PARENT_TS, 'The cc is a thread reply')
+  assert.equal(ccPost.text, ccText, 'The cc is sent as raw text')
   assert.equal(
-    calls.updated.length, 0,
-    'The parent is complete at post time, no edit needed'
+    calls.sequence[calls.sequence.length - 1], 'post:cc',
+    'The cc completion marker is the last write'
+  )
+  assert.ok(
+    calls.sequence.indexOf(`update:${PARENT_TS}`) <
+      calls.sequence.indexOf('post:cc'),
+    'The parent must be finalized before the cc marker'
   )
 }
-console.log('  postNudgeThreads: parent with inline cc, one reply per alert')
+console.log('  postNudgeThreads: parent, per-alert replies, parent edit, cc last')
+
+// Test: a failed parent edit keeps the cc marker away so the
+// thread stays incomplete for the next run
+{
+  const { web, calls } = buildMockWeb({ updateFail: [PARENT_TS] })
+  await run(web, [])
+
+  assert.ok(
+    calls.posted.some(p => p.metadata?.event_payload?.kind === 'alerts'),
+    'Findings are posted before the parent edit'
+  )
+  assert.ok(
+    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'A failed parent edit must not be marked complete'
+  )
+}
+console.log('  postNudgeThreads: no cc after a failed parent edit')
 
 // Test: an existing thread is refreshed in place, never
-// re-posted or re-pinged
+// re-posted, and completed with its cc reply
 {
   const parent = { ...parentMessage(), reply_count: 1 }
   const { web, calls } = buildMockWeb({
@@ -182,10 +214,14 @@ console.log('  postNudgeThreads: parent with inline cc, one reply per alert')
     calls.posted.filter(p => p.metadata?.event_type === PARENT_EVENT_TYPE).length, 0,
     'Should not post a second parent'
   )
-  assert.ok(
-    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
-    'No cc reply is ever posted'
+  const ccPost = calls.posted.find(
+    p => p.metadata?.event_payload?.kind === 'cc'
   )
+  assert.equal(
+    calls.posted.filter(p => p.metadata?.event_payload?.kind === 'cc').length, 1,
+    'The refreshed thread is completed with exactly one cc reply'
+  )
+  assert.equal(ccPost.thread_ts, PARENT_TS, 'The cc lands in the thread')
 }
 console.log('  postNudgeThreads: refreshes an existing thread in place')
 

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -20,7 +20,7 @@ import {
   parentCcLine
 } from './dependabotNudge.js'
 import { messageToBlocks } from './sendSlackMessage.js'
-import { findRepoParent, postAlertReply } from './nudgeThread.js'
+import { findRepoParent, postAlertReply, postCcReply } from './nudgeThread.js'
 import {
   chunkNudgeMessage,
   fetchThreadReplies,
@@ -115,6 +115,9 @@ async function deleteThread ({
 // @param {object[]} opts.messages    - Channel history
 // @param {string} opts.repoFullName  - 'org/repo'
 // @param {object[]} opts.alerts      - Qualifying open alerts
+// @param {string} [opts.providedCc]  - This run's maintainer
+//   cc line, used when the thread carries none anywhere
+//   (an earlier run failed before the parent edit landed)
 // @param {boolean} [opts.debug]
 // @returns {Promise<{touched: number, ok: boolean}>}
 //   touched - messages written; ok - false when any write
@@ -126,6 +129,7 @@ export default async function refreshNudgeThread ({
   messages = [],
   repoFullName,
   alerts = [],
+  providedCc = null,
   debug = false
 }) {
   debug = debug === 'true' || debug === true
@@ -156,11 +160,10 @@ export default async function refreshNudgeThread ({
     })
   }
 
-  // Only the detail replies are rewritten. A legacy cc reply
-  // is handled after the parent update below: it carries the
-  // mentions, so it must survive until the parent shows
-  // them. Human replies in the thread are ignored the same
-  // way.
+  // Only the detail replies are rewritten. The cc reply is
+  // left alone: it carries the mentions and its content
+  // does not depend on which alerts are still open. Human
+  // replies in the thread are ignored the same way.
   const details = thread.filter(m =>
     m.ts !== parent.ts &&
     m.metadata?.event_payload?.kind === 'alerts'
@@ -169,10 +172,14 @@ export default async function refreshNudgeThread ({
     m.ts !== parent.ts &&
     m.metadata?.event_payload?.kind === 'cc'
   )
-  // The parent keeps its cc until the cc reply lands: reuse
-  // it when the reply is missing so the retry does not strip
-  // the mentions from the summary.
-  const cc = ccReply?.text || parentCcLine(parent.blocks)
+  // The parent keeps its cc until the cc reply lands: the
+  // posted reply is authoritative (it is what notified),
+  // then the parent's inline cc, then this run's cc line
+  // for threads whose earlier run failed before the parent
+  // edit landed.
+  const cc = ccReply?.text ||
+    parentCcLine(parent.blocks) ||
+    providedCc
 
   if (debug) {
     console.log(
@@ -257,7 +264,6 @@ export default async function refreshNudgeThread ({
   // Correct the count on the thread parent and keep the
   // maintainers visible in the channel overview. Editing
   // does not re-notify.
-  let parentOk = true
   try {
     const parentBlocks = await buildParentBlocks({
       repo: repoFullName, total, critical, cc
@@ -272,7 +278,6 @@ export default async function refreshNudgeThread ({
       touched++
     }
   } catch (err) {
-    parentOk = false
     ok = false
     console.error(
       `refresh: failed to update parent ts=${parent.ts}: ` +
@@ -280,21 +285,18 @@ export default async function refreshNudgeThread ({
     )
   }
 
-  // Threads posted before the parent carried the cc inline
-  // end with a 'cc' reply. It duplicates the parent's
-  // mentions now, so drop it once the parent is known to
-  // show them; keep it when the parent write failed so the
-  // mentions are never lost.
-  if (ccReply && cc && parentOk) {
+  // The cc reply is the thread's completion marker: when an
+  // earlier run failed to post it, complete the thread now
+  // so the maintainers still get their single ping.
+  if (!ccReply && cc) {
     try {
-      await web.chat.delete({
-        channel: channelId, ts: ccReply.ts
-      })
+      await postCcReply(web, channelId, parent.ts, cc, repoFullName)
       touched++
+      await pace()
     } catch (err) {
       ok = false
       console.error(
-        `refresh: failed to delete cc reply ts=${ccReply.ts}: ` +
+        `refresh: failed to post cc reply for ${repoFullName}: ` +
         err.message
       )
     }

--- a/src/refreshNudgeThread.test.js
+++ b/src/refreshNudgeThread.test.js
@@ -94,7 +94,7 @@ console.log('\nTesting refreshNudgeThread...')
 {
   const { web, calls } = buildMockWeb()
   // Two multi-alert replies become one reply per alert, and
-  // the legacy cc reply is dropped once the parent shows it.
+  // the cc reply survives: it carries the notification.
   await refreshNudgeThread({
     web,
     channelId: 'C001',
@@ -133,12 +133,16 @@ console.log('\nTesting refreshNudgeThread...')
     'Should rewrite the second detail reply too'
   )
   assert.equal(
-    calls.posted.length, 1,
+    calls.posted.filter(p => p.metadata?.event_payload?.kind === 'alerts').length, 1,
     'The third alert needs a new reply'
   )
   assert.deepEqual(
-    calls.deleted, ['103.0'],
-    'Should drop the legacy cc reply once the parent shows it'
+    calls.deleted, [],
+    'The cc reply is kept: it is the thread\'s notification'
+  )
+  assert.ok(
+    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'The cc reply already exists, none is posted'
   )
   assert.ok(
     !calls.updated.some(u => u.ts === '103.0'),
@@ -223,8 +227,8 @@ console.log('  refreshNudgeThread: omits criticals when none are left')
     'Appended replies must be tagged as findings, not a parent'
   )
   assert.ok(
-    calls.deleted.includes('103.0'),
-    'The legacy cc reply is dropped once the parent shows the mentions'
+    !calls.deleted.includes('103.0'),
+    'The cc reply survives the refresh'
   )
 }
 console.log('  refreshNudgeThread: appends when alerts grew')
@@ -262,7 +266,8 @@ console.log('  refreshNudgeThread: no-op without a thread')
 }
 console.log('  refreshNudgeThread: debug mode is read-only')
 
-// Test: an already-accurate thread is left untouched, so
+// Test: an already-accurate thread (inline-cc parent, one
+// reply per alert, cc reply present) is left untouched, so
 // routine runs don't rewrite every message
 {
   const alerts = [makeAlert(1)]
@@ -298,14 +303,16 @@ console.log('  refreshNudgeThread: debug mode is read-only')
     alerts
   })).touched
 
-  assert.equal(touched, 1, 'Only the redundant cc reply is touched')
+  assert.equal(touched, 0, 'An up-to-date thread is untouched')
   assert.equal(calls.updated.length, 0, 'Should issue no updates')
-  assert.deepEqual(calls.deleted, ['103.0'], 'Should drop the legacy cc reply')
+  assert.equal(calls.deleted.length, 0, 'Should issue no deletes')
+  assert.equal(calls.posted.length, 0, 'Should issue no posts')
 }
-console.log('  refreshNudgeThread: skips an up-to-date thread, dedupes the cc')
+console.log('  refreshNudgeThread: skips an up-to-date thread')
 
-// Test: a missing cc reply must not strip the existing parent
-// mentions before postNudgeThreads retries the reply.
+// Test: a missing cc reply (earlier partial failure) is
+// completed by the refresh, and the parent keeps its
+// mentions until the reply lands.
 {
   const parent = {
     ...parentMsg,
@@ -332,12 +339,18 @@ console.log('  refreshNudgeThread: skips an up-to-date thread, dedupes the cc')
     parentSummary(parentUpdate).includes(ccText),
     'Should preserve parent mentions when the cc reply is missing'
   )
+  const ccPost = calls.posted.find(
+    p => p.metadata?.event_payload?.kind === 'cc'
+  )
+  assert.ok(ccPost, 'Should complete the thread with the missing cc reply')
+  assert.equal(ccPost.thread_ts, parent.ts, 'The cc lands in the thread')
+  assert.equal(ccPost.text, ccText, 'The cc is sent as raw text')
 }
-console.log('  refreshNudgeThread: preserves parent cc pending reply retry')
+console.log('  refreshNudgeThread: completes a missing cc reply')
 
 // Test: threads written before the inline-cc format carry the
 // mentions in a standalone section block; refresh must still
-// extract and preserve them.
+// extract, preserve, and complete them with a cc reply.
 {
   const legacyParent = {
     ...parentMsg,
@@ -365,10 +378,14 @@ console.log('  refreshNudgeThread: preserves parent cc pending reply retry')
     parentSummary(parentUpdate).includes(ccText),
     'Should preserve legacy-format parent mentions'
   )
+  assert.ok(
+    calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'Should complete a legacy thread missing its cc reply'
+  )
 }
 console.log('  refreshNudgeThread: preserves legacy parent cc')
 
-// Test: when the parent update fails, the legacy cc reply
+// Test: when the parent update fails, the cc reply
 // must survive: it is the only place the mentions notify
 // from until the parent write succeeds.
 {
@@ -389,42 +406,52 @@ console.log('  refreshNudgeThread: preserves legacy parent cc')
     !calls.deleted.includes('103.0'),
     'The cc reply must stay while the parent update fails'
   )
+  assert.ok(
+    !calls.posted.some(p => p.metadata?.event_payload?.kind === 'cc'),
+    'The cc reply exists already, none is posted'
+  )
 }
 console.log('  refreshNudgeThread: keeps the cc reply when the parent write fails')
 
-// Test: a thread already in the current format (inline cc
-// parent, one reply per alert, no cc reply) is left alone
+// Test: a missing cc reply is still delivered when the
+// parent update fails: the reply carries the mentions and
+// the notification on its own.
 {
-  const alerts = [makeAlert(1), makeAlert(2)]
-  const { message, total, critical } = buildRepoMessage({ alerts })
-  const chunks = chunkNudgeMessage(message)
-  const freshParent = {
+  const parent = {
     ...parentMsg,
     blocks: await buildParentBlocks({
-      repo: 'brave/foo', total, critical, cc: ccText
+      repo: 'brave/foo', total: 1, critical: 0, cc: ccText
     })
   }
   const { web, calls } = buildMockWeb([
-    freshParent,
-    ...await Promise.all(chunks.map(async (c, i) => ({
-      ts: `10${i + 1}.0`,
-      blocks: await messageToBlocks(c),
+    parent,
+    {
+      ts: '101.0',
       metadata: { event_payload: { repo: 'brave/foo', kind: 'alerts' } }
-    })))
+    }
   ])
-  const { touched, ok } = await refreshNudgeThread({
+  web.chat.update = async (p) => {
+    if (p.ts === '100.0') throw new Error('rate_limited')
+    calls.updated.push(p)
+    return { ok: true }
+  }
+  await refreshNudgeThread({
     web,
     channelId: 'C001',
-    messages: [freshParent],
+    messages: [parent],
     repoFullName: 'brave/foo',
-    alerts
+    alerts: [makeAlert(1)]
   })
-  assert.equal(ok, true)
-  assert.equal(touched, 0, 'A current-format thread is untouched')
-  assert.equal(calls.updated.length, 0)
-  assert.equal(calls.deleted.length, 0)
+  const ccPost = calls.posted.find(
+    p => p.metadata?.event_payload?.kind === 'cc'
+  )
+  assert.ok(
+    ccPost,
+    'The missing cc reply is posted even when the parent write fails'
+  )
+  assert.equal(ccPost.text, ccText, 'The cc is sent as raw text')
 }
-console.log('  refreshNudgeThread: leaves a current-format thread alone')
+console.log('  refreshNudgeThread: completes a missing cc despite a failed parent write')
 
 // Test: zero remaining alerts deletes the thread, replies
 // first so Slack does not leave placeholders


### PR DESCRIPTION
## What

Reverts the notification behavior of #947's follow-up (`8116079`): the thread parent was posted with the maintainer mentions inline, which made the parent post itself the notification. This reintroduces the earlier "double cc" design with one notification per thread:

1. **Parent posted without the cc** — no mentions, notifies nobody
2. **One reply per alert** (kept from `8116079`) — no mentions
3. **Parent edited to show the cc inline** — `chat.update` never notifies, mentions still visible in the channel overview
4. **cc reply posted last** as raw mrkdwn text — the thread's single notification, and its completion marker

## Refresh behavior

- The cc reply **survives** refreshes (no longer deleted as a duplicate)
- Threads whose cc reply never landed (earlier partial failure) are **completed by the refresh**: the missing cc reply is posted, delivering the ping
- When an earlier run failed before the parent edit landed (no cc anywhere in the thread), refresh falls back to the current run's cc line (`providedCc`)

## Why

Mentions in a freshly posted message notify; mentions added by editing do not. The parent post should be silent so the only ping maintainers receive is the deliberate cc reply at the end of the thread.

## CODEOWNERS

Adds `@mschfh` (author of the per-repo thread work) alongside `@brave/sec-team` for the nudge pipeline files.

## Test plan

- [x] `pnpm test` — 25/25 node tests green
- [x] `standard` lint clean
- [x] New coverage: silent parent post, parent edit before cc marker, no cc after failed parent edit, refresh completes missing cc reply (including when the parent write fails), up-to-date threads untouched