### PR TITLE
test: pytest-bdd suite for the Python scanners

### DIFF
--- a/assets/npm-audit.py
+++ b/assets/npm-audit.py
@@ -7,7 +7,30 @@ import tempfile
 from os import environ, path
 
 
-def main():
+def find_lock_file_line(lock_file_lines, node_name):
+    """1-based line number of a package-lock.json entry for node_name.
+
+    Looks for `"node_name": {` first; when the node is nested under
+    node_modules/ and not found directly, retries with the prefix stripped.
+    Raises StopIteration when no entry matches.
+    """
+    search_for = f'"{node_name}": {{'
+    try:
+        return next(
+            lineno for lineno, line in enumerate(lock_file_lines)
+            if line.strip() == search_for
+        ) + 2
+    except StopIteration:
+        if not node_name.startswith("node_modules/"):
+            raise
+        search_for = f'"{node_name[len("node_modules/"):]}": {{'
+        return next(
+            lineno for lineno, line in enumerate(lock_file_lines)
+            if line.strip() == search_for
+        ) + 2
+
+
+def main(_run=subprocess.run, _which=shutil.which, _mkdtemp=tempfile.TemporaryDirectory, _copy=shutil.copy):
     with open(path.join(environ["SCRIPTPATH"], "all_changed_files.txt")) as all_changed_files:
         files = all_changed_files.read()
         changed_lock_files = [
@@ -16,14 +39,14 @@ def main():
         ]
     # Create temporary directory just for the package-lock.json file
     # without a parent directory containing package.json files
-    with tempfile.TemporaryDirectory(dir="../") as temp_dir:
+    with _mkdtemp(dir="../") as temp_dir:
         temp_file_path = path.join(temp_dir, 'package-lock.json')
         for lock_path in changed_lock_files:
             with open(lock_path) as lock_file:
                 lock_file_lines = lock_file.readlines()
