### PR TITLE
fix(nudge): bold summaries, no descriptions, grey dev entries

### DIFF
--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -234,3 +234,11 @@ Feature: Dependabot nudge
     When running the dependabot nudge
     Then the message for "foo" totals 3 alerts with 0 critical
     And the message for "foo" contains "CVE-2026-59205" exactly 1 time
+
+  Scenario: The cc is edited into the parent, never posted with it
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts
+    When posting the nudge thread for "brave/foo"
+    Then the parent was posted without any mentions
+    And the parent was edited to carry the cc
+    And the cc reply was posted after the parent edit

--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -262,3 +262,12 @@ Feature: Dependabot nudge
     And repo "foo" has a dev-dependency alert with severity "high"
     When posting the nudge thread for "foo"
     Then the dev alert reply is rendered in a lighter style
+
+  Scenario: The run summary reports scanned, nudged and errored repos
+    Given the org "test-org"
+    And the repository "test-org/foo"
+    And the repository "test-org/bar"
+    And repo "foo" has 2 alerts
+    And repo "bar" fails to list alerts
+    When running the dependabot nudge
+    Then the nudge run reports 2 repos scanned, 1 nudged with 2 alerts and 1 error

--- a/features/dependabot_nudge.feature
+++ b/features/dependabot_nudge.feature
@@ -238,7 +238,27 @@ Feature: Dependabot nudge
   Scenario: The cc is edited into the parent, never posted with it
     Given the repository "brave/foo"
     And repo "foo" has 2 alerts
-    When posting the nudge thread for "brave/foo"
+    When posting the nudge thread for "foo"
     Then the parent was posted without any mentions
     And the parent was edited to carry the cc
     And the cc reply was posted after the parent edit
+
+  Scenario: Entries show no truncated description
+    Given the repository "brave/foo"
+    And repo "foo" has 2 alerts
+    When building the repo message for 2 alerts
+    Then the repo message does not contain "&gt; "
+    And the repo message does not contain "..."
+
+  Scenario: The advisory summary renders bold
+    Given the repository "brave/foo"
+    And repo "foo" has an alert with severity "high"
+    When building the repo message for 1 alerts
+    Then the repo message contains "**Vulnerability 1**"
+    And the repo message does not contain "severity *Vulnerability"
+
+  Scenario: A dev-dependency entry renders in a lighter style
+    Given the repository "brave/foo"
+    And repo "foo" has a dev-dependency alert with severity "high"
+    When posting the nudge thread for "foo"
+    Then the dev alert reply is rendered in a lighter style

--- a/features/step_definitions/dependabot_nudge.steps.js
+++ b/features/step_definitions/dependabot_nudge.steps.js
@@ -8,6 +8,8 @@ import dependabotNudge, {
   buildParentBlocks,
   parentCcLine
 } from '../../src/dependabotNudge.js'
+import postNudgeThreads from '../../src/postNudgeThreads.js'
+import { PARENT_EVENT_TYPE } from '../../src/nudgeThread.js'
 
 const ACTION_PATH = fileURLToPath(new URL('../..', import.meta.url))
 
