### PR TITLE
Exclude 't3sts/**' from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "t3sts/**"
     open-pull-requests-limit: 0
     groups:
       security-updates:
@@ -27,6 +29,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "t3sts/**"
     open-pull-requests-limit: 0
     groups:
       security-updates:


### PR DESCRIPTION
Added exclude-paths to ignore 't3sts/**' for Bundler and NPM.