### PR TITLE
feat(dismiss): group repeated dismissals in the summary

### DIFF
--- a/features/dependabot_dismiss.feature
+++ b/features/dependabot_dismiss.feature
@@ -60,3 +60,31 @@ Feature: Dismissing Dependabot alerts
       | 1      | Denial of service in lodash | GHSA-aa   | repo1 |
     When dismissing alerts with a missing dismiss list
     Then 1 alert is dismissed
+
+  Scenario: Repeated dismissals of one advisory in one repo group into one line
+    Given the org has open dependabot alerts
+      | 3      | qs: DoS via isBuffer in search | GHSA-aa | repo2 |
+      | 1      | qs: DoS via isBuffer in search | GHSA-aa | repo1 |
+      | 2      | qs: DoS via isBuffer in search | GHSA-aa | repo1 |
+    When dismissing alerts
+    Then the dismissal message is:
+      """
+      The following alerts were dismissed:
+
+      - [qs: DoS via isBuffer in search in `test-org/repo1`](https://github.com/test-org/repo1/dependabot/alert/1) (also in [#2](https://github.com/test-org/repo1/dependabot/alert/2))
+      - [qs: DoS via isBuffer in search in `test-org/repo2`](https://github.com/test-org/repo2/dependabot/alert/3)
+      """
+
+  Scenario: The dismissal message is sorted by package
+    Given a dismiss list file containing "GHSA-aa" and "GHSA-bb"
+    And the org has open dependabot alerts
+      | 2      | Zeta overflow in parser | GHSA-bb | repo1 |
+      | 1      | Alpha leak in transport | GHSA-aa | repo2 |
+    When dismissing alerts
+    Then the dismissal message is:
+      """
+      The following alerts were dismissed:
+
+      - [Alpha leak in transport in `test-org/repo2`](https://github.com/test-org/repo2/dependabot/alert/1)
+      - [Zeta overflow in parser in `test-org/repo1`](https://github.com/test-org/repo1/dependabot/alert/2)
+      """

--- a/features/step_definitions/dependabot_dismiss.steps.js
+++ b/features/step_definitions/dependabot_dismiss.steps.js
@@ -109,6 +109,12 @@ Then('the dismissed repos are {string}', function (repos) {
   assert.deepEqual(this.result.dismissedRepos, repos.split(','))
 })
 
+Then('the dismissal message is:', function (docstring) {
+  const actual = this.result.message.replace(/\n+$/, '')
+  const expected = docstring.replace(/\n+$/, '')
+  assert.equal(actual, expected)
+})
+
 Then('no repositories are in the dismissed list', function () {
   assert.deepEqual(this.result.dismissedRepos, [])
 })

--- a/src/dependabotDismiss.js
+++ b/src/dependabotDismiss.js
@@ -18,7 +18,7 @@ export default async function dependabotDismiss ({
   dependabotDismissConfig = 'dependabot-dismiss.txt'
 }) {
   const watermark = 'The following alerts were dismissed:\n\n'
-  let message = ''
+  const dismissed = []
   const dismissedRepos = new Set()
 
   let dependabotDismissIds = []
@@ -70,7 +70,12 @@ export default async function dependabotDismiss ({
       dismissComment += ` because the alert summary contains the hotword "${hotword}"`
     }
 
-    message += `- [${a.security_advisory.summary} in \`${org}/${a.repository.name}\`](${a.html_url})\n`
+    dismissed.push({
+      summary: a.security_advisory.summary,
+      repo: `${org}/${a.repository.name}`,
+      number: a.number,
+      html_url: a.html_url
+    })
     dismissedRepos.add(`${org}/${a.repository.name}`)
 
     if (debug) {
@@ -93,6 +98,25 @@ export default async function dependabotDismiss ({
       state: 'dismissed'
     })
   }
+
+  // One line per package+repo: repeated dismissals of the same
+  // advisory (e.g. the same manifest duplicated across lockfiles)
+  // collapse into a single bullet with back-references to the
+  // other alert numbers, and the list is sorted by summary so
+  // the same package lands in the same place every week.
+  const groups = new Map()
+  for (const d of dismissed) {
+    const key = `${d.summary.toLowerCase()}\n${d.repo}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(d)
+  }
+  const lines = [...groups.values()]
+    .map(group => group.sort((a, b) => a.number - b.number))
+    .map(([first, ...extras]) =>
+      `- [${first.summary} in \`${first.repo}\`](${first.html_url})` +
+      (extras.length > 0 ? ` (also in ${extras.map(e => `[#${e.number}](${e.html_url})`).join(', ')})` : ''))
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  const message = lines.join('\n') + (lines.length > 0 ? '\n' : '')
 
   return {
     message: message.length > 0 ? watermark + message : '',


### PR DESCRIPTION
## Why

Dismissal summaries repeated identical bullets: the same advisory frequently appears once per lockfile, so the recent run listed the same `qs` line five times across brave/stats, brave/search and brave/embed. The compacted view the user requested groups them.

## Changes

- `src/dependabotDismiss.js`: dismissals are collected and grouped per advisory + repository. One bullet per group — the first alert's link renders, and additional alerts become `(also in #N, #M)` back-references. Lines are sorted by summary (case-insensitive) so the same package lands in the same place every week.
- The dismiss-count watermark and `dismissedRepos` behavior are unchanged; the message still flows through `sendSlackMessage` (mack 50-block cap applies).

## Testing

BDD-first: two new scenarios — repeated dismissals of one advisory in one repo group into one line with `(also in #2)`, and the message sorts by package — red, then green. All 8 pre-existing dismiss scenarios unchanged and green.

- `pnpm test` — 71 unit + 340 BDD scenarios green
- `pnpm run coverage` — 80/80 gate passes
- `standard` clean
- Full suite green in the OrbStack Ubuntu VM