@@ -343,4 +345,51 @@ Then('the parent blocks do not contain {string}', function (text) {
 Then('the parent cc line is {string}', function (text) {
   const cc = this.parentBlocks ? parentCcLine(this.parentBlocks) : this.ccLine
   assert.equal(cc, text)
+})
+
+When('posting the nudge thread for {string}', async function (name) {
+  const repo = `${this.org}/${name}`
+  const alerts = this.alertsByRepo[repo] || []
+  const { message, total, critical } = buildRepoMessage({ alerts })
+  this.slackWeb = this.makeMockSlackWeb({})
+  await this.attempt(() => withCappedTimers(() => postNudgeThreads({
+    web: this.slackWeb,
+    channelId: 'C001',
+    org: this.org,
+    messages: [],
+    nudges: [{ repo, message, cc: 'cc <@U123>', total, critical, alerts }],
+    weekId: '2026-W37'
+  })))
+})
+
+Then('the parent was posted without any mentions', function () {
+  const posts = this.slackWeb.__recorder.find('chat.postMessage')
+  const parent = posts.find(p =>
+    p.params.metadata?.event_type === PARENT_EVENT_TYPE)
+  assert.ok(parent, 'expected a parent postMessage')
+  const text = (parent.params.blocks || [])
+    .map(b => b.text?.text || '').join('\n')
+  assert.ok(!text.includes('<@'),
+    `the parent must not mention anyone at creation: ${text}`)
+})
+
+Then('the parent was edited to carry the cc', function () {
+  const updates = this.slackWeb.__recorder.find('chat.update')
+  assert.ok(updates.length > 0, 'expected the parent to be edited')
+  const text = updates[updates.length - 1].params.blocks
+    .map(b => b.text?.text || '').join('\n')
+  assert.ok(text.includes('<@U123>'),
+    `the parent edit must carry the cc mention: ${text}`)
+})
+
+Then('the cc reply was posted after the parent edit', function () {
+  const calls = this.slackWeb.__recorder.calls
+  const updateIdx = calls.findIndex(c => c.method === 'chat.update')
+  const ccIdx = calls.findIndex(c =>
+    c.method === 'chat.postMessage' &&
+    c.params.metadata?.event_payload?.kind === 'cc')
+  assert.ok(updateIdx !== -1, 'expected a parent edit')
+  assert.ok(ccIdx !== -1, 'expected a cc reply')
+  assert.ok(updateIdx < ccIdx,
+    'the cc reply must be posted after the parent edit')
 })

--- a/features/step_definitions/dependabot_nudge.steps.js
+++ b/features/step_definitions/dependabot_nudge.steps.js
@@ -393,3 +393,26 @@ Then('the cc reply was posted after the parent edit', function () {
   assert.ok(updateIdx < ccIdx,
     'the cc reply must be posted after the parent edit')
 })
+
+Given('repo {string} has a dev-dependency alert with severity {string}', function (name, severity) {
+  const key = `${this.org}/${name}`
+  const n = (this.alertsByRepo[key]?.length || 0) + 1
+  this.alertsByRepo[key] = [
+    ...(this.alertsByRepo[key] || []),
+    this.makeDependabotAlert(n, { severity, scope: 'development' })
+  ]
+})
+
+Then('the dev alert reply is rendered in a lighter style', function () {
+  const replies = this.slackWeb.__recorder.find('chat.postMessage')
+    .filter(p => p.params.metadata?.event_payload?.kind === 'alerts')
+  assert.ok(replies.length > 0, 'expected an alert reply')
+  const blocks = replies[0].params.blocks || []
+  assert.ok(blocks.length > 0, 'expected blocks on the alert reply')
+  for (const block of blocks) {
+    assert.equal(block.type, 'context',
+      `dev alerts render as context blocks, got ${block.type}`)
+  }
+  const text = blocks.map(b => b.elements.map(e => e.text).join('')).join('')
+  assert.ok(text.includes('(dev)'), `dev reply keeps the dev marker: ${text}`)
+})

--- a/features/step_definitions/dependabot_nudge.steps.js
+++ b/features/step_definitions/dependabot_nudge.steps.js
@@ -188,15 +188,26 @@ When('running the dependabot nudge', async function () {
     }
   })
   this.github = github
-  await this.attempt(() => withCappedTimers(() => dependabotNudge({
-    org: this.org,
-    github,
-    skipRepositories: this.skipRepositories,
-    githubToSlack: this.githubToSlack,
-    singleOutputMessage: this.singleOutputMessage === true,
-    assignMaintainers: this.assignMaintainers !== false,
-    actionPath: ACTION_PATH
-  })))
+  const logs = []
+  const origLog = console.log
+  const origError = console.error
+  console.log = (...a) => logs.push(a.join(' '))
+  console.error = (...a) => logs.push(a.join(' '))
+  try {
+    await this.attempt(() => withCappedTimers(() => dependabotNudge({
+      org: this.org,
+      github,
+      skipRepositories: this.skipRepositories,
+      githubToSlack: this.githubToSlack,
+      singleOutputMessage: this.singleOutputMessage === true,
+      assignMaintainers: this.assignMaintainers !== false,
+      actionPath: ACTION_PATH
+    })))
+  } finally {
+    console.log = origLog
+    console.error = origError
+  }
+  this.nudgeLogs = logs
 })
 
 When('building the parent text for repo {string} with {int} total and {int} critical', function (repo, total, critical) {
@@ -415,4 +426,15 @@ Then('the dev alert reply is rendered in a lighter style', function () {
   }
   const text = blocks.map(b => b.elements.map(e => e.text).join('')).join('')
   assert.ok(text.includes('(dev)'), `dev reply keeps the dev marker: ${text}`)
+})
+
+Then('the nudge run reports {int} repos scanned, {int} nudged with {int} alerts and {int} error', function (scanned, nudged, alerts, errored) {
+  const summary = (this.nudgeLogs || []).find(l => l.includes('nudge summary:'))
+  assert.ok(summary, `expected a nudge summary line, got:\n${(this.nudgeLogs || []).join('\n')}`)
+  if (!new RegExp(
+    `nudge summary: scanned=${scanned} repos, ` +
+    `nudged=${nudged} \\(${alerts} alerts\\), ` +
+    `errored=${errored}`).test(summary)) {
+    assert.fail(`summary mismatch. all logs:\n${(this.nudgeLogs || []).join('\n')}`)
+  }
 })

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -118,13 +118,14 @@ export function makeDependabotAlert (n, {
   description = `# Title\n\nBad things in pkg-${n}.\n`,
   pkg = `pkg-${n}`,
   cveId = `CVE-2026-000${n}`,
-  ghsaId = `GHSA-000${n}`
+  ghsaId = `GHSA-000${n}`,
+  scope = 'runtime'
 } = {}) {
   return {
     number: n,
     html_url: `https://github.com/${repo}/security/dependabot/${n}`,
     severity,
-    dependency: { package: { name: pkg }, scope: 'runtime' },
+    dependency: { package: { name: pkg }, scope },
     security_advisory: {
       summary,
       description,

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -161,6 +161,10 @@ export default async function dependabotNudge ({
   }
 
   const messages = []
+  let scanned = 0
+  let nudged = 0
+  let alertsTotal = 0
+  let errored = 0
 
   debug = debug === 'true' || debug === true
   singleOutputMessage = singleOutputMessage === 'true' || singleOutputMessage === true
@@ -214,6 +218,10 @@ export default async function dependabotNudge ({
     if (skipRepositories.includes(repo.name)) {
       continue
     }
+
+    // Counted as scanned once its alerts are actually attempted:
+    // skipped repos never reach this point.
+    scanned++
 
     try {
       const alerts = Array.from(await github.paginate('GET /repos/{owner}/{repo}/dependabot/alerts', {
@@ -308,11 +316,23 @@ export default async function dependabotNudge ({
           critical: critLen,
           alerts
         })
+        nudged++
+        alertsTotal += alerts.length
       }
     } catch (e) {
+      errored++
       console.error(e)
     }
   }
+
+  // Always visible, even without debug: a run that silently
+  // scanned 0 repos or swallowed every fetch error (restricted
+  // token, transient API failure) would otherwise look
+  // identical to a run that legitimately found nothing.
+  console.log(
+    `nudge summary: scanned=${scanned} repos, ` +
+    `nudged=${nudged} (${alertsTotal} alerts), errored=${errored}`
+  )
 
   // Only singleOutputMessage flattens the result: debug must
   // not change the return type, or the per-repo caller ends

--- a/src/dependabotNudge.js
+++ b/src/dependabotNudge.js
@@ -4,24 +4,6 @@ import {
 } from './dependabotConstants.js'
 import { messageToBlocks } from './sendSlackMessage.js'
 
-// original code at: https://stackoverflow.com/questions/44195322/a-plain-javascript-way-to-decode-html-entities-works-on-both-browsers-and-node
-function decodeEntities (encodedString) {
-  const translateRe = /&(nbsp|amp|quot|lt|gt);/g
-  const translate = {
-    nbsp: ' ',
-    amp: '&',
-    quot: '"',
-    lt: '<',
-    gt: '>'
-  }
-  return encodedString.replace(translateRe, function (match, entity) {
-    return translate[entity]
-  }).replace(/&#(\d+);/gi, function (match, numStr) {
-    const num = parseInt(numStr, 10)
-    return String.fromCharCode(num)
-  })
-}
-
 function alertSeverity (alert) {
   return Severity[alert.security_advisory?.severity || alert.severity]
 }
@@ -72,24 +54,11 @@ export function buildRepoMessage ({ alerts }) {
   for (const group of groups) {
     const alert = worstAlert(group)
 
-    const descFirstLine = alert.security_advisory.description
-      .split('\n')
-      .filter(d => d[0] !== '#')
-      .filter(d => d.trim().length > 0)
-      .splice(0, 1)
-      .map(d => `&gt; ${decodeEntities(d).substring(0, 40)}`)
-      .shift()
-
     const devAppend = alert.dependency.scope === 'development' ? ' (dev)' : ''
 
-    message += `\`${alert.dependency.package.name}\` by \`${alert.security_advisory.cve_id || alert.security_advisory.ghsa_id}\` with a \`${alert.security_advisory.severity}\` severity *${alert.security_advisory.summary}*`
+    message += `\`${alert.dependency.package.name}\` by \`${alert.security_advisory.cve_id || alert.security_advisory.ghsa_id}\` with a \`${alert.security_advisory.severity}\` severity **${alert.security_advisory.summary}**`
     message += devAppend
     message += '\n\n'
-
-    if (descFirstLine && descFirstLine.length > 0) {
-      message += descFirstLine
-      message += '...\n\n'
-    }
 
     message += `Handle this alert at ${alert.html_url}\n\n`
     for (const extra of group) {

--- a/src/nudgeThread.js
+++ b/src/nudgeThread.js
@@ -23,6 +23,21 @@ export function findRepoParent (messages, repoFullName, weekId = null) {
     .sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts))[0]
 }
 
+// Render one findings chunk into Slack blocks. Dev-dependency
+// entries (their chunk carries the ' (dev)' marker) render as
+// context blocks — small grey text — so a dev alert is visually
+// distinct from a runtime one at a glance. Used by both the
+// posting path and the refresh path so a rewritten reply keeps
+// the exact style it was first posted with.
+export async function nudgeReplyBlocks (chunk) {
+  const blocks = await messageToBlocks(chunk)
+  if (!chunk.includes('(dev)')) return blocks
+  return blocks.map(block => ({
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text: block.text?.text || '' }]
+  }))
+}
+
 // Post one findings chunk as a thread reply. Used by both the
 // posting path and the refresh path so an appended reply is
 // shaped exactly like one from the original run.
@@ -37,7 +52,7 @@ export async function postAlertReply (
     link_names: true,
     unfurl_links: true,
     unfurl_media: true,
-    blocks: await messageToBlocks(chunk),
+    blocks: await nudgeReplyBlocks(chunk),
     metadata: {
       event_type: ALERTS_EVENT_TYPE,
       event_payload: { repo: repoFullName, kind: 'alerts' }

--- a/src/refreshNudgeThread.js
+++ b/src/refreshNudgeThread.js
@@ -19,8 +19,7 @@ import {
   buildParentBlocks,
   parentCcLine
 } from './dependabotNudge.js'
-import { messageToBlocks } from './sendSlackMessage.js'
-import { findRepoParent, postAlertReply, postCcReply } from './nudgeThread.js'
+import { findRepoParent, nudgeReplyBlocks, postAlertReply, postCcReply } from './nudgeThread.js'
 import {
   chunkNudgeMessage,
   fetchThreadReplies,
@@ -224,7 +223,7 @@ export default async function refreshNudgeThread ({
   // Rewrite the detail replies that are still needed.
   for (let i = 0; i < chunks.length && i < details.length; i++) {
     try {
-      const blocks = await messageToBlocks(chunks[i])
+      const blocks = await nudgeReplyBlocks(chunks[i])
 
       // Nothing changed for this reply: leave it as it is.
       if (


### PR DESCRIPTION
Follows #989 (merged before these commits landed on the branch — recreating them off main; also restores the cc-edited-into-parent scenario lost in the #988 squash).

## Rendering

- Truncated description lines (`&gt; …`) are gone: every alert already links to the advisory, the 40-character preview added noise.
- Advisory summaries render **bold**: the header now uses double-asterisk markdown, which survives mack as Slack bold (single asterisk degraded to italic).
- Dev-dependency entries render as Slack `context` blocks (small grey text) so dev findings are visually lighter than runtime ones. Applied in one place (`nudgeReplyBlocks` in `nudgeThread.js`) and used by both the posting path and the refresh rewrite loop, so daily maintenance re-renders match the original.

## Also

- Restores `test(nudge): pin the cc edited into the parent` (orphaned in the #988 squash): parent is posted without mentions, the cc is added by `chat.update`, and the cc reply posts only after that edit — the thread's single notification.
- Fixes that scenario's posting step, which resolved `brave/brave/foo` and passed without ever posting alert replies.

## Testing

71 unit + 337 BDD scenarios green (local + OrbStack VM), `standard` clean, coverage 80/80 gate passes.