### PR TITLE
fix(nudge): one weekly send, deduplicated issues

### DIFF
--- a/actions/dependabot-nudge/action.cjs
+++ b/actions/dependabot-nudge/action.cjs
@@ -1,6 +1,7 @@
 module.exports = async ({ github, context, inputs, actionPath, core, debug = false }) => {
   const { default: dependabotNudge } = await import(`${actionPath}/src/dependabotNudge.js`)
   const { default: isoWeekId } = await import(`${actionPath}/src/isoWeekId.js`)
+  const { nudgeSeverityForWeek } = await import(`${actionPath}/src/dependabotConstants.js`)
   const { default: postNudgeThreads } = await import(`${actionPath}/src/postNudgeThreads.js`)
   const { prepareSlackContext } = await import(`${actionPath}/src/slackUtils.js`)
 
@@ -11,13 +12,12 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     if (debug) console.log('GH_TO_SLACK_USER_MAP is not valid JSON')
   }
 
-  // set minlevel to 'medium' if it's the first Monday of the month, otherwise stick to high or critical issues
-  let minlevel = 'medium'
+  // 'medium' when the ISO week's Monday falls in the first 7 days
+  // of the month, otherwise 'high'. Derived from the Monday (not
+  // today) so every run of the week shares the nudge's threshold.
   const today = new Date()
-  if (today.getDate() > 7) {
-    if (debug) { console.log('Not the first Monday of the month!') }
-    minlevel = 'high'
-  }
+  const minlevel = nudgeSeverityForWeek(today)
+  if (debug) { console.log(`nudge minlevel: ${minlevel}`) }
 
   const nudges = await dependabotNudge({ debug, org: context.repo.owner, github, minlevel, githubToSlack, actionPath })
 

--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -174,3 +174,41 @@ Feature: Dependabot nudge
     When reading the parent cc line from blocks
       | no cc anywhere |
     Then the parent cc line is ""
+
+  Scenario: Duplicate advisories on one package render as one issue
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severity "medium"
+    When running the dependabot nudge
+    Then the result has 1 message
+    And the message for "foo" totals 1 alerts with 0 critical
+    And the message for "foo" contains "CVE-2026-2739" exactly 1 time
+    And the message for "foo" contains "Also reported at"
+    And the message for "foo" contains "security/dependabot/1"
+    And the message for "foo" contains "security/dependabot/2"
+
+  Scenario: The same advisory on different packages stays separate
+    Given the repository "brave/foo"
+    And repo "foo" has an alert for package "left-pad" advisory "GHSA-aaaa-bbbb" with severity "high"
+    And repo "foo" has an alert for package "right-pad" advisory "GHSA-aaaa-bbbb" with severity "high"
+    When running the dependabot nudge
+    Then the message for "foo" totals 2 alerts with 0 critical
+
+  Scenario: Different advisories on one package stay separate
+    Given the repository "brave/foo"
+    And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-2739" with severity "medium"
+    And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-9999" with severity "high"
+    When running the dependabot nudge
+    Then the message for "foo" totals 2 alerts with 0 critical
+
+  Scenario: A duplicated critical advisory counts once
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severity "critical"
+    When running the dependabot nudge
+    Then the message for "foo" totals 1 alerts with 1 critical
+
+  Scenario: A grouped issue shows its most severe member
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severities "medium" and "critical"
+    When running the dependabot nudge
+    Then the message for "foo" totals 1 alerts with 1 critical
+    And the message for "foo" contains "`critical` severity"

--- a/features/dependabot_reconcile.feature
+++ b/features/dependabot_reconcile.feature
@@ -15,3 +15,48 @@ Feature: Dependabot nudge message reconciliation
     And the repo "brave/app" has 2 open alerts
     When reconciling nudge messages
     Then the reconcile alert severity filter is "medium,high,critical"
+
+  Scenario: Daily reconcile adds no notifications to a completed thread
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 5 open alerts
+    And a completed nudge thread for "brave/app" built from 5 alerts
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the parent still shows 5 open Dependabot issues
+
+  Scenario: Alerts added mid-week wait for the next weekly nudge
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 6 open alerts
+    And a completed nudge thread for "brave/app" built from 5 alerts
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the parent still shows 5 open Dependabot issues
+
+  Scenario: Alerts resolved mid-week are trimmed silently
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 4 open alerts
+    And a completed nudge thread for "brave/app" built from 5 alerts
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the parent shows 4 open Dependabot issues
+
+  Scenario: A thread whose alerts are all gone is cleaned up
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 0 open alerts
+    And a completed nudge thread for "brave/app" built from 5 alerts
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the stale nudge messages are deleted
+
+  Scenario: An incomplete thread is finished by the reconcile
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 5 open alerts
+    And an incomplete nudge thread for "brave/app" built from 5 alerts
+    When reconciling nudge messages
+    Then the thread is completed with exactly one cc reply
+
+  Scenario: The weekly nudge path still appends to a completed thread
+    Given the repo "brave/app" has 6 open alerts
+    And a completed nudge thread for "brave/app" built from 5 alerts
+    When refreshing the nudge thread in notify mode
+    Then the thread has 1 new alert replies

