### PR TITLE
fix(nudge): scope reconcile to the nudge week

### DIFF
--- a/actions/dependabot-auto-dismiss/action.cjs
+++ b/actions/dependabot-auto-dismiss/action.cjs
@@ -56,14 +56,12 @@ module.exports = async ({
     debug,
     listSlackMessageRepos,
     deleteSlackMessages,
-    refreshNudgeThread: ({ repoFullName, alerts }) =>
+    refreshNudgeThread: (args) =>
       refreshNudgeThread({
         web,
         channelId,
         messages: slackMessages,
-        repoFullName,
-        alerts,
-        debug
+        ...args
       })
   })
 

--- a/features/dependabot_reconcile.feature
+++ b/features/dependabot_reconcile.feature
@@ -2,7 +2,9 @@ Feature: Dependabot nudge message reconciliation
   The daily dismiss run reconciles nudge threads: stale threads are
   deleted and threads with remaining alerts are refreshed. The severity
   threshold must match the one the week's nudge used, so a mid-week run
-  never qualifies more alerts than the nudge actually posted.
+  never qualifies more alerts than the nudge actually posted, and the
+  run is scoped to the current nudge week: once the week has rolled
+  over, last week's thread waits untouched for next week's nudge.
 
   Scenario: Reconcile uses the nudge week's severity after a month boundary
     Given the reconcile runs on 2026-09-01
@@ -68,3 +70,19 @@ Feature: Dependabot nudge message reconciliation
     When reconciling nudge messages
     Then no replies are posted to the thread
     And the parent shows 1 open Dependabot issues
+
+  Scenario: Reconcile never touches a previous week's thread
+    Given the reconcile runs on 2026-09-08
+    And the repo "brave/app" has 7 open alerts
+    And a completed nudge thread for "brave/app" from week "2026-W36" built from 5 alerts
+    When reconciling nudge messages
+    Then no replies are posted to the thread
+    And the thread is left untouched
+    And the stale nudge messages are not deleted
+
+  Scenario: A previous week's thread with no alerts left is still cleaned up
+    Given the reconcile runs on 2026-09-08
+    And the repo "brave/app" has 0 open alerts
+    And a completed nudge thread for "brave/app" from week "2026-W36" built from 5 alerts
+    When reconciling nudge messages
+    Then the stale nudge messages are deleted

--- a/features/step_definitions/dependabot_reconcile.steps.js
+++ b/features/step_definitions/dependabot_reconcile.steps.js
@@ -19,7 +19,7 @@ function nextTs (ts) {
 // Build a realistic nudge thread: parent + one reply per chunk
 // (+ the cc completion reply), rendered through the same
 // builders the posting path uses.
-async function buildThreadFixture (world, { threadAlerts, chunks, withCc }) {
+async function buildThreadFixture (world, { threadAlerts, chunks, withCc, weekId = '2026-W36' }) {
   let built
   if (chunks) {
     const total = chunks.length
@@ -42,7 +42,7 @@ async function buildThreadFixture (world, { threadAlerts, chunks, withCc }) {
     }),
     metadata: {
       event_type: PARENT_EVENT_TYPE,
-      event_payload: { org: 'brave', repo: REPO, weekId: '2026-W36' }
+      event_payload: { org: 'brave', repo: REPO, weekId }
     }
   }
 
@@ -97,6 +97,15 @@ Given('a completed nudge thread for {string} built from {int} alerts', async fun
   await buildThreadFixture(this, {
     threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(this, i + 1)),
     withCc: true
+  })
+})
+
+Given('a completed nudge thread for {string} from week {string} built from {int} alerts', async function (repo, weekId, count) {
+  assert.equal(repo, REPO)
+  await buildThreadFixture(this, {
+    threadAlerts: Array.from({ length: count }, (_, i) => makeAlert(this, i + 1)),
+    withCc: true,
+    weekId
   })
 })
 