-            shutil.copy(lock_path, temp_file_path)
-            process_output = subprocess.run(
-                [shutil.which("npm"), "audit", "--package-lock-only", "--json"],
+            _copy(lock_path, temp_file_path)
+            process_output = _run(
+                [_which("npm"), "audit", "--package-lock-only", "--json"],
                 cwd=temp_dir,
                 capture_output=True,
             )
@@ -34,22 +57,11 @@ def main():
                     via = vulnerability["via"][0]
                     source = via.get("url", "")
                     node_name = vulnerability["nodes"][0]
-                    search_for = f'"{node_name}": {{'
                     try:
-                        line = next(
-                            lineno for lineno, line in enumerate(lock_file_lines)
-                            if line.strip() == search_for
-                        ) + 2
+                        line = find_lock_file_line(lock_file_lines, node_name)
                     except StopIteration:
-                        if node_name.startswith("node_modules/"):
-                            search_for = f'"{node_name[len("node_modules/"):]}": {{'
-                            line = next(
-                                lineno for lineno, line in enumerate(lock_file_lines)
-                                if line.strip() == search_for
-                            ) + 2
-                        else:
-                            print("Cannot find", search_for, vulnerability, file=sys.stderr)
-                            raise
+                        print("Cannot find", f'"{node_name}": {{', vulnerability, file=sys.stderr)
+                        raise
                     if source:
                         source = f"<br /><br />See {source}"
                     print(f"{severity}:{lock_path}:{line} {via.get('title')}{source}")

--- a/assets/tests/conftest.py
+++ b/assets/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for the Python scanner BDD suites.
+
+Scanner scripts live directly under assets/ and use hyphenated filenames,
+so they are loaded via importlib instead of normal imports.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ASSETS = Path(__file__).resolve().parent.parent
+
+
+def _load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, ASSETS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def modelscan_audit():
+    return _load_module("modelscan_audit_under_test", "modelscan-audit.py")
+
+
+@pytest.fixture
+def npm_audit():
+    return _load_module("npm_audit_under_test", "npm-audit.py")
+
+
+@pytest.fixture
+def pip_audit():
+    return _load_module("pip_audit_under_test", "pip-audit.py")
+
+
+@pytest.fixture
+def scripttagextractor():
+    return _load_module("scripttagextractor_under_test", "scripttagextractor.py")
+
+
+@pytest.fixture
+def context():
+    """Mutable state shared between Given/When/Then steps of a scenario."""
+    return {}

--- a/assets/tests/features/modelscan_audit.feature
+++ b/assets/tests/features/modelscan_audit.feature
@@ -1,0 +1,121 @@
+Feature: modelscan audit scanner
+  Identify model files by magic bytes and report scan findings as JSON lines.
+
+  Scenario: Unset scanner selection enables every scanner
+    Given no scanner selection
+    Then every scanner is enabled
+
+  Scenario: Explicit all enables every scanner
+    Given the scanner selection "all"
+    Then every scanner is enabled
+
+  Scenario Outline: Falsey selections disable the scanner
+    Given the scanner selection "<selection>"
+    Then no scanner is enabled
+
+    Examples:
+      | selection |
+      | false     |
+      |  FALSE    |
+
+  Scenario: An empty selection disables the scanner
+    Given the empty scanner selection
+    Then no scanner is enabled
+
+  Scenario: A scanner list is normalized
+    Given the scanner selection " Pickle , pytorch "
+    Then the enabled scanners are "pickle,pytorch"
+
+  Scenario: Unknown scanners are warned about and ignored
+    Given the scanner selection "pickle,bogus"
+    Then the enabled scanners are "pickle"
+    And a warning mentions "bogus"
+
+  Scenario Outline: Model files are identified by magic bytes or suffix
+    Given a model file "<file>" with <magic> content
+    Then the file is identified as "<scanner>" with heavyweight "<heavy>"
+
+    Examples:
+      | file    | magic           | scanner     | heavy |
+      | m.pkl   | pickle protocol | pickle      | no    |
+      | m.npy   | numpy           | numpy       | no    |
+      | m.bin   | pytorch zip     | pytorch     | no    |
+      | m.h5    | h5              | h5          | yes   |
+      | m.keras | h5              | keras       | yes   |
+      | m.pb    | anything        | saved_model | yes   |
+      | m.txt   | unknown         | nothing     | no    |
+      | m.pkl   | bad pickle      | nothing     | no    |
+      | m.pkl   | truncated pickle| nothing     | no    |
+
+  Scenario: Missing files are not identified
+    When identifying the file "does-not-exist.bin"
+    Then the file is identified as "nothing" with heavyweight "no"
+
+  Scenario: Issues are emitted as JSON lines
+    Given an issue with severity "HIGH" and details "eval call|__builtin__|eval|pickle"
+    When emitting the issue for "m.pkl"
+    Then the JSON output line is
+      """
+      {"path": "m.pkl", "severity": "HIGH", "description": "eval call", "module": "__builtin__", "operator": "eval", "scanner": "pickle"}
+      """
+
+  Scenario: output_json details take precedence
+    Given an issue with output_json details
+    When emitting the issue for "m.bin"
+    Then the JSON output has description "fresh" and severity "CRITICAL"
+
+  Scenario: Missing optional dependencies log and return nothing
+    Given a scanner whose import fails with ImportError
+    When scanning "m.keras" with it
+    Then the scan result is none
+    And the error output mentions "tensorflow"
+
+  Scenario: Optional dependency scan failures are logged
+    Given a scanner that raises while scanning
+    When scanning "m.keras" with it
+    Then the scan result is none
+    And the error output mentions "boom"
+
+  Scenario: Optional dependency scan results pass through
+    Given a scanner that returns a result
+    When scanning "m.keras" with it
+    Then the scan result is the scanner result
+
+  Scenario: A missing file list exits with status 1
+    Given a script directory without a file list
+    When running the audit
+    Then the audit exits with status 1
+
+  Scenario: Disabled scanners produce no output
+    Given a file list with "m.pkl"
+    And the scanner selection "false"
+    When running the audit
+    Then the audit output is empty
+
+  Scenario: Findings are scanned and emitted
+    Given a file list with a pickle file
+    And the scanner selection "pickle"
+    And the pickle scanner returns one issue
+    When running the audit
+    Then the JSON output has description "eval" and severity "HIGH"
+
+  Scenario: Disabled scanners skip their files
+    Given a file list with an h5 file
+    And the scanner selection "pickle"
+    And the h5 scanner must not run
+    When running the audit
+    Then the audit output is empty
+
+  Scenario: Scan failures are logged and skipped
+    Given a file list with a pickle file
+    And the scanner selection "pickle"
+    And the pickle scanner raises "boom"
+    When running the audit
+    Then the audit output is empty
+    And the error output mentions "boom"
+
+  Scenario: Missing SCRIPTPATH falls back to the script directory
+    Given no SCRIPTPATH
+    And the scanner selection "false"
+    When running the audit
+    Then the audit output is empty

--- a/assets/tests/features/npm_audit.feature
+++ b/assets/tests/features/npm_audit.feature
@@ -1,0 +1,90 @@
+Feature: npm audit scanner
+  The npm audit wrapper reports lock file findings with line numbers.
+
+  Scenario: Direct lock file entry lookup
+    Given a lock file containing
+      """
+      "lodash": {
+        "version": "1.0.0"
+      """
+    Then the line for "lodash" is 2
+
+  Scenario: Nested node names fall back to the stripped name
+    Given a lock file containing
+      """
+      "lodash": {
+        "version": "1.0.0"
+      """
+    Then the line for "node_modules/lodash" is 2
+
+  Scenario: Unknown nodes raise StopIteration
+    Given a lock file containing
+      """
+      "lodash": {
+      """
+    Then looking up "missing" raises StopIteration
+
+  Scenario: Unknown nested nodes raise StopIteration after fallback
+    Given a lock file containing
+      """
+      "other": {
+      """
+    Then looking up "node_modules/missing" raises StopIteration
+
+  Scenario: Only lock files are audited
+    Given the changed files
+      """
+      src/index.js
+      docs/readme.md
+      """
+    And a "high" vulnerability in "lodash" titled "Prototype pollution" with url "https://example.com/advisory"
+    When the audit runs
+    Then no vulnerability is reported
+
+  Scenario: Vulnerable dependencies are reported with line numbers
+    Given a lock file containing
+      """
+      "lodash": {
+        "version": "1.0.0"
+      """
+    And the lock file is among the changed files
+    And a "high" vulnerability in "lodash" titled "Prototype pollution" with url "https://example.com/advisory"
+    When the audit runs
+    Then the output matches the finding pattern
+      """
+      H:.+:2 Prototype pollution<br /><br />See https://example.com/advisory
+      """
+
+  Scenario: Vulnerabilities without a URL omit the reference
+    Given a lock file containing
+      """
+      "lodash": {
+      """
+    And the lock file is among the changed files
+    And a "moderate" vulnerability in "lodash" titled "Timing attack" without a url
+    When the audit runs
+    Then the output matches the finding pattern
+      """
+      M:.+:2 Timing attack
+      """
+
+  Scenario: Vulnerabilities reported via a string are skipped
+    Given a lock file containing
+      """
+      "lodash": {
+      """
+    And the lock file is among the changed files
+    And a "high" vulnerability in "lodash" reported via a string
+    When the audit runs
+    Then no vulnerability is reported
+
+  Scenario: A node missing from the lock file aborts the audit
+    Given a lock file containing
+      """
+      "other": {
+      """
+    And the lock file is among the changed files
+    And a "high" vulnerability in "missing" titled "Prototype pollution" without a url
+    When the audit runs
+    Then the audit aborts with StopIteration
+    And stderr mentions the node "missing"

--- a/assets/tests/features/pip_audit.feature
+++ b/assets/tests/features/pip_audit.feature
@@ -1,0 +1,210 @@
+Feature: pip audit scanner
+  The pip audit wrapper audits requirements and pyproject lock files.
+
+  Scenario: Requirements lines yield install commands
+    Given a requirements file with the lines
+      """
+      django==1.0
+      # comment
+      --index-url https://example.com
+      -e ./
+      requests==2.0
+      """
+    And every line changed
+    Then the install commands are
+      | django==1.0 |
+      | requests==2.0 |
+
+  Scenario: Backslash continuations report the last line
+    Given a requirements file with the lines
+      """
+      django==1.0 \
+      --extra-arg
+      flask==2.0
+      """
+    And every line changed
+    Then the install commands with line numbers are
+      | django==1.0 | 2 |
+      | flask==2.0 | 3 |
+
+  Scenario: Only changed requirements lines are audited
+    Given a requirements file with the lines
+      """
+      django==1.0
+      requests==2.0
+      """
+    And the changed lines
+      | requests==2.0 |
+    Then the install commands are
+      | requests==2.0 |
+
+  Scenario: Pyproject dependencies yield per dependency
+    Given a pyproject file with the lines
+      """
+      [project]
+      dependencies = [
+        "requests>=2.0",
+        "django==1.0",
+      ]
+      """
+    And every line changed
+    Then the install commands with line numbers are
+      | requests>=2.0 | 3 |
+      | django==1.0 | 4 |
+
+  Scenario: Multiple dependencies on one line yield together
+    Given a pyproject file with the lines
+      """
+      [project]
+      dependencies = ["foo", "foobar"]
+      """
+    And every line changed
+    Then the install commands with line numbers are
+      | foo | 2 |
+      | foobar | 2 |
+
+  Scenario: Dependencies are matched only once
+    Given a pyproject file with the lines
+      """
+      [project]
+      dependencies = [
+        "requests",
+      ]
+      description = "requests everywhere"
+      """
+    And every line changed
+    Then the install commands with line numbers are
+      | requests | 3 |
+
+  Scenario: A pyproject without dependencies yields nothing
+    Given a pyproject file with the lines
+      """
+      [project]
+      name = "example"
+      """
+    And every line changed
+    Then no install command is yielded
+
+  Scenario: Commented pyproject lines are skipped
+    Given a pyproject file with the lines
+      """
+      [project]
+      dependencies = [
+        "requests",
+      ]
+      # requests
+      """
+    And every line changed
+    Then the install commands with line numbers are
+      | requests | 3 |
+
+  Scenario: Without a base ref every line is scanned
+    Given a requirements file with the lines
+      """
+      django==1.0
+      requests==2.0
+      """
+    And the file is written to disk without a base ref
+    Then the install commands from the file are
+      | django==1.0 | 1 |
+      | requests==2.0 | 2 |
+
+  Scenario: With a base ref only diff lines are scanned
+    Given a requirements file with the lines
+      """
+      django==1.0
+      requests==2.0
+      """
+    And the file is written to disk with base ref "main" and the diff
+      """
+      --- a/requirements.txt
+      +++ b/requirements.txt
+      +requests==2.0
+      """
+    Then the install commands from the file are
+      | requests==2.0 | 2 |
+
+  Scenario: Vulnerable dependencies are reported
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the audit reports the vulnerability "GHSA-1" for "django" version "1.0"
+    When the audit runs
+    Then the output matches the finding pattern
+      """
+      M:.+:1 Requiring `django==1.0` imports packages with known vulnerabilities:<br><br>django 1.0:<br>1. GHSA-1<br><br>
+      """
+
+  Scenario: Vulnerabilities without aliases use their id
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the audit reports the id-only vulnerability "PYSEC-9" for "django" version "1.0"
+    When the audit runs
+    Then the output matches the finding pattern
+      """
+      M:.+:1 Requiring `django==1.0` imports packages with known vulnerabilities:<br><br>django 1.0:<br>1. PYSEC-9<br><br>
+      """
+
+  Scenario: Clean dependencies are not reported
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the audit reports no vulnerabilities
+    When the audit runs
+    Then no finding is printed
+
+  Scenario: A venv failure is printed and skipped
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the venv creation fails with "boom"
+    When the audit runs
+    Then no finding is printed
+    And the venv failure "boom" is printed
+
+  Scenario: An audit timeout is printed and skipped
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the audit times out with "timed out"
+    When the audit runs
+    Then no finding is printed
+    And the venv failure "timed out" is printed
+
+  Scenario: The index and insecure hosts are passed to the venv
+    Given a requirements file with the lines
+      """
+      django==1.0
+      """
+    And the file is written to disk without a base ref
+    And the file is among the changed files
+    And the audit reports no vulnerabilities
+    And the PyPI index "https://pypi.example" with insecure hosts "host1,host2"
+    When the audit runs
+    Then the venv is created with install command "django==1.0 --trusted-host host1 --trusted-host host2" and index "https://pypi.example"
+
+  Scenario: Only dependency lock files are audited
+    Given the changed files
+      """
+      src/index.py
+      docs/readme.md
+      """
+    And the audit reports the vulnerability "GHSA-1" for "django" version "1.0"
+    When the audit runs
+    Then no finding is printed

--- a/assets/tests/features/scripttagextractor.feature
+++ b/assets/tests/features/scripttagextractor.feature
@@ -1,0 +1,90 @@
+Feature: script tag extractor
+  The extractor pulls <script> contents into separate files for semgrep.
+
+  Scenario: Script contents are captured with positions
+    Given an HTML document
+      """
+      <html>
+      <script>
+      var a = 1;
+      </script>
+      </html>
+      """
+    When the document is parsed
+    Then one script is found at line 2
+    And the script data contains "var a = 1;"
+
+  Scenario: Text outside script tags is ignored
+    Given an HTML document
+      """
+      <html><style>body { color: red; }</style><p>hello</p></html>
+      """
+    When the document is parsed
+    Then no script is found
+
+  Scenario: Tags are matched case-insensitively
+    Given an HTML document
+      """
+      <SCRIPT>var b = 2;</SCRIPT>
+      """
+    When the document is parsed
+    Then one script is found at line 1
+    And the script data contains "var b = 2;"
+
+  Scenario: Found scripts count their new lines
+    Given a found script with the data
+      """
+      a
+      b
+      c
+      """
+    Then the script spans 2 new lines
+
+  Scenario: Extracted scripts are aligned to their original lines
+    Given an HTML document
+      """
+      <html>
+      <script>a</script>
+      <p>text</p>
+      <script>b</script>
+      </html>
+      """
+    When the scripts are extracted
+    Then the extracted file "page.html.extractedscript.js" contains exactly
+      """
+
+      ; a
+
+      ; b
+      """
+
+  Scenario: The original can be copied with a suffix
+    Given an HTML document
+      """
+      <html><script>a</script></html>
+      """
+    When the scripts are extracted with the original copied to ".orig.html"
+    Then the extracted file "page.html.extractedscript.js" contains exactly
+      """
+      ; a
+      """
+    And the copied file "page.html.orig.html" contains exactly
+      """
+      <html><script>a</script></html>
+      """
+
+  Scenario: A dry run writes nothing
+    Given an HTML document
+      """
+      <html><script>a</script></html>
+      """
+    When a dry run extracts the scripts
+    Then the extracted file "page.html.extractedscript.js" does not exist
+
+  Scenario: Documents without scripts produce no output file
+    Given an HTML document
+      """
+      <html><p>hello</p></html>
+      """
+    When the scripts are extracted
+    Then the extracted file "page.html.extractedscript.js" does not exist

--- a/assets/tests/step_defs/test_modelscan_audit.py
+++ b/assets/tests/step_defs/test_modelscan_audit.py
@@ -1,0 +1,296 @@
+"""pytest-bdd steps for modelscan_audit.feature"""
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from pytest_bdd import given, when, then, scenarios, parsers
+
+
+@pytest.fixture(autouse=True)
+def _activate_output_capture(capsys):
+    """Start capture before any step runs — steps print via print()."""
+    yield
+
+
+scenarios("../features/modelscan_audit.feature")
+
+MAGIC_CONTENTS = {
+    "pickle protocol": b"\x80\x02}q\x00.",
+    "numpy": b"\x93NUMPY\x01\x00\x76\x08",
+    "pytorch zip": b"PK\x03\x04data/archive.pkl",
+    "h5": b"\x89HDF\r\n\x1a\n\x00\x00",
+    "anything": b"\x00\x00\x00\x10whatever",
+    "unknown": b"hello world",
+    "bad pickle": b"\x80\xffjunk",
+    "truncated pickle": b"\x80",
+}
+
+
+class _Severity:
+    def __init__(self, name):
+        self.name = name
+
+
+def _issue(severity="HIGH", **details):
+    return SimpleNamespace(severity=_Severity(severity), details=SimpleNamespace(**details))
+
+
+# ── scanner selection ────────────────────────────────────────────────────────
+
+@given("no scanner selection")
+def no_scanner_selection(monkeypatch):
+    monkeypatch.delenv("MODELSCAN_ENABLED_SCANNERS", raising=False)
+
+
+@given(parsers.parse('the scanner selection "{selection}"'))
+def scanner_selection(monkeypatch, selection):
+    monkeypatch.setenv("MODELSCAN_ENABLED_SCANNERS", selection)
+
+
+@given("the empty scanner selection")
+def empty_scanner_selection(monkeypatch):
+    monkeypatch.setenv("MODELSCAN_ENABLED_SCANNERS", "")
+
+
+@then("every scanner is enabled")
+def every_scanner_enabled(modelscan_audit):
+    assert modelscan_audit._enabled_scanners() == set(modelscan_audit.ALL_SCANNERS)
+
+
+@then("no scanner is enabled")
+def no_scanner_enabled(modelscan_audit):
+    assert modelscan_audit._enabled_scanners() == set()
+
+
+@then(parsers.parse('the enabled scanners are "{expected}"'))
+def enabled_scanners_are(modelscan_audit, expected):
+    assert modelscan_audit._enabled_scanners() == set(expected.split(","))
+
+
+@then(parsers.parse('a warning mentions "{text}"'))
+def warning_mentions(capsys, text):
+    assert text in capsys.readouterr().err
+
+
+# ── file identification ──────────────────────────────────────────────────────
+
+@given(parsers.parse('a model file "{filename}" with {magic} content'))
+def model_file(modelscan_audit, tmp_path, context, filename, magic):
+    target = tmp_path / filename
+    target.write_bytes(MAGIC_CONTENTS[magic])
+    context["script_dir"] = tmp_path
+    context["identified"] = modelscan_audit._identify_file(str(target))
+
+
+@when(parsers.parse('identifying the file "{filename}"'))
+def identify_file(modelscan_audit, tmp_path, context, filename):
+    context.setdefault("script_dir", tmp_path)
+    context["identified"] = modelscan_audit._identify_file(str(context["script_dir"] / filename))
+
+
+@then(parsers.parse('the file is identified as "{scanner}" with heavyweight "{heavy}"'))
+def file_identified_as(context, scanner, heavy):
+    expected = (scanner, heavy == "yes") if scanner != "nothing" else (None, False)
+    assert context["identified"] == expected
+
+
+# ── issue emission ───────────────────────────────────────────────────────────
+
+@given(parsers.parse('an issue with severity "{severity}" and details "{details}"'))
+def issue_with_details(context, severity, details):
+    description, module, operator, scanner = details.split("|")
+    context["issue"] = _issue(
+        severity, description=description, module=module, operator=operator, scanner=scanner
+    )
+
+
+@given("an issue with output_json details")
+def issue_with_output_json(context):
+    details = SimpleNamespace(
+        description="stale", module="stale", operator="stale", scanner="stale",
+        output_json=lambda: {
+            "description": "fresh", "module": "os",
+            "operator": "system", "scanner": "pytorch",
+        },
+    )
+    context["issue"] = SimpleNamespace(severity=_Severity("CRITICAL"), details=details)
+
+
+@when(parsers.parse('emitting the issue for "{path}"'))
+def emit_issue(modelscan_audit, context, path):
+    modelscan_audit._emit_issue(path, context["issue"])
+
+
+@then("the JSON output line is")
+def json_output_line(capsys, docstring):
+    assert capsys.readouterr().out.strip() == docstring.strip()
+
+
+@then(parsers.parse('the JSON output has description "{description}" and severity "{severity}"'))
+def json_output_fields(capsys, description, severity):
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["description"] == description
+    assert payload["severity"] == severity
+
+
+# ── optional dependency scanners ─────────────────────────────────────────────
+
+@given("a scanner whose import fails with ImportError")
+def scanner_import_fails(context):
+    context["scanner"] = {"importer": lambda: (_ for _ in ()).throw(ImportError("no tensorflow"))}
+
+
+@given("a scanner that raises while scanning")
+def scanner_raises(context):
+    class ExplodingScan:
+        def __init__(self, settings):
+            pass
+
+        def scan(self, model):
+            raise RuntimeError("boom")
+
+    context["scanner"] = {"importer": lambda: ExplodingScan}
+
+
+@given("a scanner that returns a result")
+def scanner_returns(context):
+    scan_result = object()
+
+    class OkScan:
+        def __init__(self, settings):
+            pass
+
+        def scan(self, model):
+            return scan_result
+
+    context["scanner"] = {"importer": lambda: OkScan, "result": scan_result}
+
+
+@when(parsers.parse('scanning "{path}" with it'))
+def scan_with_optional_dep(modelscan_audit, monkeypatch, context, path):
+    scanner = context["scanner"]
+    monkeypatch.setitem(sys.modules, "modelscan.settings", SimpleNamespace(DEFAULT_SETTINGS="S"))
+    monkeypatch.setitem(sys.modules, "modelscan.model", SimpleNamespace(Model=lambda p: p))
+    scan = modelscan_audit._scan_optional_dep(scanner["importer"], "Scan", "tensorflow")
+    context["scan_result"] = scan(path)
+
+
+@then("the scan result is none")
+def scan_result_is_none(context):
+    assert context["scan_result"] is None
+
+
+@then("the scan result is the scanner result")
+def scan_result_is_passed_through(context):
+    assert context["scan_result"] is context["scanner"]["result"]
+
+
+@then(parsers.parse('the error output mentions "{text}"'))
+def error_output_mentions(capsys, context, text):
+    err = context.get("audit_err")
+    if err is None:
+        err = capsys.readouterr().err
+    assert text in err
+
+
+# ── main flow ────────────────────────────────────────────────────────────────
+
+def _write_file_list(tmp_path, entries):
+    (tmp_path / "all_changed_files.txt").write_text("\0".join(entries) + "\0")
+
+
+@given("a script directory without a file list")
+def script_dir_without_file_list(tmp_path, context, monkeypatch):
+    context["script_dir"] = tmp_path
+    monkeypatch.setenv("SCRIPTPATH", str(tmp_path))
+
+
+@given(parsers.parse('a file list with "{filename}"'))
+def file_list_with_filename(tmp_path, context, monkeypatch, filename):
+    _write_file_list(tmp_path, [filename])
+    context["script_dir"] = tmp_path
+    monkeypatch.setenv("SCRIPTPATH", str(tmp_path))
+
+
+@given("a file list with a pickle file")
+def file_list_with_pickle_file(tmp_path, context, monkeypatch):
+    target = tmp_path / "bad.pkl"
+    target.write_bytes(b"\x80\x02}q\x00.")
+    _write_file_list(tmp_path, [str(target)])
+    context["script_dir"] = tmp_path
+    monkeypatch.setenv("SCRIPTPATH", str(tmp_path))
+    context["scan_target"] = str(target)
+
+
+@given("a file list with an h5 file")
+def file_list_with_h5_file(tmp_path, context, monkeypatch):
+    target = tmp_path / "m.h5"
+    target.write_bytes(b"\x89HDF\r\n\x1a\n\x00\x00")
+    _write_file_list(tmp_path, [str(target)])
+    context["script_dir"] = tmp_path
+    monkeypatch.setenv("SCRIPTPATH", str(tmp_path))
+
+
+@given("the pickle scanner returns one issue")
+def pickle_scanner_returns_issue(context):
+    def fake_scan(path):
+        assert path == context["scan_target"]
+        return SimpleNamespace(issues=[_issue(
+            description="eval", module="__builtin__", operator="eval", scanner="pickle"
+        )])
+
+    context["fake_scans"] = {"pickle": fake_scan}
+
+
+@given("the h5 scanner must not run")
+def h5_scanner_must_not_run(context):
+    def boom(path):
+        raise AssertionError("h5 scanner must not run")
+
+    context["fake_scans"] = {"h5": boom}
+
+
+@given(parsers.parse('the pickle scanner raises "{message}"'))
+def pickle_scanner_raises(context, message):
+    def broken_scan(path):
+        raise RuntimeError(message)
+
+    context["fake_scans"] = {"pickle": broken_scan}
+
+
+@given("no SCRIPTPATH")
+def no_scriptpath(monkeypatch, tmp_path, context):
+    monkeypatch.delenv("SCRIPTPATH", raising=False)
+    _write_file_list(tmp_path, ["m.pkl"])
+    context["script_dir"] = tmp_path
+    context["patch_script_file"] = True
+
+
+@when("running the audit")
+def run_audit(modelscan_audit, monkeypatch, context):
+    fake_scans = context.get("fake_scans")
+    if fake_scans:
+        for name, scan in fake_scans.items():
+            monkeypatch.setitem(modelscan_audit.SCAN_DISPATCH, name, scan)
+    if context.get("patch_script_file"):
+        monkeypatch.setattr(
+            modelscan_audit, "__file__", str(context["script_dir"] / "modelscan-audit.py")
+        )
+    context["exit"] = None
+    try:
+        modelscan_audit.main()
+    except SystemExit as e:
+        context["exit"] = e.code
+
+
+@then("the audit exits with status 1")
+def audit_exits_1(context):
+    assert context["exit"] == 1
+
+
+@then("the audit output is empty")
+def audit_output_empty(capsys, context):
+    captured = capsys.readouterr()
+    context["audit_err"] = captured.err
+    assert captured.out == ""

--- a/assets/tests/step_defs/test_npm_audit.py
+++ b/assets/tests/step_defs/test_npm_audit.py
@@ -1,0 +1,143 @@
+"""pytest-bdd steps for npm_audit.feature"""
+import contextlib
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+from pytest_bdd import given, when, then, scenarios, parsers
+
+
+@pytest.fixture(autouse=True)
+def _activate_output_capture(capsys):
+    """Start capture before any step runs — steps print via print()."""
+    yield
+
+
+scenarios("../features/npm_audit.feature")
+
+
+def _capture(context, capsys):
+    if "audit_out" not in context:
+        captured = capsys.readouterr()
+        context["audit_out"] = captured.out
+        context["audit_err"] = captured.err
+
+
+# ── lock file line lookup ────────────────────────────────────────────────────
+
+@given("a lock file containing")
+def lock_file(tmp_path, context, docstring):
+    target = tmp_path / "package-lock.json"
+    target.write_text(docstring + "\n")
+    context["lock_path"] = str(target)
+
+
+@then(parsers.parse('the line for "{node}" is {line:d}'))
+def line_for(npm_audit, context, node, line):
+    with open(context["lock_path"]) as f:
+        lines = f.readlines()
+    assert npm_audit.find_lock_file_line(lines, node) == line
+
+
+@then(parsers.parse('looking up "{node}" raises StopIteration'))
+def lookup_raises(npm_audit, context, node):
+    with open(context["lock_path"]) as f:
+        lines = f.readlines()
+    with pytest.raises(StopIteration):
+        npm_audit.find_lock_file_line(lines, node)
+
+
+# ── audit report fixtures ────────────────────────────────────────────────────
+
+@given("the changed files")
+def changed_files(context, docstring):
+    context.setdefault("changed_files", []).extend(docstring.splitlines())
+
+
+@given("the lock file is among the changed files")
+def lock_file_changed(context):
+    context.setdefault("changed_files", []).append(context["lock_path"])
+
+
+@given(parsers.parse('a "{severity}" vulnerability in "{node}" titled "{title}" with url "{url}"'))
+def vulnerability_with_url(context, severity, node, title, url):
+    context.setdefault("vulnerabilities", {})[node] = {
+        "severity": severity,
+        "via": [{"title": title, "url": url}],
+        "nodes": [node],
+    }
+
+
+@given(parsers.parse('a "{severity}" vulnerability in "{node}" titled "{title}" without a url'))
+def vulnerability_without_url(context, severity, node, title):
+    context.setdefault("vulnerabilities", {})[node] = {
+        "severity": severity,
+        "via": [{"title": title}],
+        "nodes": [node],
+    }
+
+
+@given(parsers.parse('a "{severity}" vulnerability in "{node}" reported via a string'))
+def vulnerability_via_string(context, severity, node):
+    context.setdefault("vulnerabilities", {})[node] = {
+        "severity": severity,
+        "via": ["lodash"],
+        "nodes": [node],
+    }
+
+
+# ── run main with fakes ──────────────────────────────────────────────────────
+
+@when("the audit runs")
+def audit_runs(npm_audit, monkeypatch, tmp_path, context):
+    script_dir = tmp_path / "scriptpath"
+    script_dir.mkdir(exist_ok=True)
+    changed = context.get("changed_files", [])
+    (script_dir / "all_changed_files.txt").write_bytes("\x00".join(changed).encode())
+    monkeypatch.setenv("SCRIPTPATH", str(script_dir))
+
+    stdout = json.dumps({"vulnerabilities": context.get("vulnerabilities", {})}).encode()
+
+    def fake_run(args, cwd=None, capture_output=False):
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr=b"")
+
+    @contextlib.contextmanager
+    def fake_mkdtemp(dir=None):
+        temp = tmp_path / "temp"
+        temp.mkdir(exist_ok=True)
+        yield str(temp)
+
+    try:
+        npm_audit.main(_run=fake_run, _which=lambda name: "npm", _mkdtemp=fake_mkdtemp, _copy=shutil.copy)
+    except BaseException as exc:  # noqa: BLE001
+        context["error"] = exc
+
+
+# ── assertions ───────────────────────────────────────────────────────────────
+
+@then("no vulnerability is reported")
+def no_vulnerability_reported(context, capsys):
+    _capture(context, capsys)
+    assert context["audit_out"] == ""
+
+
+@then("the output matches the finding pattern")
+def output_matches_pattern(context, capsys, docstring):
+    _capture(context, capsys)
+    pattern = re.compile(docstring)
+    assert any(pattern.fullmatch(line) for line in context["audit_out"].splitlines()), context["audit_out"]
+
+
+@then("the audit aborts with StopIteration")
+def audit_aborts(context):
+    assert isinstance(context.get("error"), StopIteration)
+
+
+@then(parsers.parse('stderr mentions the node "{node}"'))
+def stderr_mentions_node(context, capsys, node):
+    err = context.get("audit_err")
+    if err is None:
+        err = capsys.readouterr().err
+    assert node in err

