### PR TITLE
feat(ci): Add shellcheck linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm run lint-rules
+      - run: pnpm run shellcheck
       - run: pnpm test
       - if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         run: pnpm audit

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "standard --ignore assets/opengrep_rules",
     "lint-fix": "standard --fix --ignore assets/opengrep_rules",
     "lint-rules": "node src/checkRuleMetadata.js",
+    "shellcheck": "shellcheck $(git ls-files '*.sh')",
     "test": "node --test 'src/**/*.test.js' && python3 assets/modelscan-audit.test.py"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves https://github.com/brave/security-action/pull/954#issuecomment-5417840755

Depends on #954

For the record - `shellcheck` is included in the most recent Ubuntu GH runner ([docs](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md)).