### PR TITLE
test: symbolic verification passes and workflow

### DIFF
--- a/.github/workflows/symbolic.yml
+++ b/.github/workflows/symbolic.yml
@@ -1,0 +1,36 @@
+# Manual symbolic-verification pass (not a CI gate).
+#
+# CrossHair checks the Python contracts in
+# scripts/symbolic/crosshair_contracts.py; ExpoSE runs the JS harnesses
+# in scripts/symbolic/harnesses/. ExpoSE is best-effort: it vendors a
+# 2019-era z3 fork that modern clang cannot compile, so the step is
+# allowed to fail and is expected to succeed on Linux/GCC runners or
+# older toolchains only.
+name: symbolic verification
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  crosshair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: CrossHair contracts
+        run: bash scripts/symbolic/run-crosshair.sh
+
+  expose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+      - name: ExpoSE harnesses
+        continue-on-error: true
+        run: bash scripts/symbolic/run-expose.sh

--- a/.github/workflows/symbolic.yml
+++ b/.github/workflows/symbolic.yml
@@ -27,10 +27,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Install bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.4.0
       - name: ExpoSE harnesses
         continue-on-error: true
         run: bash scripts/symbolic/run-expose.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,42 @@ pnpm exec standard --fix --ignore assets/opengrep_rules
 ### Testing
 
 ```bash
-pnpm test
+pnpm test          # node:test unit + property tests, then cucumber-js scenarios
+pnpm run test:bdd  # BDD scenarios only (features/*.feature)
+uv run --group test pytest  # Python pytest-bdd suite (assets/tests/)
 ```
+
+Tests are BDD-first: Gherkin features live in `features/`, step definitions in
+`features/step_definitions/` (shared world + mock factories in
+`features/support/world.js`), Python features in `assets/tests/features/` with
+steps in `assets/tests/step_defs/`. Property tests (fast-check for JS,
+Hypothesis for Python) live next to the suites as `*.property.test.js` and
+`assets/tests/test_properties.py`.
+
+### Coverage Gates
+
+CI (`.github/workflows/lint.yml`) enforces 80% lines and 80% branches:
+
+```bash
+pnpm run coverage    # JS: unit + BDD under c8, gate at 80/80
+pnpm run coverage:py # Python: pytest --cov + separate 80/80 gate
+```
+
+Scope: `src/**/*.js` (excluding `*.test.js`) and the four Python scanners in
+`assets/` (`modelscan-audit.py`, `npm-audit.py`, `pip-audit.py`,
+`scripttagextractor.py`).
+
+### Symbolic Verification (manual, not a CI gate)
+
+```bash
+bash scripts/symbolic/run-crosshair.sh  # CrossHair contracts for the Python scanners
+bash scripts/symbolic/run-expose.sh     # ExpoSE harnesses for pure src functions
+```
+
+Also available via the `symbolic verification` workflow_dispatch workflow.
+ExpoSE is best-effort: it vendors a 2019-era z3 fork that modern clang cannot
+compile (works on Linux with older GCC). The property suites remain the
+soundness gate.
 
 ### Rule Metadata Validation
 

