### PR TITLE
fix(nudge): group alerts per package, not per advisory

### DIFF
--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -193,12 +193,26 @@ Feature: Dependabot nudge
     When running the dependabot nudge
     Then the message for "foo" totals 2 alerts with 0 critical
 
-  Scenario: Different advisories on one package stay separate
+  Scenario: Different advisories on one package group into one issue
     Given the repository "brave/foo"
     And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-2739" with severity "medium"
     And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-9999" with severity "high"
     When running the dependabot nudge
-    Then the message for "foo" totals 2 alerts with 0 critical
+    Then the message for "foo" totals 1 alerts with 0 critical
+    And the message for "foo" contains "`high` severity"
+    And the message for "foo" contains "CVE-2026-9999" exactly 1 time
+    And the message for "foo" contains "security/dependabot/1"
+    And the message for "foo" contains "security/dependabot/2"
+    And the message for "foo" contains "Also reported at"
+
+  Scenario: Package names group case-insensitively
+    Given the repository "brave/foo"
+    And repo "foo" has an alert for package "pillow" advisory "CVE-2026-59205" with severity "high"
+    And repo "foo" has an alert for package "Pillow" advisory "CVE-2026-59199" with severity "medium"
+    When running the dependabot nudge
+    Then the message for "foo" totals 1 alerts with 0 critical
+    And the message for "foo" contains "security/dependabot/1"
+    And the message for "foo" contains "security/dependabot/2"
 
   Scenario: A duplicated critical advisory counts once
     Given the repository "brave/foo"

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -37,19 +37,19 @@ function criticalCount (alerts) {
   return alerts.filter(a => alertSeverity(a) >= Severity.critical).length
 }
 
-// Group alerts that are the same advisory on the same package.
-// Dependabot opens one alert per manifest, so a package present
-// in two lockfiles yields two alerts for a single issue; without
-// grouping the thread would show the same CVE twice (e.g. bn.js
-// CVE-2026-2739 as alerts #125 and #112). Grouping is per
-// package: the same advisory in two different packages is two
-// dependency problems, not one.
+// Group alerts by package (case-insensitive: manifests spell the
+// same PyPI/npm dependency as both "pillow" and "Pillow").
+// Dependabot opens one alert per manifest and per advisory, so a
+// package present in several lockfiles, or with several open
+// advisories, yields many alerts for a single dependency; without
+// grouping the thread would list the same dependency over and over
+// (e.g. nine Pillow entries for one upgrade). One group = one
+// maintainer action: bump the package. The same advisory in two
+// different packages stays separate: those are two upgrades.
 export function groupAlerts (alerts) {
   const groups = new Map()
   for (const alert of alerts) {
-    const key =
-      `${alert.dependency.package.name}|` +
-      `${alert.security_advisory.cve_id || alert.security_advisory.ghsa_id}`
+    const key = alert.dependency.package.name.toLowerCase()
     if (!groups.has(key)) groups.set(key, [])
     groups.get(key).push(alert)
   }
@@ -60,8 +60,8 @@ export function groupAlerts (alerts) {
 // thread parent (buildParentText), the findings in the replies.
 // Shared with the refresh path (refreshNudgeThread.js) so an
 // updated thread is rendered exactly like the original nudge.
-// Counts and entries are per unique advisory-package issue, not
-// per alert; duplicates list their extra alert URLs.
+// Counts and entries are per package, not per alert; extra
+// alerts list their URLs under the package's entry.
 export function buildRepoMessage ({ alerts }) {
   let message = ''
   const groups = groupAlerts(alerts)
@@ -89,8 +89,10 @@ export function buildRepoMessage ({ alerts }) {
     }
 
     message += `Handle this alert at ${alert.html_url}\n\n`
-    for (const extra of group.slice(1)) {
-      message += `Also reported at ${extra.html_url}\n\n`
+    for (const extra of group) {
+      if (extra !== alert) {
+        message += `Also reported at ${extra.html_url}\n\n`
+      }
     }
     message += '\n\n---\n\n'
   }


### PR DESCRIPTION
## Problem

The brave/ml-projects W37 thread listed **16 separate entries**: nine `pillow`/`Pillow` entries and three `aiohttp` entries. Each was a distinct advisory on the *same package* — the grouping key was `package|advisory`, so only same-CVE duplicates collapsed. But the maintainer action is per dependency: bump the package, and one upgrade resolves all nine Pillow alerts.

Manifests also spell dependency names with mixed case (`pillow` vs `Pillow` depending on the lockfile), so the advisory key split even identical upgrades.

## Changes

- `groupAlerts` keys on the lowercased package name. One group = one upgrade: the entry renders the worst advisory of the group and lists the other alerts under `Also reported at`; the parent count is now the number of dependencies with open alerts (ml-projects would show 5, not 16).
- Same advisory in two different packages still stays separate: two upgrades.
- Fixes a latent render bug the new scenarios caught: the extras loop sliced off the first group member while the entry renders the *worst* member — whenever the worst alert wasn't first, its URL was listed twice and the other alert was dropped.

## Testing

BDD-first: "Different advisories on one package group into one issue" (totals 1, worst severity label, both URLs, `Also reported at`) and "Package names group case-insensitively" (pillow + Pillow → 1). Red on both, green after.

- `pnpm test` — 71 unit + 330 BDD green
- `pnpm run coverage` — 80/80 gate passes
- `standard` clean; full suite green in the OrbStack Ubuntu VM