--- a/features/dependabot_reconcile.feature
+++ b/features/dependabot_reconcile.feature
@@ -1,0 +1,17 @@
+Feature: Dependabot nudge message reconciliation
+  The daily dismiss run reconciles nudge threads: stale threads are
+  deleted and threads with remaining alerts are refreshed. The severity
+  threshold must match the one the week's nudge used, so a mid-week run
+  never qualifies more alerts than the nudge actually posted.
+
+  Scenario: Reconcile uses the nudge week's severity after a month boundary
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 5 open alerts
+    When reconciling nudge messages
+    Then the reconcile alert severity filter is "high,critical"
+
+  Scenario: Reconcile uses the nudge week's severity during the first week of the month
+    Given the reconcile runs on 2026-09-07
+    And the repo "brave/app" has 2 open alerts
+    When reconciling nudge messages
+    Then the reconcile alert severity filter is "medium,high,critical"

--- a/features/dependabot_reconcile.feature
+++ b/features/dependabot_reconcile.feature
@@ -60,3 +60,11 @@ Feature: Dependabot nudge message reconciliation
     And a completed nudge thread for "brave/app" built from 5 alerts
     When refreshing the nudge thread in notify mode
     Then the thread has 1 new alert replies
+
+  Scenario: A pre-grouping thread with duplicate advisories heals
+    Given the reconcile runs on 2026-09-01
+    And the repo "brave/app" has 2 duplicate-advisory alerts
+    And a legacy nudge thread for "brave/app" with one reply per alert
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the parent shows 1 open Dependabot issues

--- a/features/dependabot_severity.feature
+++ b/features/dependabot_severity.feature
@@ -35,3 +35,23 @@ Feature: Dependabot severity constants
 
   Scenario: Default skip hotwords are defined
     Then the default skip hotwords include "dos" and "denial of service"
+
+  Scenario: Nudge week severity after a month boundary uses the week's Monday
+    Given today is 2026-09-01
+    Then the nudge severity for the nudge week is "high"
+
+  Scenario: Nudge week severity on the first Monday of the month
+    Given today is 2026-09-07
+    Then the nudge severity for the nudge week is "medium"
+
+  Scenario: Nudge week severity later in the first week of the month
+    Given today is 2026-09-10
+    Then the nudge severity for the nudge week is "medium"
+
+  Scenario: Nudge week severity on a Sunday uses its own week's Monday
+    Given today is 2026-09-06
+    Then the nudge severity for the nudge week is "high"
+
+  Scenario: Nudge week severity for a mid-month week
+    Given today is 2026-09-15
+    Then the nudge severity for the nudge week is "high"

