### PR TITLE
fix(shell): Resolve shellcheck warnings across all scripts

### DIFF
--- a/assets/debug.sh
+++ b/assets/debug.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -xe
 pwd
 tree -a
-echo $RUNNER_TEMP
-tree -a $RUNNER_TEMP
+echo "$RUNNER_TEMP"
+tree -a "$RUNNER_TEMP"
 realpath "$0"
 realpath -s "$0"
-echo $ASSIGNEES
+echo "$ASSIGNEES"

--- a/assets/reviewdog.sh
+++ b/assets/reviewdog.sh
@@ -7,7 +7,7 @@ export SCRIPTPATH
 export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 export SEC_ACTION_DEBUG=$SEC_ACTION_DEBUG
-ASSIGNEES=$(echo "$ASSIGNEES" | sed 's|\([^ ]\)|@\1|' | tr -s '\n' ' ')
+ASSIGNEES=$(echo "$ASSIGNEES" | sed 's|[^ ]\+|@&|g' | tr -s '\n' ' ')
 export ASSIGNEES
 
 RUNNERS="safesvg opengrep sveltegrep npm-audit pip-audit" # disabled: tfsec brakeman

--- a/assets/reviewdog.sh
+++ b/assets/reviewdog.sh
@@ -1,53 +1,55 @@
 #!/bin/bash -xe
 # Absolute path to this script. /home/user/bin/foo.sh
-SCRIPT=$(readlink -f $0)
+SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in. /home/user/bin
-export SCRIPTPATH=`dirname $SCRIPT`
+SCRIPTPATH=$(dirname "$SCRIPT")
+export SCRIPTPATH
 export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 export SEC_ACTION_DEBUG=$SEC_ACTION_DEBUG
-export ASSIGNEES=$(echo "$ASSIGNEES" | sed 's|\([^ ]\)|@\1|' | tr -s '\n' ' ')
+ASSIGNEES=$(echo "$ASSIGNEES" | sed 's|\([^ ]\)|@\1|' | tr -s '\n' ' ')
+export ASSIGNEES
 
 RUNNERS="safesvg opengrep sveltegrep npm-audit pip-audit" # disabled: tfsec brakeman
 
 if [ -n "${GITHUB_BASE_REF+set}" ]; then
     for runner in $RUNNERS; do
-        reviewdog -reporter=local -runners=$runner -conf="$SCRIPTPATH/reviewdog/reviewdog.yml" -diff="git diff -U0 origin/$GITHUB_BASE_REF" > $runner.log 2>> reviewdog.log || true
-        grep -H "" reviewdog.$runner.stderr.log >> reviewdog.fail.log || true
-        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" reviewdog.$runner.stderr.log || true
+        reviewdog -reporter=local -runners="$runner" -conf="$SCRIPTPATH/reviewdog/reviewdog.yml" -diff="git diff -U0 origin/$GITHUB_BASE_REF" >"$runner.log" 2>>reviewdog.log || true
+        grep -H "" "reviewdog.$runner.stderr.log" >>reviewdog.fail.log || true
+        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" "reviewdog.$runner.stderr.log" || true
     done
 
     for runner in $RUNNERS; do
-        cat $runner.log | reviewdog -reporter=github-pr-review -efm='%f:%l: %m' \
-          || cat $runner.log >> reviewdog.fail.log
-        grep -H "" $runner.log >> reviewdog.log || true
+        cat "$runner.log" | reviewdog -reporter=github-pr-review -efm='%f:%l: %m' ||
+            cat "$runner.log" >>reviewdog.fail.log
+        grep -H "" "$runner.log" >>reviewdog.log || true
         echo -n "$runner: "
-        echo "${runner//-/_}_count=$(grep -c "^" $runner.log)" >> $GITHUB_OUTPUT || true
-        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" $runner.log || true
+        echo "${runner//-/_}_count=$(grep -c "^" "$runner.log")" >>"$GITHUB_OUTPUT" || true
+        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" "$runner.log" || true
     done
 
 else
