### PR TITLE
fix(nudge): count every open alert, not grouped entries

### DIFF
--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -180,7 +180,7 @@ Feature: Dependabot nudge
     And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severity "medium"
     When running the dependabot nudge
     Then the result has 1 message
-    And the message for "foo" totals 1 alerts with 0 critical
+    And the message for "foo" totals 2 alerts with 0 critical
     And the message for "foo" contains "CVE-2026-2739" exactly 1 time
     And the message for "foo" contains "Also reported at"
     And the message for "foo" contains "security/dependabot/1"
@@ -198,7 +198,7 @@ Feature: Dependabot nudge
     And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-2739" with severity "medium"
     And repo "foo" has an alert for package "bn.js" advisory "CVE-2026-9999" with severity "high"
     When running the dependabot nudge
-    Then the message for "foo" totals 1 alerts with 0 critical
+    Then the message for "foo" totals 2 alerts with 0 critical
     And the message for "foo" contains "`high` severity"
     And the message for "foo" contains "CVE-2026-9999" exactly 1 time
     And the message for "foo" contains "security/dependabot/1"
@@ -210,19 +210,27 @@ Feature: Dependabot nudge
     And repo "foo" has an alert for package "pillow" advisory "CVE-2026-59205" with severity "high"
     And repo "foo" has an alert for package "Pillow" advisory "CVE-2026-59199" with severity "medium"
     When running the dependabot nudge
-    Then the message for "foo" totals 1 alerts with 0 critical
+    Then the message for "foo" totals 2 alerts with 0 critical
     And the message for "foo" contains "security/dependabot/1"
     And the message for "foo" contains "security/dependabot/2"
 
-  Scenario: A duplicated critical advisory counts once
+  Scenario: A duplicated critical advisory counts every alert
     Given the repository "brave/foo"
     And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severity "critical"
     When running the dependabot nudge
-    Then the message for "foo" totals 1 alerts with 1 critical
+    Then the message for "foo" totals 2 alerts with 2 critical
 
   Scenario: A grouped issue shows its most severe member
     Given the repository "brave/foo"
     And repo "foo" has 2 alerts for package "bn.js" advisory "CVE-2026-2739" with severities "medium" and "critical"
     When running the dependabot nudge
-    Then the message for "foo" totals 1 alerts with 1 critical
+    Then the message for "foo" totals 2 alerts with 1 critical
     And the message for "foo" contains "`critical` severity"
+
+  Scenario: Totals stay cumulative when entries are grouped
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts for package "pillow" advisory "CVE-2026-59205" with severity "high"
+    And repo "foo" has an alert with severity "high"
+    When running the dependabot nudge
+    Then the message for "foo" totals 3 alerts with 0 critical
+    And the message for "foo" contains "CVE-2026-59205" exactly 1 time

--- a/features/dependabot_reconcile.feature
+++ b/features/dependabot_reconcile.feature
@@ -5,6 +5,8 @@ Feature: Dependabot nudge message reconciliation
   never qualifies more alerts than the nudge actually posted, and the
   run is scoped to the current nudge week: once the week has rolled
   over, last week's thread waits untouched for next week's nudge.
+  The parent's finding count always reflects the current number of
+  open alerts, never the number of grouped entries.
 
   Scenario: Reconcile uses the nudge week's severity after a month boundary
     Given the reconcile runs on 2026-09-01
@@ -32,7 +34,7 @@ Feature: Dependabot nudge message reconciliation
     And a completed nudge thread for "brave/app" built from 5 alerts
     When reconciling nudge messages
     Then no replies are posted to the thread
-    And the parent still shows 5 open Dependabot issues
+    And the parent shows 6 open Dependabot issues
 
   Scenario: Alerts resolved mid-week are trimmed silently
     Given the reconcile runs on 2026-09-01
@@ -69,7 +71,7 @@ Feature: Dependabot nudge message reconciliation
     And a legacy nudge thread for "brave/app" with one reply per alert
     When reconciling nudge messages
     Then no replies are posted to the thread