--- a/assets/tests/step_defs/test_pip_audit.py
+++ b/assets/tests/step_defs/test_pip_audit.py
@@ -1,0 +1,230 @@
+"""pytest-bdd steps for pip_audit.feature"""
+import json
+import re
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+from pytest_bdd import given, when, then, scenarios, parsers
+
+
+@pytest.fixture(autouse=True)
+def _activate_output_capture(capsys):
+    """Start capture before any step runs — steps print via print()."""
+    yield
+
+
+scenarios("../features/pip_audit.feature")
+
+
+def _capture(context, capsys):
+    if "audit_out" not in context:
+        captured = capsys.readouterr()
+        context["audit_out"] = captured.out
+        context["audit_err"] = captured.err
+
+
+# ── lock file fixtures ───────────────────────────────────────────────────────
+
+@given("a requirements file with the lines")
+def requirements_lines(context, docstring):
+    context["lock_lines"] = docstring.splitlines()
+    context["lock_name"] = "requirements.txt"
+
+
+@given("a pyproject file with the lines")
+def pyproject_lines(context, docstring):
+    context["lock_lines"] = docstring.splitlines()
+    context["lock_name"] = "pyproject.toml"
+
+
+@given("every line changed")
+def every_line_changed(context):
+    context["diff_lines"] = set(context["lock_lines"])
+
+
+@given("the changed lines")
+def changed_lines(context, datatable):
+    context["diff_lines"] = {row[0] for row in datatable}
+
+
+@given("the file is written to disk without a base ref")
+def written_without_base_ref(tmp_path, context, monkeypatch):
+    target = tmp_path / context["lock_name"]
+    target.write_text("\n".join(context["lock_lines"]) + "\n")
+    context["lock_path"] = str(target)
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+
+
+@given(parsers.parse('the file is written to disk with base ref "{ref}" and the diff'))
+def written_with_base_ref(tmp_path, context, monkeypatch, pip_audit, ref, docstring):
+    target = tmp_path / context["lock_name"]
+    target.write_text("\n".join(context["lock_lines"]) + "\n")
+    context["lock_path"] = str(target)
+    monkeypatch.setenv("GITHUB_BASE_REF", ref)
+
+    def fake_run(args, capture_output=False):
+        return subprocess.CompletedProcess(args, 0, stdout=docstring.encode(), stderr=b"")
+
+    monkeypatch.setattr(pip_audit.subprocess, "run", fake_run)
+
+
+# ── generator assertions ─────────────────────────────────────────────────────
+
+@then("the install commands are")
+def install_commands_are(pip_audit, context, datatable):
+    expected = [row[0] for row in datatable]
+    result = list(pip_audit.install_commands_for_requirements_txt(
+        context["lock_lines"], context["diff_lines"]) if context["lock_name"] == "requirements.txt"
+        else pip_audit.install_commands_for_pyproject_toml(context["lock_lines"], context["diff_lines"]))
+    assert [cmd[0] for cmd, _ in result] == expected
+
+
+@then("the install commands with line numbers are")
+def install_commands_with_lines_are(pip_audit, context, datatable):
+    expected = sorted((row[0], int(row[1])) for row in datatable)
+    result = list(pip_audit.install_commands_for_requirements_txt(
+        context["lock_lines"], context["diff_lines"]) if context["lock_name"] == "requirements.txt"
+        else pip_audit.install_commands_for_pyproject_toml(context["lock_lines"], context["diff_lines"]))
+    assert sorted((cmd[0], line) for cmd, line in result) == expected
+
+
+@then("no install command is yielded")
+def no_install_command(pip_audit, context):
+    result = list(pip_audit.install_commands_for_requirements_txt(
+        context["lock_lines"], context["diff_lines"]) if context["lock_name"] == "requirements.txt"
+        else pip_audit.install_commands_for_pyproject_toml(context["lock_lines"], context["diff_lines"]))
+    assert result == []
+
+
+@then("the install commands from the file are")
+def install_commands_from_file(pip_audit, context, datatable):
+    expected = sorted((row[0], int(row[1])) for row in datatable)
+    result = list(pip_audit.install_commands(context["lock_path"]))
+    assert sorted((cmd[0], line) for cmd, line in result) == expected
+
+
+# ── main() fixtures ──────────────────────────────────────────────────────────
+
+@given("the changed files")
+def changed_files(context, docstring):
+    context.setdefault("changed_files", []).extend(docstring.splitlines())
+
+
+@given("the file is among the changed files")
+def file_among_changed(context):
+    context.setdefault("changed_files", []).append(context["lock_path"])
+
+
+@given(parsers.parse('the audit reports the vulnerability "{alias}" for "{name}" version "{version}"'))
+def audit_reports_vulnerability(context, alias, name, version):
+    context["audit_results"] = [(
+        SimpleNamespace(name=name, version=version),
+        [SimpleNamespace(aliases={alias}, id="PYSEC-0")],
+    )]
+
+
+@given(parsers.parse('the audit reports the id-only vulnerability "{vuln_id}" for "{name}" version "{version}"'))
+def audit_reports_id_only(context, vuln_id, name, version):
+    context["audit_results"] = [(
+        SimpleNamespace(name=name, version=version),
+        [SimpleNamespace(aliases=set(), id=vuln_id)],
+    )]
+
+
+@given("the audit reports no vulnerabilities")
+def audit_reports_none(context):
+    context["audit_results"] = []
+
+
+@given(parsers.parse('the venv creation fails with "{message}"'))
+def venv_creation_fails(context, message):
+    context["venv_error"] = message
+
+
+@given(parsers.parse('the audit times out with "{message}"'))
+def audit_times_out(context, message):
+    context["audit_timeout"] = message
+
+
+@given(parsers.parse('the PyPI index "{index}" with insecure hosts "{hosts}"'))
+def pypi_index(context, monkeypatch, index, hosts):
+    monkeypatch.setenv("PYPI_INDEX_URL", index)
+    monkeypatch.setenv("PYPI_INSECURE_HOSTS", hosts)
+
+
+# ── run main with fakes ──────────────────────────────────────────────────────
+
+@when("the audit runs")
+def audit_runs(pip_audit, monkeypatch, tmp_path, context):
+    script_dir = tmp_path / "scriptpath"
+    script_dir.mkdir(exist_ok=True)
+    changed = context.get("changed_files", [])
+    (script_dir / "all_changed_files.txt").write_bytes("\x00".join(changed).encode())
+    monkeypatch.setenv("SCRIPTPATH", str(script_dir))
+
+    venvs = []
+
+    class FakeVirtualEnv:
+        def __init__(self, install_cmd, index_url=None):
+            self.install_cmd = install_cmd
+            self.index_url = index_url
+            self.cleared = []
+            venvs.append(self)
+
+        def create(self, directory):
+            if "venv_error" in context:
+                raise pip_audit.VirtualEnvError(context["venv_error"])
+
+        def clear_directory(self, directory):
+            self.cleared.append(directory)
+
+    class FakeAuditor:
+        def __init__(self, service):
+            self.service = service
+
+        def audit(self, source):
+            if "audit_timeout" in context:
+                raise pip_audit.ReadTimeout(context["audit_timeout"])
+            return context.get("audit_results", [])
+
+    monkeypatch.setattr(pip_audit, "VirtualEnv", FakeVirtualEnv)
+    monkeypatch.setattr(pip_audit, "Auditor", FakeAuditor)
+    monkeypatch.setattr(pip_audit, "VulnerabilityServiceChoice",
+                        SimpleNamespace(Pypi=SimpleNamespace(to_service=lambda t, s: "svc")))
+
+    try:
+        pip_audit.main()
+    except BaseException as exc:  # noqa: BLE001
+        context["error"] = exc
+    context["venvs"] = venvs
+
+
+# ── main() assertions ────────────────────────────────────────────────────────
+
+@then("no finding is printed")
+def no_finding_printed(context, capsys):
+    _capture(context, capsys)
+    assert not [line for line in context["audit_out"].splitlines() if line.startswith("M:")]
+
+
+@then("the output matches the finding pattern")
+def output_matches_pattern(context, capsys, docstring):
+    _capture(context, capsys)
+    pattern = re.compile(docstring)
+    assert any(pattern.fullmatch(line) for line in context["audit_out"].splitlines()), context["audit_out"]
+
+
+@then(parsers.parse('the venv failure "{message}" is printed'))
+def venv_failure_printed(context, capsys, message):
+    _capture(context, capsys)
+    assert message in context["audit_out"]
+
+
+@then(parsers.parse('the venv is created with install command "{command}" and index "{index}"'))
+def venv_created_with(pip_audit, context, command, index):
+    assert len(context["venvs"]) == 1
+    venv = context["venvs"][0]
+    assert venv.install_cmd == command.split(" ")
+    assert venv.index_url == index
+    assert venv.cleared == ["./.venv-deleteme"]