-    git ls-files | tr '\n' '\0' > $SCRIPTPATH/all_changed_files.txt
+    git ls-files | tr '\n' '\0' >"$SCRIPTPATH/all_changed_files.txt"
     reviewdog \
-      -runners=$(echo "$RUNNERS" | tr ' ' ',') \
-      -conf="$SCRIPTPATH/reviewdog/reviewdog.yml"  \
-      -filter-mode=nofilter \
-      -reporter=local \
-      -tee \
-      | sed 's/<br><br>Cc @brave\/sec-team[ ]*//' \
-      | tee reviewdog.log
+        -runners="$(echo "$RUNNERS" | tr ' ' ',')" \
+        -conf="$SCRIPTPATH/reviewdog/reviewdog.yml" \
+        -filter-mode=nofilter \
+        -reporter=local \
+        -tee |
+        sed 's/<br><br>Cc @brave\/sec-team[ ]*//' |
+        tee reviewdog.log
     # TODO: in the future send reviewdog.log to a database and just print out errors with
     # [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && somethingsomething
     # TODO: fix brakeman on full-scan
-    grep -H "" reviewdog.*.stderr.log | grep -v "reviewdog.brakeman.stderr.log:" >> reviewdog.fail.log || true
+    grep -H "" reviewdog.*.stderr.log | grep -v "reviewdog.brakeman.stderr.log:" >>reviewdog.fail.log || true
     for runner in $RUNNERS; do
-      echo "${runner//-/_}_count=$(grep -c ": \[${runner}\] .*$" reviewdog.log)" >> $GITHUB_OUTPUT || true
+        echo "${runner//-/_}_count=$(grep -c ": \[${runner}\] .*$" reviewdog.log)" >>"$GITHUB_OUTPUT" || true
     done
 fi
 
-cat reviewdog.log | grep 'failed with zero findings: The command itself failed' >> reviewdog.fail.log || true
+cat reviewdog.log | grep 'failed with zero findings: The command itself failed' >>reviewdog.fail.log || true
 
-echo "findings=$(cat reviewdog.log | grep '^[A-Z]:[^:]*:' | wc -l)" >> $GITHUB_OUTPUT
+echo "findings=$(grep -c '^[A-Z]:[^:]*:' reviewdog.log)" >>"$GITHUB_OUTPUT"
 
 sed -i '/^$/d' reviewdog.log reviewdog.fail.log
 find reviewdog.log -type f -empty -delete

--- a/assets/reviewdog.sh
+++ b/assets/reviewdog.sh
@@ -16,16 +16,22 @@ if [ -n "${GITHUB_BASE_REF+set}" ]; then
     for runner in $RUNNERS; do
         reviewdog -reporter=local -runners="$runner" -conf="$SCRIPTPATH/reviewdog/reviewdog.yml" -diff="git diff -U0 origin/$GITHUB_BASE_REF" >"$runner.log" 2>>reviewdog.log || true
         grep -H "" "reviewdog.$runner.stderr.log" >>reviewdog.fail.log || true
-        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" "reviewdog.$runner.stderr.log" || true
+        if [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]]; then
+            # || true: grep exit 1 just means empty file, not an error
+            grep -H "" "reviewdog.$runner.stderr.log" || true
+        fi
     done
 
     for runner in $RUNNERS; do
-        cat "$runner.log" | reviewdog -reporter=github-pr-review -efm='%f:%l: %m' ||
+        reviewdog -reporter=github-pr-review -efm='%f:%l: %m' < "$runner.log" ||
             cat "$runner.log" >>reviewdog.fail.log
         grep -H "" "$runner.log" >>reviewdog.log || true
         echo -n "$runner: "
         echo "${runner//-/_}_count=$(grep -c "^" "$runner.log")" >>"$GITHUB_OUTPUT" || true
-        [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]] && grep -H "" "$runner.log" || true
+        if [[ ${SEC_ACTION_DEBUG:-false} == 'true' ]]; then
+            # || true: grep exit 1 just means empty file, not an error
+            grep -H "" "$runner.log" || true
+        fi
     done
 
 else