@@ -179,6 +188,20 @@ Then('no replies are posted to the thread', function () {
   const posts = this.slackWeb.__recorder.find('chat.postMessage')
   assert.equal(posts.length, 0,
     `expected no posts, got ${JSON.stringify(posts.map(p => p.params.metadata?.event_payload))}`)
+})
+
+Then('the thread is left untouched', function () {
+  const updated = this.slackWeb.__recorder.find('chat.update')
+    .filter(u => u.params.ts === this.threadParentTs)
+  assert.equal(updated.length, 0,
+    `expected no updates, got ${updated.length}`)
+  const deleted = this.slackWeb.__recorder.find('chat.delete')
+  assert.equal(deleted.length, 0,
+    `expected no deletions, got ${deleted.length}`)
+})
+
+Then('the stale nudge messages are not deleted', function () {
+  assert.deepEqual(this.deletedStale, [])
 })
 
 Then('the thread has {int} new alert replies', function (count) {

--- a/src/postNudgeThreads.js
+++ b/src/postNudgeThreads.js
@@ -89,6 +89,7 @@ export default async function postNudgeThreads ({
           repoFullName: repo,
           alerts,
           providedCc: cc,
+          weekId,
           debug
         })
         if (!ok) {

--- a/src/reconcileNudgeMessages.js
+++ b/src/reconcileNudgeMessages.js
@@ -8,6 +8,7 @@ import {
   nudgeSeverityForWeek,
   severityKeysAbove
 } from './dependabotConstants.js'
+import isoWeekId from './isoWeekId.js'
 
 // Fetch a repo's qualifying open alerts.
 // Returns an array (empty means the nudge message is
@@ -144,7 +145,14 @@ export default async function reconcileNudgeMessages ({
       // the count on the parent match reality.
       try {
         await refreshNudgeThread({
-          repoFullName, alerts, debug, silent: true
+          repoFullName,
+          alerts,
+          debug,
+          silent: true,
+          // Scope to this week's thread: once the ISO week has
+          // rolled over, last week's thread must wait untouched
+          // for the new week's nudge instead of growing.
+          weekId: isoWeekId(now)
         })
       } catch (err) {
         console.error(

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -127,6 +127,11 @@ async function deleteThread ({
 //   thread is still finished off: that completes the original
 //   send rather than adding a second one.
 // @param {boolean} [opts.debug]
+// @param {string} [opts.weekId] - When set, only the thread for
+//   this ISO week is considered: runs between weekly nudges must
+//   never reach across the week boundary, or a Monday-morning
+//   reconcile would append to the previous week's thread instead
+//   of leaving it for the new week's nudge.
 // @returns {Promise<{touched: number, ok: boolean}>}
 //   touched - messages written; ok - false when any write
 //   failed, so callers do not mark the thread complete on
@@ -139,11 +144,12 @@ export default async function refreshNudgeThread ({
   alerts = [],
   providedCc = null,
   silent = false,
+  weekId = null,
   debug = false
 }) {
   debug = debug === 'true' || debug === true
 
-  const parent = findRepoParent(messages, repoFullName)
+  const parent = findRepoParent(messages, repoFullName, weekId)
   if (!parent) {
     if (debug) {
       console.log(


### PR DESCRIPTION
## Root cause

Monday 2026-09-07 00:24 UTC the daily dismiss run appended medium alerts to the previous week's (W36) nudge threads hours before the W37 nudge ran (upload-settlements 5:41 PM, security-action 5:24 PM, leography 5:24 PM). Two stacked defects:

1. The dismiss action's refresh callback hand-picked its args (`({ repoFullName, alerts }) =>`), silently dropping the `silent: true` that `reconcileNudgeMessages` passes — silent maintenance has been dead in production since it landed. Uncapped, the refresh appended.
2. `findRepoParent` matches a repo's newest nudge thread of any week; inside the 8-day lookback the 6-day-old W36 thread was found and grown instead of being left for the W37 nudge.

## Changes

- `src/reconcileNudgeMessages.js` scopes its refresh callback to `weekId: isoWeekId(now)`; `src/refreshNudgeThread.js` threads the option into `findRepoParent`. Previous-week threads are never rewritten, appended to, or counted again.
- `actions/dependabot-auto-dismiss/action.cjs` forwards all refresh callback args (`(args) => refreshNudgeThread({ ... })`), restoring `silent: true` and future-proofing the seam.
- `src/postNudgeThreads.js` passes its `weekId` to refresh as well.
- Cross-week stale cleanup is preserved: a previous week's thread with no alerts left is still deleted (pinned by BDD).

## Testing

BDD-first (`features/dependabot_reconcile.feature` +2 scenarios): reconcile against a previous-week thread leaves it untouched (no posts, no parent update, no deletes, stale not deleted); previous-week thread with zero alerts left is still cleaned up.

- `pnpm test` — 71 unit + 331 BDD scenarios green
- `pnpm run coverage` — 80/80 gate passes
- `standard` clean
- Full suite green in the OrbStack Ubuntu VM