--- a/assets/tests/step_defs/test_scripttagextractor.py
+++ b/assets/tests/step_defs/test_scripttagextractor.py
@@ -1,0 +1,84 @@
+"""pytest-bdd steps for scripttagextractor.feature"""
+from pytest_bdd import given, when, then, scenarios, parsers
+
+
+scenarios("../features/scripttagextractor.feature")
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+@given("an HTML document")
+def html_document(tmp_path, context, docstring):
+    source = tmp_path / "page.html"
+    source.write_text(docstring)
+    context["source_file"] = str(source)
+
+
+@given("a found script with the data")
+def found_script(scripttagextractor, context, docstring):
+    context["found_script"] = scripttagextractor.FoundScript(1, 0, docstring)
+
+
+# ── parsing ──────────────────────────────────────────────────────────────────
+
+@when("the document is parsed")
+def document_parsed(scripttagextractor, context):
+    parser = scripttagextractor.MyHTMLParser()
+    with open(context["source_file"]) as f:
+        parser.feed(f.read())
+    context["scripts"] = parser.scripts
+
+
+@then(parsers.parse("one script is found at line {line:d}"))
+def one_script_at_line(context, line):
+    assert len(context["scripts"]) == 1
+    assert context["scripts"][0].line_number == line
+
+
+@then("no script is found")
+def no_script_found(context):
+    assert context["scripts"] == []
+
+
+@then(parsers.parse('the script data contains "{text}"'))
+def script_data_contains(context, text):
+    assert text in context["scripts"][0].data
+
+
+@then(parsers.parse("the script spans {count:d} new lines"))
+def script_spans_new_lines(context, count):
+    assert context["found_script"].new_lines() == count
+
+
+# ── extraction ───────────────────────────────────────────────────────────────
+
+@when("the scripts are extracted")
+def scripts_extracted(scripttagextractor, context):
+    scripttagextractor.main(context["source_file"], ".extractedscript.js", None)
+
+
+@when(parsers.parse('the scripts are extracted with the original copied to "{suffix}"'))
+def scripts_extracted_with_copy(scripttagextractor, context, suffix):
+    scripttagextractor.main(context["source_file"], ".extractedscript.js", suffix)
+
+
+@when("a dry run extracts the scripts")
+def scripts_extracted_dry(scripttagextractor, context):
+    scripttagextractor.main(context["source_file"], ".extractedscript.js", None, dry_run=True)
+
+
+@then(parsers.parse('the extracted file "{name}" contains exactly'))
+def extracted_file_contains(tmp_path, context, name, docstring):
+    content = (tmp_path / name).read_text()
+    assert content == docstring
+
+
+@then(parsers.parse('the copied file "{name}" contains exactly'))
+def copied_file_contains(tmp_path, context, name, docstring):
+    content = (tmp_path / name).read_text()
+    assert content == docstring
+
+
+@then(parsers.parse('the extracted file "{name}" does not exist'))
+def extracted_file_absent(tmp_path, name):
+    assert not (tmp_path / name).exists()