-    And the parent shows 1 open Dependabot issues
+    And the parent shows 2 open Dependabot issues
 
   Scenario: Reconcile never touches a previous week's thread
     Given the reconcile runs on 2026-09-08

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -60,8 +60,11 @@ export function groupAlerts (alerts) {
 // thread parent (buildParentText), the findings in the replies.
 // Shared with the refresh path (refreshNudgeThread.js) so an
 // updated thread is rendered exactly like the original nudge.
-// Counts and entries are per package, not per alert; extra
-// alerts list their URLs under the package's entry.
+// Entries are per package, not per alert; extra alerts list
+// their URLs under the package's entry. The counts stay
+// cumulative: they report every open alert, not the number of
+// grouped entries, so the parent count matches what Dependabot
+// itself reports.
 export function buildRepoMessage ({ alerts }) {
   let message = ''
   const groups = groupAlerts(alerts)
@@ -99,8 +102,8 @@ export function buildRepoMessage ({ alerts }) {
 
   return {
     message,
-    total: groups.length,
-    critical: criticalCount(groups.map(worstAlert))
+    total: alerts.length,
+    critical: criticalCount(alerts)
   }
 }
 

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -122,10 +122,10 @@ async function deleteThread ({
 //   weekly nudges: a completed thread (its cc reply landed)
 //   never grows, because thread replies notify everyone
 //   following the thread. Alerts added mid-week stay hidden
-//   until the next weekly nudge renders them, and the parent
-//   keeps the count of what is displayed. An incomplete
-//   thread is still finished off: that completes the original
-//   send rather than adding a second one.
+//   until the next weekly nudge renders them, while the
+//   parent's count keeps tracking every open alert. An
+//   incomplete thread is still finished off: that completes
+//   the original send rather than adding a second one.
 // @param {boolean} [opts.debug]
 // @param {string} [opts.weekId] - When set, only the thread for
 //   this ISO week is considered: runs between weekly nudges must
@@ -163,7 +163,7 @@ export default async function refreshNudgeThread ({
     web, channelId, parent.ts
   )
 
-  let { message, total, critical } =
+  const { message, total, critical } =
     buildRepoMessage({ alerts })
   let chunks = chunkNudgeMessage(message)
 
@@ -208,18 +208,14 @@ export default async function refreshNudgeThread ({
   // Between weekly nudges a completed thread must not grow:
   // every thread reply notifies the maintainers following it,
   // so a daily reconcile appending newly created alerts would
-  // turn one weekly ping into an unprompted second wave. Trim
-  // the render to what the thread already shows instead; the
-  // next weekly nudge renders the new alerts. Rewrites and
-  // deletions stay allowed: chat.update is a revision, not a
-  // delivery, so syncing existing replies never re-notifies.
+  // turn one weekly ping into an unprompted second wave. Cap
+  // the replies at what the thread already shows instead; the
+  // next weekly nudge renders the new alerts. The parent's
+  // count stays current regardless: it tracks every open
+  // alert, and chat.update is a revision, not a delivery, so
+  // rewrites, deletions and count fixes never re-notify.
   if (silent && ccReply && chunks.length > details.length) {
-    const capped = buildRepoMessage({
-      alerts: alerts.slice(0, details.length)
-    })
-    total = capped.total
-    critical = capped.critical
-    chunks = chunkNudgeMessage(capped.message)
+    chunks = chunks.slice(0, details.length)
   }
 
   let touched = 0


### PR DESCRIPTION
## Why

The parent count introduced with per-package grouping followed the grouped entries: a repo with 16 open alerts across 9 pillow manifests showed "5 open Dependabot issues" — a number that matched neither Dependabot's own count nor the reply count. The count must be the cumulative number of open alerts; the grouping belongs to the entries only.

## Changes

- `buildRepoMessage` keeps grouped entries (one per package, worst advisory rendered, extras under "Also reported at") but reports `total: alerts.length` and alert-level `criticalCount`.
- The silent refresh cap shrinks from a re-render to a plain `chunks.slice(0, details.length)`: replies never grow mid-week, while the parent count is corrected to the current total on every daily run. `chat.update` never notifies, so counts stay current with zero pings.

## Testing

BDD-first: grouping scenarios now assert cumulative totals (2 dups → "totals 2 alerts", 2 critical dups → "2 critical"); new scenario "Totals stay cumulative when entries are grouped" (3 alerts, 2 entries → totals 3); reconcile scenarios updated — mid-week growth leaves replies capped but corrects the parent to 6, and a healed legacy thread shows its 2 alerts.

- `pnpm test` — 71 unit + 333 BDD scenarios green
- `pnpm run coverage` — 80/80 gate passes
- `standard` clean
- Full suite green in the OrbStack Ubuntu VM