--- a/scripts/symbolic/crosshair_contracts.py
+++ b/scripts/symbolic/crosshair_contracts.py
@@ -1,0 +1,93 @@
+"""CrossHair symbolic-verification contracts for the pure asset scanners.
+
+Run via scripts/symbolic/run-crosshair.sh (external verification pass,
+not a CI gate). Each function returns an invariant boolean with a PEP316
+``post: __return__`` contract — CrossHair searches for an input that makes it
+return False (or crash), which would mean a real bug in the scanner logic.
+
+The asset modules have hyphenated filenames, so they are loaded through
+importlib the same way as in assets/tests/conftest.py.
+"""
+import importlib.util
+import tomllib
+from pathlib import Path
+from typing import List
+
+ASSETS = Path(__file__).resolve().parent.parent.parent / 'assets'
+
+
+def _load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, ASSETS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+npm_audit = _load_module('npm_audit', 'npm-audit.py')
+pip_audit = _load_module('pip_audit', 'pip-audit.py')
+scripttagextractor = _load_module('scripttagextractor', 'scripttagextractor.py')
+
+
+def find_lock_file_line_is_in_bounds(lines: List[str], node_name: str) -> bool:
+    """post: __return__"""
+    try:
+        result = npm_audit.find_lock_file_line(lines, node_name)
+    except StopIteration:
+        return True
+    return 2 <= result <= len(lines) + 1
+
+
+def requirements_install_commands_are_bounded(lines: List[str], diff_lines: List[str]) -> bool:
+    """post: __return__"""
+    if lines and lines[-1].endswith('\\'):
+        # A trailing continuation line is malformed input outside the contract.
+        return True
+    last = 0
+    for install_cmd, line_number in pip_audit.install_commands_for_requirements_txt(lines, diff_lines):
+        if not (last < line_number <= len(lines)):
+            return False
+        last = line_number
+        if len(install_cmd) != 1:
+            return False
+    return True
+
+
+def pyproject_install_commands_are_bounded(lines: List[str], diff_lines: List[str]) -> bool:
+    """post: __return__"""
+    try:
+        tomllib.loads('\n'.join(lines))
+    except tomllib.TOMLDecodeError:
+        # Unparseable TOML is outside the contract.
+        return True
+    last = 0
+    seen = set()
+    for install_cmd, line_number in pip_audit.install_commands_for_pyproject_toml(lines, diff_lines):
+        if not (last < line_number <= len(lines)):
+            return False
+        last = line_number
+        if len(install_cmd) != 1:
+            return False
+        if install_cmd[0] in seen:
+            return False
+        seen.add(install_cmd[0])
+    return True
+
+
+def found_script_new_lines_counts_newlines(data: str) -> bool:
+    """post: __return__"""
+    found = scripttagextractor.FoundScript(1, 0, data)
+    return found.new_lines() == data.count('\n')
+
+
+def parser_script_positions_are_ordered(text: str) -> bool:
+    """post: __return__"""
+    parser = scripttagextractor.MyHTMLParser()
+    parser.feed(text)
+    last = 1
+    for found in parser.scripts:
+        if found.line_number < last:
+            return False
+        last = found.line_number
+        if found.start_offset < 0:
+            return False
+    return True

--- a/scripts/symbolic/run-crosshair.sh
+++ b/scripts/symbolic/run-crosshair.sh
@@ -14,4 +14,7 @@ if [ ! -f "$CONTRACTS" ]; then
   exit 0
 fi
 
-uv run --with crosshair python -m crosshair check "$CONTRACTS"
+# crosshair-tool is the symbolic-execution engine (PyPI package name;
+# the similarly named "crosshair" package is an unrelated SSH tool).
+# Contracts use PEP316 "post: retval" docstrings.
+uv run --with crosshair-tool crosshair check "$CONTRACTS"

--- a/scripts/symbolic/run-expose.sh
+++ b/scripts/symbolic/run-expose.sh
@@ -72,6 +72,7 @@ fi
 # node_modules/.bin is prepended to PATH instead.
 if [ ! -f "$EXPOSE_DIR/Distributor/bin/Distributor.js" ]; then
   echo "building ExpoSE (one-time setup)"
+  # shellcheck disable=SC1091  # build scripts only exist inside the cloned ExpoSE tree
   (cd "$EXPOSE_DIR" \
     && npm install --no-audit --no-fund --omit=dev \
     && export PATH="$EXPOSE_DIR/node_modules/.bin:$PATH" \

--- a/scripts/symbolic/run-expose.sh
+++ b/scripts/symbolic/run-expose.sh
@@ -6,14 +6,30 @@
 # scripts/symbolic/harnesses/*.src.js to CommonJS (ExpoSE/Jalangi2 cannot
 # instrument ESM), then runs the analysis and reports explored paths.
 #
-# ExpoSE requires node 21.7.2 + clang + make. Missing prerequisites are
-# reported and skipped — the property suite remains the soundness gate.
+# ExpoSE pins node 21.7.2 (engines in its package.json). The pinned
+# binary is downloaded from nodejs.org into tmp/node-dist — no version
+# manager required. cmake + make are needed to build the z3 fork once.
+# The property suite remains the soundness gate.
+#
+# TOOLCHAIN LIMITATION: the vendored z3 fork (ExpoSEJS/z3 @8f3b923,
+# 2019-era C++) does not compile with modern clang (two-phase template
+# lookup errors in src/math/lp/*.h). When the z3 build fails, this
+# script reports the limitation and exits non-zero instead of silently
+# skipping analysis. Known workarounds:
+#   - build z3javascript on a Linux host with an older GCC toolchain
+#   - or use an older Xcode/clang that predates strict two-phase lookup
+# CrossHair (Python) and the fast-check/Hypothesis property suites are
+# the maintained soundness gates; ExpoSE is a best-effort extra pass.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 EXPOSE_DIR="$ROOT/tmp/ExpoSE"
 HARNESS_OUT="$ROOT/tmp/symbolic-harnesses"
+NODE_DIST="$ROOT/tmp/node-dist"
 NODE_VERSION="21.7.2"
+
+Z3JS_DIR="$EXPOSE_DIR/Analyser/node_modules/z3javascript"
+Z3_DIR="$Z3JS_DIR/z3"
 
 mkdir -p "$HARNESS_OUT"
 
@@ -27,24 +43,123 @@ if [ ! -d "$EXPOSE_DIR" ]; then
   git clone --depth 1 https://github.com/ExpoSEJS/ExpoSE.git "$EXPOSE_DIR"
 fi
 
-# ExpoSE is tested against node 21.7.2 only.
-if command -v fnm >/dev/null 2>&1; then
-  eval "$(fnm env)"
-  fnm install "$NODE_VERSION" 2>/dev/null || true
-  fnm use "$NODE_VERSION" 2>/dev/null || echo "WARN: cannot pin node $NODE_VERSION, using $(node -v)"
-else
-  echo "WARN: fnm not found — ExpoSE requires node $NODE_VERSION, using $(node -v)"
+# Pin node to the version ExpoSE declares in its engines field.
+case "$(uname -s)/$(uname -m)" in
+  Darwin/arm64) NODE_PLATFORM="darwin-arm64" ;;
+  Darwin/x86_64) NODE_PLATFORM="darwin-x64" ;;
+  Linux/x86_64) NODE_PLATFORM="linux-x64" ;;
+  Linux/aarch64) NODE_PLATFORM="linux-arm64" ;;
+  *) echo "ERROR: unsupported platform $(uname -s)/$(uname -m)" >&2; exit 1 ;;
+esac
+NODE_BIN="$NODE_DIST/node-v$NODE_VERSION-$NODE_PLATFORM/bin"
+if [ ! -x "$NODE_BIN/node" ]; then
+  echo "downloading node v$NODE_VERSION ($NODE_PLATFORM)"
+  mkdir -p "$NODE_DIST"
+  curl -fsSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-$NODE_PLATFORM.tar.gz" \
+    | tar xz -C "$NODE_DIST"
 fi