--- a/assets/tests/test_properties.py
+++ b/assets/tests/test_properties.py
@@ -1,0 +1,152 @@
+"""Hypothesis property tests for the Python scanner scripts."""
+import contextlib
+import importlib.util
+import os
+import string
+from pathlib import Path
+
+from hypothesis import given, settings, strategies as st
+
+ASSETS = Path(__file__).resolve().parent.parent
+
+
+def _load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, ASSETS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+modelscan_audit = _load_module("modelscan_audit_props", "modelscan-audit.py")
+npm_audit = _load_module("npm_audit_props", "npm-audit.py")
+pip_audit = _load_module("pip_audit_props", "pip-audit.py")
+scripttagextractor = _load_module("scripttagextractor_props", "scripttagextractor.py")
+
+
+@contextlib.contextmanager
+def _scanner_selection(value):
+    old = os.environ.get("MODELSCAN_ENABLED_SCANNERS")
+    try:
+        if value is None:
+            os.environ.pop("MODELSCAN_ENABLED_SCANNERS", None)
+        else:
+            os.environ["MODELSCAN_ENABLED_SCANNERS"] = value
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("MODELSCAN_ENABLED_SCANNERS", None)
+        else:
+            os.environ["MODELSCAN_ENABLED_SCANNERS"] = old
+
+
+scanner_names = st.sampled_from(sorted(modelscan_audit.ALL_SCANNERS))
+
+identifier = st.text(
+    alphabet=string.ascii_letters + string.digits + "-_./",
+    min_size=1,
+    max_size=12,
+).filter(lambda s: not any(s.startswith(p) for p in ("-", ".", "/")))
+
+
+# ── modelscan-audit: scanner selection ───────────────────────────────────────
+
+@given(names=st.sets(scanner_names, min_size=1, max_size=5))
+def test_scanner_selection_selects_exactly_the_requested(names):
+    with _scanner_selection(",".join(names)):
+        assert modelscan_audit._enabled_scanners() == names
+
+
+@given(names=st.sets(scanner_names, min_size=1, max_size=5))
+def test_scanner_selection_ignores_whitespace_and_case(names):
+    with _scanner_selection(",".join(f"  {n.upper()} " for n in names)):
+        assert modelscan_audit._enabled_scanners() == names
+
+
+@given(names=st.sets(scanner_names, min_size=1, max_size=5))
+def test_scanner_selection_ignores_unknown_names(names):
+    with _scanner_selection(",".join(list(names) + ["not-a-scanner"])):
+        assert modelscan_audit._enabled_scanners() == names
+
+
+# ── npm-audit: lock file line lookup ─────────────────────────────────────────
+
+lock_lines = st.lists(
+    st.text(alphabet=string.ascii_letters + string.digits + "_-:", min_size=0, max_size=20),
+    min_size=0,
+    max_size=10,
+)
+
+
+@given(prefix=lock_lines, node=identifier, suffix=lock_lines)
+def test_lock_file_line_points_past_the_entry(prefix, node, suffix):
+    lines = prefix + [f'"{node}": {{'] + suffix
+    assert npm_audit.find_lock_file_line(lines, node) == len(prefix) + 2
+
+
+# ── pip-audit: requirements install commands ─────────────────────────────────
+
+requirement_lines = st.lists(
+    identifier.filter(lambda s: "\\" not in s),
+    min_size=1,
+    max_size=15,
+    unique=True,
+)
+
+
+@settings(max_examples=50)
+@given(lines=requirement_lines)
+def test_requirements_full_scan_yields_every_line(lines):
+    result = list(pip_audit.install_commands_for_requirements_txt(lines, set(lines)))
+    assert result == [([line], index + 1) for index, line in enumerate(lines)]
+
+
+@settings(max_examples=50)
+@given(lines=requirement_lines, changed=st.sets(st.integers(min_value=0)))
+def test_requirements_scan_respects_the_diff(lines, changed):
+    changed_positions = {i % len(lines) for i in changed}
+    diff = {lines[i] for i in changed_positions}
+    result = list(pip_audit.install_commands_for_requirements_txt(lines, diff))
+    expected = [([lines[i]], i + 1) for i in sorted(changed_positions)]
+    assert result == expected
+
+
+# ── pip-audit: pyproject install commands ────────────────────────────────────
+
+dependency = st.text(
+    alphabet=string.ascii_letters + string.digits + "-_.>=<",
+    min_size=1,
+    max_size=12,
+).filter(lambda s: not any(s.startswith(p) for p in ("-", ".", "/", ">=", "<")))
+
+
+@settings(max_examples=50)
+@given(deps=st.lists(dependency, min_size=1, max_size=8, unique=True))
+def test_pyproject_full_scan_yields_each_dependency_once(deps):
+    lines = ["[project]", "dependencies = ["] + [f'  "{d}",' for d in deps] + ["]"]
+    result = list(pip_audit.install_commands_for_pyproject_toml(lines, set(lines)))
+    assert sorted(cmd[0] for cmd, _ in result) == sorted(deps)
+    assert len(result) == len(deps)
+
+
+# ── scripttagextractor ───────────────────────────────────────────────────────
+
+script_data = st.text(alphabet=string.ascii_letters + string.digits + "\n;= ()", min_size=0, max_size=50)
+
+
+@given(data=script_data)
+def test_found_script_new_lines_counts_newlines(data):
+    assert scripttagextractor.FoundScript(1, 0, data).new_lines() == data.count("\n")
+
+
+html_text = st.text(alphabet=string.ascii_letters + " \n", min_size=0, max_size=30)
+
+
+@settings(max_examples=50)
+@given(text=html_text)
+def test_parser_only_reports_script_data(text):
+    document = f"<script>{text}</script>"
+    parser = scripttagextractor.MyHTMLParser()
+    parser.feed(document)
+    joined = "".join(s.data for s in parser.scripts)
+    assert joined == text

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "shellcheck": "shellcheck $(git ls-files '*.sh')",
     "test:unit": "node --test 'src/**/*.test.js' && python3 assets/modelscan-audit.test.py",
     "test:bdd": "cucumber-js",