@@ -47,7 +53,7 @@ else
     done
 fi
 
-cat reviewdog.log | grep 'failed with zero findings: The command itself failed' >>reviewdog.fail.log || true
+grep 'failed with zero findings: The command itself failed' reviewdog.log >>reviewdog.fail.log || true
 
 echo "findings=$(grep -c '^[A-Z]:[^:]*:' reviewdog.log)" >>"$GITHUB_OUTPUT"
 

--- a/assets/tfsec.sh
+++ b/assets/tfsec.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+set -o pipefail
 # Absolute path to this script. /home/user/bin/foo.sh
 SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in. /home/user/bin

--- a/assets/tfsec.sh
+++ b/assets/tfsec.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -e
 # Absolute path to this script. /home/user/bin/foo.sh
-SCRIPT=$(readlink -f $0)
+SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in. /home/user/bin
-export SCRIPTPATH=`dirname $SCRIPT`
+SCRIPTPATH=$(dirname "$SCRIPT")
+export SCRIPTPATH
 
-ARGS=""
-if ls *.tfvars 2> /dev/null; then
-    for TFVARS in *.tfvars; do
-        ARGS+="--tfvars-file $TFVARS "
-    done
-fi
+shopt -s nullglob
+ARGS=()
+for TFVARS in *.tfvars; do
+    ARGS+=(--tfvars-file "$TFVARS")
+done
 
-tfsec "$1" $ARGS --format=json | jq -r -f "$SCRIPTPATH/tfsec.jq"
+tfsec "$1" "${ARGS[@]}" --format=json | jq -r -f "$SCRIPTPATH/tfsec.jq"

--- a/assets/xmllint.sh
+++ b/assets/xmllint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+set -o pipefail
 # Absolute path to this script. /home/user/bin/foo.sh
 SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in. /home/user/bin
@@ -8,8 +9,4 @@ export SCRIPTPATH
 # Only check SVGs
 [[ "$1" == *".svg" ]] || exit 0
 
-OUT=$(xmllint --dtdvalid "$SCRIPTPATH/dtd/svg11-secure-flat.dtd" --noout "$1" 2>&1) || {
-    echo "$OUT"
-    exit 1
-}
-echo "$OUT" | grep -v '^Document'
+xmllint --dtdvalid "$SCRIPTPATH/dtd/svg11-secure-flat.dtd" --noout "$1" 2>&1 | { grep -v '^Document' || true; }

--- a/assets/xmllint.sh
+++ b/assets/xmllint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -e
 # Absolute path to this script. /home/user/bin/foo.sh
-SCRIPT=$(readlink -f $0)
+SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in. /home/user/bin
-export SCRIPTPATH=`dirname $SCRIPT`
+SCRIPTPATH=$(dirname "$SCRIPT")
+export SCRIPTPATH
 
 # Only check SVGs
 [[ "$1" == *".svg" ]] || exit 0
 
-xmllint --dtdvalid $SCRIPTPATH/dtd/svg11-secure-flat.dtd --noout "$1" 2>&1 | grep -v '^Document'
+xmllint --dtdvalid "$SCRIPTPATH/dtd/svg11-secure-flat.dtd" --noout "$1" 2>&1 | grep -v '^Document'

--- a/assets/xmllint.sh
+++ b/assets/xmllint.sh
@@ -8,4 +8,8 @@ export SCRIPTPATH
 # Only check SVGs
 [[ "$1" == *".svg" ]] || exit 0
 
-xmllint --dtdvalid "$SCRIPTPATH/dtd/svg11-secure-flat.dtd" --noout "$1" 2>&1 | grep -v '^Document'
+OUT=$(xmllint --dtdvalid "$SCRIPTPATH/dtd/svg11-secure-flat.dtd" --noout "$1" 2>&1) || {
+    echo "$OUT"
+    exit 1
+}
+echo "$OUT" | grep -v '^Document'


### PR DESCRIPTION
Fixes all the issues reported by `shellcheck $(fd -t f "\.sh")`