+export PATH="$NODE_BIN:$PATH"
+echo "using node $(node -v)"
 
 if ! command -v bun >/dev/null 2>&1; then
   echo "ERROR: bun is required to bundle CJS harnesses" >&2
   exit 1
 fi
 
+# Build ExpoSE once (npm install + babel build of Distributor/Analyser).
+# build_all is not used directly: its prettier step (a devDependency) is
+# irrelevant for the build and npx is avoided — the repo-local
+# node_modules/.bin is prepended to PATH instead.
+if [ ! -f "$EXPOSE_DIR/Distributor/bin/Distributor.js" ]; then
+  echo "building ExpoSE (one-time setup)"
+  (cd "$EXPOSE_DIR" \
+    && npm install --no-audit --no-fund --omit=dev \
+    && export PATH="$EXPOSE_DIR/node_modules/.bin:$PATH" \
+    && EXPOSE_LOG_LEVEL=1 . ./scripts/build/build_babelconfig > babel.config.js \
+    && . ./scripts/build/build_libs \
+    && . ./scripts/build/build Distributor src bin \
+    && . ./scripts/build/build Analyser src bin \
+    && ./scripts/build/bundle Analyser bin/Analyser.js bin/bundle.js \
+    && rm babel.config.js)
+fi
+
+# Subpackage installs. Analyser/z3javascript are installed manually:
+# z3javascript's postinstall clones z3 over SSH and runs a python build
+# that assumes distutils (removed in python >= 3.12), so the pieces are
+# assembled here over HTTPS with --ignore-scripts instead.
+if [ ! -d "$EXPOSE_DIR/Distributor/node_modules" ]; then
+  echo "installing Distributor dependencies"
+  (cd "$EXPOSE_DIR/Distributor" && npm install --no-audit --no-fund --omit=dev)
+fi
+if [ ! -d "$EXPOSE_DIR/Analyser/node_modules" ]; then
+  echo "installing Analyser dependencies (ignore-scripts)"
+  (cd "$EXPOSE_DIR/Analyser" && npm install --no-audit --no-fund --ignore-scripts)
+fi
+if [ ! -d "$EXPOSE_DIR/Analyser/node_modules/jalangi2/node_modules" ]; then
+  echo "installing jalangi2 dependencies"
+  (cd "$EXPOSE_DIR/Analyser/node_modules/jalangi2" && npm install --no-audit --no-fund)
+fi
+if [ ! -d "$Z3JS_DIR" ]; then
+  echo "cloning z3javascript"
+  git clone https://github.com/ExpoSEJS/z3javascript.git "$Z3JS_DIR"
+  (cd "$Z3JS_DIR" && npm install --no-audit --no-fund --ignore-scripts)
+fi
+if [ ! -d "$Z3_DIR" ]; then
+  echo "cloning the vendored z3 fork (8f3b923)"
+  git clone https://github.com/ExpoSEJS/z3.git "$Z3_DIR"
+  git -C "$Z3_DIR" checkout 8f3b923
+fi
+
+z3_built() {
+  [ -e "$Z3JS_DIR/bin/libz3.dylib" ] || [ -e "$Z3JS_DIR/bin/libz3.so" ]
+}
+
+if ! z3_built; then
+  echo "building z3 (cmake; may fail on modern clang — see header comment)"
+  (
+    cd "$Z3_DIR" \
+      && rm -rf build \
+      && cmake -S . -B build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+      && cmake --build build --parallel "$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)" \
+      && cp build/libz3* "$Z3JS_DIR/bin/"
+  ) || true
+fi
+
+if ! z3_built; then
+  cat >&2 <<'EOF'
+ERROR: the vendored z3 fork could not be built on this machine.
+
+The ExpoSEJS/z3 fork (8f3b923) is 2019-era C++ and modern clang rejects
+it (two-phase template lookup errors in src/math/lp/*.h). ExpoSE
+analysis cannot run without libz3.
+
+Workarounds:
+  - run this script on Linux with an older GCC toolchain
+  - or install an older Xcode command-line tools release
+The CrossHair pass (scripts/symbolic/run-crosshair.sh) and the property
+suites (pnpm test / uv run --group test pytest) remain the soundness
+gates and run everywhere.
+EOF
+  exit 1
+fi
+
+# JS-side ffi bindings are plain file concatenations (no native build).
+if [ ! -f "$Z3JS_DIR/bin/z3_bindings_built.js" ] || [ ! -f "$Z3JS_DIR/bin/package.js" ]; then
+  echo "assembling z3javascript ffi bindings"
+  (cd "$Z3JS_DIR" \
+    && ./scripts/copy_bindings \
+    && ./scripts/binds \
+    && cp ./bin/z3_bindings_ref.js ./bin/package.js)
+fi
+
 FAILED=0
 for harness in "$ROOT"/scripts/symbolic/harnesses/*.src.js; do
   name="$(basename "$harness" .src.js)"
   bun build "$harness" --format=cjs --outfile "$HARNESS_OUT/$name.cjs"
+  # Concrete-mode smoke run: every harness executes standalone (J$ absent)
+  # and prints "ok" before any symbolic machinery gets involved.
+  echo "=== concrete smoke: $name ==="
+  node "$HARNESS_OUT/$name.cjs"
   echo "=== ExpoSE: $name ==="
   if (cd "$EXPOSE_DIR" && EXPOSE_MAX_TIME=60000 ./expoSE "$HARNESS_OUT/$name.cjs"); then
     echo "=== $name: OK ==="


### PR DESCRIPTION
## Summary

Implements the full approved test plan: BDD-first test suites for JS and Python, property-based tests, coverage gates (80% lines + 80% branches) enforced in CI, and a symbolic verification workflow.

- **BDD (JS)**: 309 cucumber-js scenarios across `features/` covering the pure core, Slack layer, GitHub tools, opengrep tooling, and PR step modules. Shared mock factories and DI seams in `features/support/world.js`.
- **BDD (Python)**: 72 pytest-bdd scenarios for the four scanners (`modelscan-audit.py`, `npm-audit.py`, `pip-audit.py`, `scripttagextractor.py`).
- **Property tests**: fast-check (JS, 43 properties) + Hypothesis (Python, 9 properties).
- **Coverage gates**: `pnpm run coverage` (c8, 80/80 on `src/**/*.js`) and `pnpm run coverage:py` (pytest-cov, 80/80 on the Python scanners), both wired into `lint.yml`.
- **Symbolic verification** (manual, workflow_dispatch): CrossHair contracts for Python scanners (passing) and ExpoSE harnesses for pure JS functions (best-effort; the vendored z3 fork does not build with modern clang).
- **DI refactors** (backward compatible): injectable `exec`/`fs`/`fetch` seams in `opengrepCompare`, `installOpengrep`, `updateOpengrepVersion`; `find_lock_file_line` extracted in `npm-audit.py`.
- Superseded suites retired: `modelscanPostComments.test.js`, `dependabotNudge.test.js`, `assets/modelscan-audit.test.py`.

## Test plan

- [x] `pnpm test` (309 scenarios, 73 JS unit/property tests)
- [x] `uv run --group test pytest` (72 passed)
- [x] `pnpm run coverage` — JS 95.5% lines / 89.94% branches (gate 80/80)
- [x] `pnpm run coverage:py` — Python 89.06% lines / 91.67% branches (gate 80/80)
- [x] `pnpm exec standard --ignore assets/opengrep_rules` — clean
- [x] `bash scripts/symbolic/run-crosshair.sh` — exit 0, no counterexamples