--- a/features/step_definitions/dependabot_nudge.steps.js
+++ b/features/step_definitions/dependabot_nudge.steps.js
@@ -11,25 +11,6 @@ import dependabotNudge, {
 
 const ACTION_PATH = fileURLToPath(new URL('../..', import.meta.url))
 
-function makeAlert (n, severity = 'high', summary = `Vulnerability ${n}`) {
-  return {
-    number: n,
-    html_url: `https://github.com/brave/foo/security/dependabot/${n}`,
-    severity,
-    dependency: { package: { name: `pkg-${n}` }, scope: 'runtime' },
-    security_advisory: {
-      summary,
-      description: `# Title\n\nBad things in pkg-${n}.\n`,
-      severity,
-      cve_id: `CVE-2026-000${n}`,
-      ghsa_id: `GHSA-000${n}`
-    },
-    security_vulnerability: {
-      first_patched_version: { identifier: '1.2.3' }
-    }
-  }
-}
-
 async function withCappedTimers (fn) {
   const orig = globalThis.setTimeout
   globalThis.setTimeout = (cb, ms) => orig(cb, Math.min(ms, 1))
@@ -80,20 +61,20 @@ function addAlerts (name, count) {
   const start = this.alertsByRepo[key]?.length || 0
   this.alertsByRepo[key] = [
     ...(this.alertsByRepo[key] || []),
-    ...Array.from({ length: count }, (_, i) => makeAlert(start + i + 1))
+    ...Array.from({ length: count }, (_, i) => this.makeDependabotAlert(start + i + 1))
   ]
 }
 
 Given('repo {string} has an alert with severity {string}', function (name, severity) {
   const key = `${this.org}/${name}`
   const n = (this.alertsByRepo[key]?.length || 0) + 1
-  this.alertsByRepo[key] = [...(this.alertsByRepo[key] || []), makeAlert(n, severity)]
+  this.alertsByRepo[key] = [...(this.alertsByRepo[key] || []), this.makeDependabotAlert(n, { severity })]
 })
 
 Given('repo {string} has an alert with summary {string}', function (name, summary) {
   const key = `${this.org}/${name}`
   const n = (this.alertsByRepo[key]?.length || 0) + 1
-  this.alertsByRepo[key] = [...(this.alertsByRepo[key] || []), makeAlert(n, 'high', summary)]
+  this.alertsByRepo[key] = [...(this.alertsByRepo[key] || []), this.makeDependabotAlert(n, { summary })]
 })
 
 Given('repo {string} has an alert without a patched version', function (name) {
@@ -101,8 +82,41 @@ Given('repo {string} has an alert without a patched version', function (name) {
   const n = (this.alertsByRepo[key]?.length || 0) + 1
   this.alertsByRepo[key] = [
     ...(this.alertsByRepo[key] || []),
-    { ...makeAlert(n), security_vulnerability: {} }
+    { ...this.makeDependabotAlert(n), security_vulnerability: {} }
   ]
+})
+
+function dupAdvisoryAlert (world, n, pkg, advisory, severity) {
+  const isCve = advisory.startsWith('CVE-')
+  return world.makeDependabotAlert(n, {
+    pkg,
+    severity,
+    summary: `${pkg} affected by an open issue`,
+    cveId: isCve ? advisory : `CVE-2026-999${n}`,
+    ghsaId: isCve ? `GHSA-999${n}` : advisory
+  })
+}
+
+function addDupAlerts (name, pkg, advisory, severities) {
+  const key = `${this.org}/${name}`
+  const start = this.alertsByRepo[key]?.length || 0
+  this.alertsByRepo[key] = [
+    ...(this.alertsByRepo[key] || []),
+    ...severities.map((severity, i) =>
+      dupAdvisoryAlert(this, start + i + 1, pkg, advisory, severity))
+  ]
+}
+
+Given('repo {string} has an alert for package {string} advisory {string} with severity {string}', function (name, pkg, advisory, severity) {
+  addDupAlerts.call(this, name, pkg, advisory, [severity])
+})
+
+Given('repo {string} has {int} alerts for package {string} advisory {string} with severity {string}', function (name, count, pkg, advisory, severity) {
+  addDupAlerts.call(this, name, pkg, advisory, Array(count).fill(severity))
+})
+
+Given('repo {string} has 2 alerts for package {string} advisory {string} with severities {string} and {string}', function (name, pkg, advisory, sevA, sevB) {
+  addDupAlerts.call(this, name, pkg, advisory, [sevA, sevB])
 })
 
 Given('repo {string} has maintainers {string}', function (name, maintainers) {
@@ -188,14 +202,14 @@ When('building the parent text for repo {string} with {int} total and {int} crit
 })
 
 When('building the repo message for {int} alerts', function (count) {
-  const alerts = Array.from({ length: count }, (_, i) => makeAlert(i + 1))
-  alerts[alerts.length - 1] = makeAlert(count, 'critical')
+  const alerts = Array.from({ length: count }, (_, i) => this.makeDependabotAlert(i + 1))
+  alerts[alerts.length - 1] = this.makeDependabotAlert(count, { severity: 'critical' })
   this.repoMessage = buildRepoMessage({ alerts })
 })
 
 When('building the repo message for an alert with a missing top-level severity', function () {
   this.repoMessage = buildRepoMessage({
-    alerts: [{ ...makeAlert(1, 'critical'), severity: undefined }]
+    alerts: [{ ...this.makeDependabotAlert(1, { severity: 'critical' }), severity: undefined }]
   })
 })
 
@@ -240,6 +254,14 @@ Then('the message for {string} contains {string}', function (name, text) {
   const message = this.result.find(m => m.repo === `${this.org}/${name}`)
   assert.ok(message, `no message for ${this.org}/${name}`)
   assert.ok(message.message.includes(text), `expected message to contain ${text}`)
+})
+
+Then('the message for {string} contains {string} exactly {int} time', function (name, text, count) {
+  const message = this.result.find(m => m.repo === `${this.org}/${name}`)
+  assert.ok(message, `no message for ${this.org}/${name}`)
+  const occurrences = message.message.split(text).length - 1
+  assert.equal(occurrences, count,
+    `expected ${text} ${count} time(s), found ${occurrences}`)
 })
 
 Then('the message for {string} has cc line {string}', function (name, cc) {

--- a/features/step_definitions/dependabot_reconcile.steps.js
+++ b/features/step_definitions/dependabot_reconcile.steps.js
@@ -3,39 +3,32 @@ import assert from 'assert'
 import reconcileNudgeMessages from '../../src/reconcileNudgeMessages.js'
 import refreshNudgeThread from '../../src/refreshNudgeThread.js'
 import { buildRepoMessage, buildParentBlocks } from '../../src/dependabotNudge.js'
+import { PARENT_EVENT_TYPE, ALERTS_EVENT_TYPE, CC_EVENT_TYPE } from '../../src/nudgeThread.js'
 import { messageToBlocks } from '../../src/sendSlackMessage.js'
 import { chunkNudgeMessage } from '../../src/slackUtils.js'
 
 const REPO = 'brave/app'
-const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
 
-function makeAlert (n, severity = 'high') {
-  return {
-    number: n,
-    html_url: `https://github.com/${REPO}/security/dependabot/${n}`,
-    severity,
-    dependency: { package: { name: `pkg-${n}` }, scope: 'runtime' },
-    security_advisory: {
-      summary: `advisory ${n}`,
-      description: `Description of advisory ${n}`,
-      severity,
-      cve_id: `CVE-2026-00${n}`,
-      ghsa_id: `GHSA-00${n}`
-    },
-    security_vulnerability: { first_patched_version: { identifier: '1.2.3' } }
-  }
-}
+const makeAlert = (world, n, overrides = {}) =>
+  world.makeDependabotAlert(n, { repo: REPO, ...overrides })
 
 function nextTs (ts) {
   return (parseFloat(ts) + 0.000001).toFixed(6)
 }
 
-// Build a realistic nudge thread: parent + one reply per alert
+// Build a realistic nudge thread: parent + one reply per chunk
 // (+ the cc completion reply), rendered through the same
 // builders the posting path uses.
-async function buildThreadFixture (world, { threadAlerts, withCc }) {
-  const { message, total, critical } = buildRepoMessage({ alerts: threadAlerts })
-  const chunks = chunkNudgeMessage(message)
+async function buildThreadFixture (world, { threadAlerts, chunks, withCc }) {
+  let built
+  if (chunks) {
+    const total = chunks.length
+    built = { chunks, total, critical: 0 }
+  } else {
+    const { message, total, critical } = buildRepoMessage({ alerts: threadAlerts })
+    built = { chunks: chunkNudgeMessage(message), total, critical }
+  }
+  const { chunks: rendered, total, critical } = built
   const parentTs = '1700000000.000001'
 
   const parent = {
@@ -55,7 +48,7 @@ async function buildThreadFixture (world, { threadAlerts, withCc }) {
 
   const replies = [parent]
   let ts = parentTs
-  for (const chunk of chunks) {
+  for (const chunk of rendered) {
     ts = nextTs(ts)
     replies.push({
       ts,
@@ -63,7 +56,7 @@ async function buildThreadFixture (world, { threadAlerts, withCc }) {
       text: 'dependabot alert',
       blocks: await messageToBlocks(chunk),
       metadata: {
-        event_type: 'dependabot-nudge-alerts',
+        event_type: ALERTS_EVENT_TYPE,
         event_payload: { repo: REPO, kind: 'alerts' }
       }
     })
@@ -75,7 +68,7 @@ async function buildThreadFixture (world, { threadAlerts, withCc }) {
       bot_id: 'BNUDGE',
       text: 'cc <@U123>',
       metadata: {
-        event_type: 'dependabot-nudge-cc',
+        event_type: CC_EVENT_TYPE,
         event_payload: { repo: REPO, kind: 'cc' }
       }
     })
@@ -96,21 +89,41 @@ Given('the reconcile runs on {iso-date}', function (date) {
 Given('the repo {string} has {int} open alerts', function (repo, count) {
   assert.equal(repo, REPO)
   this.reconcileRepo = repo
-  this.reconcileAlerts = Array.from({ length: count }, (_, i) => makeAlert(i + 1))
+  this.reconcileAlerts = Array.from({ length: count }, (_, i) => makeAlert(this, i + 1))
 })
 
 Given('a completed nudge thread for {string} built from {int} alerts', async function (repo, count) {
   assert.equal(repo, REPO)
   await buildThreadFixture(this, {
-    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(i + 1)),
+    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(this, i + 1)),
     withCc: true
   })
+})
+
+Given('the repo {string} has 2 duplicate-advisory alerts', function (repo) {
+  assert.equal(repo, REPO)
+  this.reconcileRepo = repo
+  this.reconcileAlerts = [1, 2].map(n => makeAlert(this, n, {
+    pkg: 'bn.js',
+    summary: 'bn.js affected by an infinite loop',
+    cveId: 'CVE-2026-2739',
+    ghsaId: 'GHSA-abcd-1234'
+  }))
+})
+
+Given('a legacy nudge thread for {string} with one reply per alert', async function (repo) {
+  assert.equal(repo, REPO)
+  // Pre-grouping format: one reply per alert, even when two
+  // alerts are the same advisory on the same package.
+  const chunks = this.reconcileAlerts.map(a =>
+    chunkNudgeMessage(buildRepoMessage({ alerts: [a] }).message)[0])
+  await buildThreadFixture(this, { chunks, withCc: true })
 })
 
 Given('an incomplete nudge thread for {string} built from {int} alerts', async function (repo, count) {
   assert.equal(repo, REPO)
   await buildThreadFixture(this, {
-    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(i + 1)),
+    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(this, i + 1)),
     withCc: false
   })
 })

--- a/features/step_definitions/dependabot_reconcile.steps.js
+++ b/features/step_definitions/dependabot_reconcile.steps.js
@@ -1,15 +1,24 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import assert from 'assert'
 import reconcileNudgeMessages from '../../src/reconcileNudgeMessages.js'
+import refreshNudgeThread from '../../src/refreshNudgeThread.js'
+import { buildRepoMessage, buildParentBlocks } from '../../src/dependabotNudge.js'
+import { messageToBlocks } from '../../src/sendSlackMessage.js'
+import { chunkNudgeMessage } from '../../src/slackUtils.js'
 
-function makeAlert (n) {
+const REPO = 'brave/app'
+const PARENT_EVENT_TYPE = 'dependabot-nudge-repo-parent'
+
+function makeAlert (n, severity = 'high') {
   return {
     number: n,
-    html_url: `https://github.com/brave/app/dependabot/${n}`,
-    severity: 'high',
-    dependency: { package: { name: `pkg-${n}` } },
+    html_url: `https://github.com/${REPO}/security/dependabot/${n}`,
+    severity,
+    dependency: { package: { name: `pkg-${n}` }, scope: 'runtime' },
     security_advisory: {
       summary: `advisory ${n}`,
+      description: `Description of advisory ${n}`,
+      severity,
       cve_id: `CVE-2026-00${n}`,
       ghsa_id: `GHSA-00${n}`
     },
@@ -17,20 +26,101 @@ function makeAlert (n) {
   }
 }
 
+function nextTs (ts) {
+  return (parseFloat(ts) + 0.000001).toFixed(6)
+}
+
+// Build a realistic nudge thread: parent + one reply per alert
+// (+ the cc completion reply), rendered through the same
+// builders the posting path uses.
+async function buildThreadFixture (world, { threadAlerts, withCc }) {
+  const { message, total, critical } = buildRepoMessage({ alerts: threadAlerts })
+  const chunks = chunkNudgeMessage(message)
+  const parentTs = '1700000000.000001'
+
+  const parent = {
+    ts: parentTs,
+    bot_id: 'BNUDGE',
+    text: 'dependabot alert',
+    // The nudge edits the cc into the parent before posting the
+    // cc reply, so even an incomplete thread carries it inline.
+    blocks: await buildParentBlocks({
+      repo: REPO, total, critical, cc: withCc ? '' : 'cc <@U123>'
+    }),
+    metadata: {
+      event_type: PARENT_EVENT_TYPE,
+      event_payload: { org: 'brave', repo: REPO, weekId: '2026-W36' }
+    }
+  }
+
+  const replies = [parent]
+  let ts = parentTs
+  for (const chunk of chunks) {
+    ts = nextTs(ts)
+    replies.push({
+      ts,
+      bot_id: 'BNUDGE',
+      text: 'dependabot alert',
+      blocks: await messageToBlocks(chunk),
+      metadata: {
+        event_type: 'dependabot-nudge-alerts',
+        event_payload: { repo: REPO, kind: 'alerts' }
+      }
+    })
+  }
+  if (withCc) {
+    ts = nextTs(ts)
+    replies.push({
+      ts,
+      bot_id: 'BNUDGE',
+      text: 'cc <@U123>',
+      metadata: {
+        event_type: 'dependabot-nudge-cc',
+        event_payload: { repo: REPO, kind: 'cc' }
+      }
+    })
+  }
+
+  world.threadParentTs = parentTs
+  world.threadHistory = [parent]
+  world.slackWeb = world.makeMockSlackWeb({
+    messages: [parent],
+    repliesByTs: { [parentTs]: replies }
+  })
+}
+
 Given('the reconcile runs on {iso-date}', function (date) {
   this.reconcileNow = date
 })
 
 Given('the repo {string} has {int} open alerts', function (repo, count) {
+  assert.equal(repo, REPO)
   this.reconcileRepo = repo
   this.reconcileAlerts = Array.from({ length: count }, (_, i) => makeAlert(i + 1))
 })
 
+Given('a completed nudge thread for {string} built from {int} alerts', async function (repo, count) {
+  assert.equal(repo, REPO)
+  await buildThreadFixture(this, {
+    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(i + 1)),
+    withCc: true
+  })
+})
+
+Given('an incomplete nudge thread for {string} built from {int} alerts', async function (repo, count) {
+  assert.equal(repo, REPO)
+  await buildThreadFixture(this, {
+    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(i + 1)),
+    withCc: false
+  })
+})
+
 When('reconciling nudge messages', async function () {
   const refreshCalls = []
-  const repo = this.reconcileRepo || 'brave/app'
+  const repo = this.reconcileRepo || REPO
   const listSlackMessageRepos = async () => [repo]
-  const deleteSlackMessages = async () => {}
+  this.deletedStale = []
+  const deleteSlackMessages = async (args) => { this.deletedStale.push(args.repos) }
   this.github = this.github || this.makeMockGithub({
     alertsByRepo: { [repo]: this.reconcileAlerts || [] }
   })
@@ -41,9 +131,28 @@ When('reconciling nudge messages', async function () {
     now: this.reconcileNow,
     listSlackMessageRepos,
     deleteSlackMessages,
-    refreshNudgeThread: async (args) => { refreshCalls.push(args) }
+    refreshNudgeThread: async (args) => {
+      refreshCalls.push(args)
+      if (!this.slackWeb) return undefined
+      return refreshNudgeThread({
+        web: this.slackWeb,
+        channelId: 'C001',
+        messages: this.threadHistory,
+        ...args
+      })
+    }
   }))
   this.refreshCalls = refreshCalls
+})
+
+When('refreshing the nudge thread in notify mode', async function () {
+  await this.attempt(() => refreshNudgeThread({
+    web: this.slackWeb,
+    channelId: 'C001',
+    messages: this.threadHistory,
+    repoFullName: REPO,
+    alerts: this.reconcileAlerts
+  }))
 })
 
 Then('the reconcile alert severity filter is {string}', function (expected) {
@@ -51,4 +160,45 @@ Then('the reconcile alert severity filter is {string}', function (expected) {
     .find(call => call.params.url.includes('dependabot/alerts'))
   assert.ok(paginate, 'expected a dependabot alerts paginate call')
   assert.deepEqual(paginate.params.opts.severity, expected.split(','))
+})
+
+Then('no replies are posted to the thread', function () {
+  const posts = this.slackWeb.__recorder.find('chat.postMessage')
+  assert.equal(posts.length, 0,
+    `expected no posts, got ${JSON.stringify(posts.map(p => p.params.metadata?.event_payload))}`)
+})
+
+Then('the thread has {int} new alert replies', function (count) {
+  const posts = this.slackWeb.__recorder.find('chat.postMessage')
+    .filter(p => p.params.metadata?.event_payload?.kind === 'alerts')
+  assert.equal(posts.length, count)
+})
+
+Then('the thread is completed with exactly one cc reply', function () {
+  const posts = this.slackWeb.__recorder.find('chat.postMessage')
+  assert.equal(posts.length, 1,
+    `expected only the cc reply, got ${posts.length} posts`)
+  assert.equal(posts[0].params.metadata?.event_payload?.kind, 'cc')
+})
+
+Then('the parent shows {int} open Dependabot issues', function (count) {
+  assertParentCount(this, count)
+})
+
+Then('the parent still shows {int} open Dependabot issues', function (count) {
+  assertParentCount(this, count)
+})
+
+function assertParentCount (world, count) {
+  const updates = world.slackWeb.__recorder.find('chat.update')
+    .filter(u => u.params.ts === world.threadParentTs)
+  const blocks = updates.length > 0
+    ? updates[updates.length - 1].params.blocks
+    : world.threadHistory[0].blocks
+  const text = blocks.map(b => b.text?.text || '').join('\n')
+  assert.match(text, new RegExp(`has \`${count}\` open Dependabot issues`))
+}
+
+Then('the stale nudge messages are deleted', function () {
+  assert.deepEqual(this.deletedStale, [[REPO]])
 })

--- a/features/step_definitions/dependabot_reconcile.steps.js
+++ b/features/step_definitions/dependabot_reconcile.steps.js
@@ -1,0 +1,54 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import assert from 'assert'
+import reconcileNudgeMessages from '../../src/reconcileNudgeMessages.js'
+
+function makeAlert (n) {
+  return {
+    number: n,
+    html_url: `https://github.com/brave/app/dependabot/${n}`,
+    severity: 'high',
+    dependency: { package: { name: `pkg-${n}` } },
+    security_advisory: {
+      summary: `advisory ${n}`,
+      cve_id: `CVE-2026-00${n}`,
+      ghsa_id: `GHSA-00${n}`
+    },
+    security_vulnerability: { first_patched_version: { identifier: '1.2.3' } }
+  }
+}
+
+Given('the reconcile runs on {iso-date}', function (date) {
+  this.reconcileNow = date
+})
+
+Given('the repo {string} has {int} open alerts', function (repo, count) {
+  this.reconcileRepo = repo
+  this.reconcileAlerts = Array.from({ length: count }, (_, i) => makeAlert(i + 1))
+})
+
+When('reconciling nudge messages', async function () {
+  const refreshCalls = []
+  const repo = this.reconcileRepo || 'brave/app'
+  const listSlackMessageRepos = async () => [repo]
+  const deleteSlackMessages = async () => {}
+  this.github = this.github || this.makeMockGithub({
+    alertsByRepo: { [repo]: this.reconcileAlerts || [] }
+  })
+  await this.attempt(() => reconcileNudgeMessages({
+    github: this.github,
+    slackToken: 'xoxb-test',
+    channel: 'C001',
+    now: this.reconcileNow,
+    listSlackMessageRepos,
+    deleteSlackMessages,
+    refreshNudgeThread: async (args) => { refreshCalls.push(args) }
+  }))
+  this.refreshCalls = refreshCalls
+})
+
+Then('the reconcile alert severity filter is {string}', function (expected) {
+  const paginate = this.github.__recorder.find('paginate')
+    .find(call => call.params.url.includes('dependabot/alerts'))
+  assert.ok(paginate, 'expected a dependabot alerts paginate call')
+  assert.deepEqual(paginate.params.opts.severity, expected.split(','))
+})

--- a/features/step_definitions/dependabot_severity.steps.js
+++ b/features/step_definitions/dependabot_severity.steps.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_SKIP_HOTWORDS,
   Severity,
   nudgeSeverityForToday,
+  nudgeSeverityForWeek,
   severityKeysAbove
 } from '../../src/dependabotConstants.js'
 
@@ -30,6 +31,10 @@ Given('today is {iso-date}', function (date) {
 
 Then('the nudge severity for today is {string}', function (expected) {
   assert.equal(nudgeSeverityForToday(this.today), expected)
+})
+
+Then('the nudge severity for the nudge week is {string}', function (expected) {
+  assert.equal(nudgeSeverityForWeek(this.today), expected)
 })
 
 Then('the default skip hotwords include {string} and {string}', function (a, b) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -107,6 +107,38 @@ export function makeMockSlackWeb ({
 }
 
 /**
+ * Canonical Dependabot alert fixture, shared by the nudge and
+ * reconcile step definitions. Options shape a scenario's alert;
+ * defaults render a plain high-severity runtime finding.
+ */
+export function makeDependabotAlert (n, {
+  repo = 'brave/foo',
+  severity = 'high',
+  summary = `Vulnerability ${n}`,
+  description = `# Title\n\nBad things in pkg-${n}.\n`,
+  pkg = `pkg-${n}`,
+  cveId = `CVE-2026-000${n}`,
+  ghsaId = `GHSA-000${n}`
+} = {}) {
+  return {
+    number: n,
+    html_url: `https://github.com/${repo}/security/dependabot/${n}`,
+    severity,
+    dependency: { package: { name: pkg }, scope: 'runtime' },
+    security_advisory: {
+      summary,
+      description,
+      severity,
+      cve_id: cveId,
+      ghsa_id: ghsaId
+    },
+    security_vulnerability: {
+      first_patched_version: { identifier: '1.2.3' }
+    }
+  }
+}
+
+/**
  * Fake Octokit instance covering the patterns used by src modules:
  * paginate (Dependabot alerts / repo properties / org endpoints), graphql
  * (review threads, timelines), repos.getContent and generic request.
@@ -364,6 +396,7 @@ Object.assign(CustomWorld.prototype, {
   makeMockExec,
   makeMockFs,
   makeMockDownload,
+  makeDependabotAlert,
   Recorder
 })
 

--- a/src/dependabotConstants.js
+++ b/src/dependabotConstants.js
@@ -32,6 +32,27 @@ export function nudgeSeverityForToday (date = new Date()) {
   return date.getDate() <= 7 ? 'medium' : 'high'
 }
 
+// Monday of the ISO week containing `date` (local time, matching
+// the local getDate() used by nudgeSeverityForToday).
+export function mondayOfIsoWeek (date = new Date()) {
+  const monday = new Date(date)
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7))
+  return monday
+}
+
+// Severity threshold the nudge used for the ISO week containing
+// `date`. The nudge runs on Mondays and applies the day-of-month
+// rule to that Monday, so every other run in the same week
+// (reconciliation, refresh) must derive its threshold from the
+// Monday as well. Using today's date instead would let a run one
+// day past a month boundary qualify more alerts than the week's
+// nudge posted (2026-08-31 incident: nudge on Monday Aug 31 at
+// 'high', reconcile on Sep 1 at 'medium' appended 5 medium alerts
+// to a high-only thread mid-week).
+export function nudgeSeverityForWeek (date = new Date()) {
+  return nudgeSeverityForToday(mondayOfIsoWeek(date))
+}
+
 // Return the severity keys at or above `minlevel`.
 // E.g. severityKeysAbove('high') => ['high','critical']
 export function severityKeysAbove (minlevel) {

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -22,22 +22,53 @@ function decodeEntities (encodedString) {
   })
 }
 
-function criticalCount (alerts) {
-  return alerts.filter(a =>
-    Severity[a.security_advisory?.severity || a.severity] >=
-    Severity.critical
-  ).length
+function alertSeverity (alert) {
+  return Severity[alert.security_advisory?.severity || alert.severity]
 }
 
-// Render the alert list for one repository: the findings
-// only, no summary line. The summary belongs on the thread
-// parent (buildParentText), the findings in the replies.
+// The most severe member of a group: a grouped issue is never
+// rendered or counted below its worst rating.
+function worstAlert (group) {
+  return group.reduce((worst, a) =>
+    alertSeverity(a) > alertSeverity(worst) ? a : worst)
+}
+
+function criticalCount (alerts) {
+  return alerts.filter(a => alertSeverity(a) >= Severity.critical).length
+}
+
+// Group alerts that are the same advisory on the same package.
+// Dependabot opens one alert per manifest, so a package present
+// in two lockfiles yields two alerts for a single issue; without
+// grouping the thread would show the same CVE twice (e.g. bn.js
+// CVE-2026-2739 as alerts #125 and #112). Grouping is per
+// package: the same advisory in two different packages is two
+// dependency problems, not one.
+export function groupAlerts (alerts) {
+  const groups = new Map()
+  for (const alert of alerts) {
+    const key =
+      `${alert.dependency.package.name}|` +
+      `${alert.security_advisory.cve_id || alert.security_advisory.ghsa_id}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(alert)
+  }
+  return [...groups.values()]
+}
+
+// Only the findings, no summary line. The summary belongs on the
+// thread parent (buildParentText), the findings in the replies.
 // Shared with the refresh path (refreshNudgeThread.js) so an
 // updated thread is rendered exactly like the original nudge.
+// Counts and entries are per unique advisory-package issue, not
+// per alert; duplicates list their extra alert URLs.
 export function buildRepoMessage ({ alerts }) {
   let message = ''
+  const groups = groupAlerts(alerts)
 
-  for (const alert of alerts) {
+  for (const group of groups) {
+    const alert = worstAlert(group)
+
     const descFirstLine = alert.security_advisory.description
       .split('\n')
       .filter(d => d[0] !== '#')
@@ -58,13 +89,16 @@ export function buildRepoMessage ({ alerts }) {
     }
 
     message += `Handle this alert at ${alert.html_url}\n\n`
+    for (const extra of group.slice(1)) {
+      message += `Also reported at ${extra.html_url}\n\n`
+    }
     message += '\n\n---\n\n'
   }
 
   return {
     message,
-    total: alerts.length,
-    critical: criticalCount(alerts)
+    total: groups.length,
+    critical: criticalCount(groups.map(worstAlert))
   }
 }
 
@@ -281,7 +315,7 @@ export default async function dependabotNudge ({
           }
         }
 
-        const { message: msg, critical: critLen } =
+        const { message: msg, total: issueCount, critical: critLen } =
           buildRepoMessage({ alerts })
 
         // The cc line is kept out of `message` on purpose:
@@ -296,7 +330,7 @@ export default async function dependabotNudge ({
           repo: `${org}/${repo.name}`,
           message: msg,
           cc,
-          total: alerts.length,
+          total: issueCount,
           critical: critLen,
           alerts
         })

--- a/src/reconcileNudgeMessages.js
+++ b/src/reconcileNudgeMessages.js
@@ -5,7 +5,7 @@
 
 import {
   DEFAULT_SKIP_HOTWORDS,
-  nudgeSeverityForToday,
+  nudgeSeverityForWeek,
   severityKeysAbove
 } from './dependabotConstants.js'
 
@@ -87,6 +87,8 @@ async function qualifyingAlerts (
 // @param {Function} [opts.refreshNudgeThread] - Called as
 //   ({repoFullName, alerts, debug}) for repos that still
 //   have alerts, to sync the thread with what is left
+// @param {Date} [opts.now] - Injected clock for tests;
+//   defaults to the current time
 // @returns {Promise<string[]>} List of stale repo names
 export default async function reconcileNudgeMessages ({
   github,
@@ -97,13 +99,18 @@ export default async function reconcileNudgeMessages ({
   skipHotwords = DEFAULT_SKIP_HOTWORDS,
   listSlackMessageRepos,
   deleteSlackMessages,
-  refreshNudgeThread = null
+  refreshNudgeThread = null,
+  now = new Date()
 }) {
   debug = debug === 'true' || debug === true
 
   const nudgeUsername = 'dependabot'
 
-  const minlevel = nudgeSeverityForToday()
+  // Match the threshold of the nudge that produced the threads
+  // being reconciled: derive it from this ISO week's Monday, not
+  // from today, so a run just past a month boundary never
+  // qualifies more alerts than the week's nudge posted.
+  const minlevel = nudgeSeverityForWeek(now)
   const severityKeys = severityKeysAbove(minlevel)
 
   const nudgedRepos = await listSlackMessageRepos({

--- a/src/reconcileNudgeMessages.js
+++ b/src/reconcileNudgeMessages.js
@@ -85,8 +85,11 @@ async function qualifyingAlerts (
 // @param {Function} opts.listSlackMessageRepos
 // @param {Function} opts.deleteSlackMessages
 // @param {Function} [opts.refreshNudgeThread] - Called as
-//   ({repoFullName, alerts, debug}) for repos that still
-//   have alerts, to sync the thread with what is left
+//   ({repoFullName, alerts, debug, silent: true}) for repos
+//   that still have alerts, to sync the thread with what is
+//   left. Silent: between weekly nudges the thread may be
+//   corrected but never grows, so the daily run stays
+//   invisible to the maintainers following the thread.
 // @param {Date} [opts.now] - Injected clock for tests;
 //   defaults to the current time
 // @returns {Promise<string[]>} List of stale repo names
@@ -141,7 +144,7 @@ export default async function reconcileNudgeMessages ({
       // the count on the parent match reality.
       try {
         await refreshNudgeThread({
-          repoFullName, alerts, debug
+          repoFullName, alerts, debug, silent: true
         })
       } catch (err) {
         console.error(

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -118,6 +118,14 @@ async function deleteThread ({
 // @param {string} [opts.providedCc]  - This run's maintainer
 //   cc line, used when the thread carries none anywhere
 //   (an earlier run failed before the parent edit landed)
+// @param {boolean} [opts.silent] - Maintenance mode between
+//   weekly nudges: a completed thread (its cc reply landed)
+//   never grows, because thread replies notify everyone
+//   following the thread. Alerts added mid-week stay hidden
+//   until the next weekly nudge renders them, and the parent
+//   keeps the count of what is displayed. An incomplete
+//   thread is still finished off: that completes the original
+//   send rather than adding a second one.
 // @param {boolean} [opts.debug]
 // @returns {Promise<{touched: number, ok: boolean}>}
 //   touched - messages written; ok - false when any write
@@ -130,6 +138,7 @@ export default async function refreshNudgeThread ({
   repoFullName,
   alerts = [],
   providedCc = null,
+  silent = false,
   debug = false
 }) {
   debug = debug === 'true' || debug === true
@@ -148,9 +157,9 @@ export default async function refreshNudgeThread ({
     web, channelId, parent.ts
   )
 
-  const { message, total, critical } =
+  let { message, total, critical } =
     buildRepoMessage({ alerts })
-  const chunks = chunkNudgeMessage(message)
+  let chunks = chunkNudgeMessage(message)
 
   // No alerts left: tear the thread down, or zero the parent
   // when its discussion has to stay.
@@ -190,6 +199,23 @@ export default async function refreshNudgeThread ({
     return { touched: chunks.length + details.length, ok: true }
   }
 
+  // Between weekly nudges a completed thread must not grow:
+  // every thread reply notifies the maintainers following it,
+  // so a daily reconcile appending newly created alerts would
+  // turn one weekly ping into an unprompted second wave. Trim
+  // the render to what the thread already shows instead; the
+  // next weekly nudge renders the new alerts. Rewrites and
+  // deletions stay allowed: chat.update is a revision, not a
+  // delivery, so syncing existing replies never re-notifies.
+  if (silent && ccReply && chunks.length > details.length) {
+    const capped = buildRepoMessage({
+      alerts: alerts.slice(0, details.length)
+    })
+    total = capped.total
+    critical = capped.critical
+    chunks = chunkNudgeMessage(capped.message)
+  }
+
   let touched = 0
   let ok = true
 
@@ -225,7 +251,9 @@ export default async function refreshNudgeThread ({
 
   // More chunks than replies means alerts were added since
   // the thread was created; append the remainder so nothing
-  // is hidden behind a count that claims otherwise.
+  // is hidden behind a count that claims otherwise. A silent
+  // refresh never reaches this loop for a completed thread:
+  // its visible chunks are capped at the existing replies.
   for (let i = details.length; i < chunks.length; i++) {
     try {
       await postAlertReply(


### PR DESCRIPTION
Fixes the 2026-08-31 incident where maintainers got a second Dependabot wave at 5:27 PM and bn.js CVE-2026-2739 was posted twice (#125, #112).

## Root causes
1. **Mid-week appends notify**: the daily dismiss run's reconcile refreshed nudge threads and appended newly created alerts; every thread reply notifies the maintainers following the thread, so the weekly nudge became two sends (5 replies at 10:07, 5 more at 17:27).
2. **Minlevel drift**: the nudge applied its day-of-month rule to its run date (Mon Aug 31 → `high`) but reconcile applied it to today (Sep 1 → `medium`), so the refresh also swapped three replies' content mid-thread.
3. **No advisory grouping**: Dependabot opens one alert per manifest, so bn.js in two lockfiles produced two alerts and two identical replies; the parent counted 10 "issues" instead of 9.

## Changes
- `nudgeSeverityForWeek`: threshold derived from the ISO week's Monday, shared by the nudge action and reconcile (reconcile gains an injected `now` for tests).
- `refreshNudgeThread` silent mode (used by reconcile): completed threads never grow — mid-week alerts wait for the next weekly nudge, the parent keeps the shown count; rewrites/trims/teardown stay (edits and deletes never notify). An incomplete thread is still finished off, completing the original send.
- `buildRepoMessage` groups alerts by package + advisory id: one entry per issue listing every alert URL, rendered from the most severe member; totals count issues, not alerts. The refresh path shares the builder, so existing duplicate replies self-heal on the next run.

## Testing
- BDD: new `features/dependabot_reconcile.feature` (silent-refresh regression scenarios incl. zero `chat.postMessage` for the incident shape) + grouping scenarios in `features/dependabot_nudge.feature`; each commit went red → green.
- `pnpm test` (unit + BDD, 329 scenarios), `pnpm run coverage` (80/80 gate), `standard` clean; suite also run in the orbstack Ubuntu VM before each commit.