+    "test:py": "uv run --group test pytest",
     "test": "pnpm run test:unit && pnpm run test:bdd",
     "coverage:unit": "c8 --no-clean --include 'src/**/*.js' --exclude 'src/**/*.test.js' node --test 'src/**/*.test.js'",
     "coverage:bdd": "c8 --no-clean --include 'src/**/*.js' --exclude 'src/**/*.test.js' cucumber-js",
+    "coverage:py": "uv run --group test pytest --cov --cov-fail-under=80",
     "coverage": "rm -rf coverage && pnpm run coverage:unit && pnpm run coverage:bdd && c8 report --check-coverage --lines 80 --branches 80"
   },
   "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,21 @@ test = [
 [tool.pytest.ini_options]
 testpaths = ["assets/tests"]
 
+[tool.coverage.run]
+branch = true
+source = ["assets"]
+
+[tool.coverage.report]
+include = [
+    "assets/modelscan-audit.py",
+    "assets/npm-audit.py",
+    "assets/pip-audit.py",
+    "assets/scripttagextractor.py",
+]
+exclude_lines = [
+    "if __name__ == .__main__.:",
+]
+
 [tool.uv]
 # No python package is built from this repo; uv only manages the dependency
 # environment (uv.lock pins every version).


### PR DESCRIPTION
Layer 7/10 of the test-plan stack.

pytest-bdd scenarios + Hypothesis properties for modelscan-audit, npm-audit, pip-audit, scripttagextractor. Refactors npm-audit.py: extracts pure find_lock_file_line + DI seams for main().