### PR TITLE
fix: scanners crash on stale changed-file paths

### DIFF
--- a/actions/main/action.cjs
+++ b/actions/main/action.cjs
@@ -99,8 +99,19 @@ module.exports = async ({ github, context, inputs, actionPath, core, debug = fal
     changedFiles = await pullRequestChangedFiles({ github, owner: context.repo.owner, name: context.repo.repo, prnumber: context.payload.pull_request.number })
     debugLog('Changed files:', changedFiles)
 
+    // The PR files API lists paths as a diff against the base branch head,
+    // but the runners consume the list against the checked-out merge
+    // commit. Drop paths missing from the working tree (e.g. renamed on
+    // the base branch after the pull request forked) or the scanners
+    // crash opening them. The unfiltered list stays for codeowners and
+    // modelscan, which reason about the PR rather than the working tree.
+    const { default: filterExistingFiles } = await import(`${actionPath}/src/filterExistingFiles.js`)
+    const existingFiles = filterExistingFiles(changedFiles, {
+      onDropped: missing => debugLog('Changed files missing from the checkout:', missing)
+    })
+
     // Write changed files to file
-    fs.writeFileSync(`${actionPath}/assets/all_changed_files.txt`, changedFiles.join('\0'))
+    fs.writeFileSync(`${actionPath}/assets/all_changed_files.txt`, existingFiles.join('\0'))
     debugLog('Wrote changed files to file')
   }
 

--- a/assets/scripttagextractor.py
+++ b/assets/scripttagextractor.py
@@ -40,6 +40,13 @@ class MyHTMLParser(HTMLParser):
 
 
 def main(source_file, suffix, add_suffix_to_original, dry_run=False):
+    if not path.exists(source_file):
+        # Stale paths reach all_changed_files.txt when a file was renamed or
+        # deleted on the base branch after the PR forked (the PR files API
+        # diffs against the base branch head, the checkout is the merge
+        # commit). Skip them instead of aborting the scan.
+        print("Skipping missing file:", source_file, file=stderr)
+        return
     parser = MyHTMLParser()
     with open(source_file) as original_file:
         original_file_data = original_file.read()

--- a/assets/tests/features/scripttagextractor.feature
+++ b/assets/tests/features/scripttagextractor.feature
@@ -88,3 +88,21 @@ Feature: script tag extractor
       """
     When the scripts are extracted
     Then the extracted file "page.html.extractedscript.js" does not exist
+
+  Scenario: A missing file is skipped with a warning
+    When a missing file "ghost/PageWidth.svelte" is processed
+    Then nothing is written to "ghost/PageWidth.svelte.extractedscript.js"
+    And a warning mentions "ghost/PageWidth.svelte"
+
+  Scenario: A missing file does not abort the remaining files
+    Given an HTML document
+      """
+      <html><script>a</script></html>
+      """
+    When the extractor runs over "missing.svelte,page.html"
+    Then the extractor exits successfully
+    And the extracted file "page.html.extractedscript.js" contains exactly
+      """
+      ; a
+      """
+    And a warning mentions "missing.svelte"

--- a/assets/tests/step_defs/test_scripttagextractor.py
+++ b/assets/tests/step_defs/test_scripttagextractor.py
@@ -1,4 +1,8 @@
 """pytest-bdd steps for scripttagextractor.feature"""
+import io
+import subprocess
+import sys
+
 from pytest_bdd import given, when, then, scenarios, parsers
 
 
@@ -82,3 +86,41 @@ def copied_file_contains(tmp_path, context, name, docstring):
 @then(parsers.parse('the extracted file "{name}" does not exist'))
 def extracted_file_absent(tmp_path, name):
     assert not (tmp_path / name).exists()
+
+
+@then(parsers.parse('nothing is written to "{name}"'))
+def nothing_written(tmp_path, name):
+    assert not (tmp_path / name).exists()
+
+
+# ── missing files ────────────────────────────────────────────────────────────
+
+@when(parsers.parse('a missing file "{name}" is processed'))
+def missing_file_processed(scripttagextractor, tmp_path, context, monkeypatch, name):
+    # The module binds `stderr` at import time, so capsys cannot see it;
+    # swap the module attribute instead.
+    buffer = io.StringIO()
+    monkeypatch.setattr(scripttagextractor, "stderr", buffer)
+    scripttagextractor.main(str(tmp_path / name), ".extractedscript.js", None)
+    context["stderr"] = buffer.getvalue()
+
+
+@when(parsers.parse('the extractor runs over "{file_list}"'))
+def extractor_runs(scripttagextractor, tmp_path, context, file_list):
+    proc = subprocess.run(
+        [sys.executable, scripttagextractor.__file__, *file_list.split(","),
+         "--suffix", ".extractedscript.js", "--ignore-no-files"],
+        capture_output=True, text=True, cwd=tmp_path, check=False,
+    )
+    context["returncode"] = proc.returncode
+    context["stderr"] = proc.stderr
+
+
+@then("the extractor exits successfully")
+def extractor_exits_successfully(context):
+    assert context["returncode"] == 0
+
+
+@then(parsers.parse('a warning mentions "{text}"'))
+def warning_mentions(context, text):
+    assert text in context["stderr"]

--- a/assets/tests/test_properties.py
+++ b/assets/tests/test_properties.py
@@ -150,3 +150,29 @@ def test_parser_only_reports_script_data(text):
     parser.feed(document)
     joined = "".join(s.data for s in parser.scripts)
     assert joined == text
+
+
+# ── scripttagextractor: stale paths ──────────────────────────────────────────
+
+# Relative paths that cannot escape a temporary workspace
+missing_path = st.text(
+    alphabet=string.ascii_letters + string.digits + "-_/",
+    min_size=1,
+    max_size=30,
+).filter(lambda s: not s.startswith("/") and ".." not in s.split("/"))
+
+
+@settings(max_examples=50)
+@given(paths=st.lists(missing_path, min_size=0, max_size=8, unique=True))
+def test_main_skips_stale_paths_without_raising(paths):
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        source = root / "page.html"
+        source.write_text("<html><script>a</script></html>")
+        for stale in paths:
+            scripttagextractor.main(str(root / stale), ".extractedscript.js", None)
+        # Stale paths never abort the run: the real file still extracts
+        scripttagextractor.main(str(source), ".extractedscript.js", None)
+        assert (root / "page.html.extractedscript.js").read_text() == "; a"

--- a/features/all_changed_files.feature
+++ b/features/all_changed_files.feature
@@ -1,0 +1,36 @@
+Feature: Filtering the changed files list against the checkout
+  The pull request files API lists paths as a diff against the current
+  base branch head, but the scanners consume all_changed_files.txt
+  against the checked-out merge commit. Paths that were renamed or
+  deleted on the base branch after the pull request forked are listed
+  yet absent from the working tree, and opening them crashes the
+  scanners (scripttagextractor FileNotFoundError).
+
+  Scenario: Paths missing from the checkout are dropped
+    Given a workspace containing the files "app.py,src/lib/util.svelte"
+    When filtering the changed files "app.py,src/lib/util.svelte,layouts/PageWidth.svelte"
+    Then the kept files are "app.py,src/lib/util.svelte"
+    And the dropped files are "layouts/PageWidth.svelte"
+
+  Scenario: Paths that exist in the checkout are kept in order
+    Given a workspace containing the files "b.py,a/c.js,d.svelte"
+    When filtering the changed files "b.py,a/c.js,d.svelte"
+    Then the kept files are "b.py,a/c.js,d.svelte"
+    And no files are reported as dropped
+
+  Scenario: Every path missing yields an empty list
+    Given a workspace containing the files "README.md"
+    When filtering the changed files "gone.svelte,gone.html"
+    Then the kept files are ""
+    And the dropped files are "gone.svelte,gone.html"
+
+  Scenario: An empty changed files list stays empty
+    Given a workspace containing the files "README.md"
+    When filtering an empty changed files list
+    Then the kept files are ""
+    And no files are reported as dropped
+
+  Scenario: Paths resolve relative to the workspace root
+    Given a workspace containing the files "ws/services/x.py"
+    When filtering the changed files "services/x.py" against workspace root "ws"
+    Then the kept files are "services/x.py"

--- a/features/step_definitions/all_changed_files.steps.js
+++ b/features/step_definitions/all_changed_files.steps.js
@@ -1,0 +1,52 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import assert from 'assert'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import filterExistingFiles from '../../src/filterExistingFiles.js'
+
+Given('a workspace containing the files {string}', function (filesCsv) {
+  this.workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'secact-ws-'))
+  for (const file of filesCsv.split(',')) {
+    const target = path.join(this.workspaceRoot, file)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, 'x')
+  }
+})
+
+When('filtering the changed files {string}', function (filesCsv) {
+  this.dropped = null
+  this.result = filterExistingFiles(filesCsv.split(','), {
+    workspaceRoot: this.workspaceRoot,
+    onDropped: (missing) => { this.dropped = missing }
+  })
+})
+
+When('filtering an empty changed files list', function () {
+  this.dropped = null
+  this.result = filterExistingFiles([], {
+    workspaceRoot: this.workspaceRoot,
+    onDropped: (missing) => { this.dropped = missing }
+  })
+})
+
+When('filtering the changed files {string} against workspace root {string}', function (filesCsv, root) {
+  this.dropped = null
+  this.result = filterExistingFiles(filesCsv.split(','), {
+    workspaceRoot: path.join(this.workspaceRoot, root),
+    onDropped: (missing) => { this.dropped = missing }
+  })
+})
+
+Then('the kept files are {string}', function (filesCsv) {
+  const expected = filesCsv === '' ? [] : filesCsv.split(',')
+  assert.deepEqual(this.result, expected)
+})
+
+Then('the dropped files are {string}', function (filesCsv) {
+  assert.deepEqual(this.dropped, filesCsv.split(','))
+})
+
+Then('no files are reported as dropped', function () {
+  assert.equal(this.dropped, null)
+})

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@slack/web-api": "^7.0.0",
     "@tryfabric/mack": "^1.2.1",
     "glob": "^13.0.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.2",
     "json5": "^2.2.3",
     "markdown-to-txt": "^2.0.1",
     "octokit": "^5.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.6
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -1138,8 +1138,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1947,7 +1947,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2736,7 +2736,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3124,7 +3124,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/src/filterExistingFiles.js
+++ b/src/filterExistingFiles.js
@@ -1,0 +1,31 @@
+/**
+ * Drop changed-file paths that do not exist in the checked-out working
+ * tree.
+ *
+ * The pull request files API lists paths as a diff against the current
+ * base branch head, but the scanners consume all_changed_files.txt
+ * against the checked-out merge commit. Paths that were renamed or
+ * deleted on the base branch after the pull request forked are listed
+ * yet absent from the working tree, and opening them crashes the
+ * scanners (scripttagextractor FileNotFoundError, brave/search#14979).
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+export default function filterExistingFiles (files, {
+  workspaceRoot = process.env.GITHUB_WORKSPACE || process.cwd(),
+  _fs = fs,
+  onDropped = null
+} = {}) {
+  const kept = []
+  const dropped = []
+  for (const file of files) {
+    if (_fs.existsSync(path.join(workspaceRoot, file))) {
+      kept.push(file)
+    } else {
+      dropped.push(file)
+    }
+  }
+  if (onDropped && dropped.length > 0) onDropped(dropped)
+  return kept
+}

--- a/src/filterExistingFiles.property.test.js
+++ b/src/filterExistingFiles.property.test.js
@@ -1,0 +1,92 @@
+/**
+ * Property tests for filterExistingFiles (fast-check).
+ */
+import { test } from 'node:test'
+import assert from 'assert'
+import fc from 'fast-check'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import filterExistingFiles from './filterExistingFiles.js'
+
+// Path segments without dots to avoid '.'/'..' traversal from random input
+const chars = 'abcdefghijklmnopqrstuvwxyz0123456789-_'.split('')
+const segmentArb = fc.array(fc.constantFrom(...chars), { minLength: 1, maxLength: 12 })
+  .map(segments => segments.join(''))
+const filePathArb = fc.array(segmentArb, { minLength: 1, maxLength: 5 })
+  .map(segments => segments.join('/'))
+
+function makeWorkspace (files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'secact-prop-'))
+  for (const file of files) {
+    const target = path.join(root, file)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, 'x')
+  }
+  return root
+}
+
+test('property: kept paths are an order-preserving subset of the input', async () => {
+  await fc.assert(fc.asyncProperty(
+    fc.uniqueArray(filePathArb, { minLength: 0, maxLength: 20 }),
+    async files => {
+      const root = makeWorkspace(files)
+      try {
+        const kept = filterExistingFiles(files, { workspaceRoot: root })
+        assert.deepEqual(kept, files)
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true })
+      }
+    }
+  ), { numRuns: 25 })
+})
+
+test('property: missing paths are exactly the reported drops', async () => {
+  await fc.assert(fc.asyncProperty(
+    fc.uniqueArray(filePathArb, { minLength: 2, maxLength: 20 }),
+    fc.subarray([], { minLength: 0, maxLength: 0 }),
+    async (files, _unused) => {
+      // Create only every second file; the rest are missing
+      const existing = files.filter((_, i) => i % 2 === 0)
+      const missing = files.filter((_, i) => i % 2 === 1)
+      const root = makeWorkspace(existing)
+      try {
+        let reported = null
+        const kept = filterExistingFiles(files, {
+          workspaceRoot: root,
+          onDropped: drops => { reported = drops }
+        })
+        assert.deepEqual(kept, existing)
+        assert.deepEqual(reported, missing)
+        // Partition holds: kept + dropped covers the input exactly
+        assert.equal(kept.length + missing.length, files.length)
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true })
+      }
+    }
+  ), { numRuns: 25 })
+})
+
+test('property: default workspace root honours GITHUB_WORKSPACE then cwd', async () => {
+  await fc.assert(fc.asyncProperty(filePathArb, async file => {
+    const root = makeWorkspace([file])
+    const previousCwd = process.cwd()
+    const previousWorkspace = process.env.GITHUB_WORKSPACE
+    try {
+      // GITHUB_WORKSPACE wins when set
+      process.env.GITHUB_WORKSPACE = root
+      assert.deepEqual(filterExistingFiles([file]), [file])
+      assert.deepEqual(filterExistingFiles(['nope/' + file]), [])
+      // falls back to cwd when unset
+      delete process.env.GITHUB_WORKSPACE
+      process.chdir(root)
+      assert.deepEqual(filterExistingFiles([file]), [file])
+      assert.deepEqual(filterExistingFiles(['nope/' + file]), [])
+    } finally {
+      if (previousWorkspace === undefined) delete process.env.GITHUB_WORKSPACE
+      else process.env.GITHUB_WORKSPACE = previousWorkspace
+      process.chdir(previousCwd)
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  }), { numRuns: 10 })
+})


### PR DESCRIPTION
## Root cause

The sveltegrep runner on brave/search PR #14979 died with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'services/mixer/serpkit/src/lib/components/layouts/PageWidth.svelte'
```

Chain of events:

1. PR #14979 branched from main at `8c06e9ed` — `PageWidth.svelte` existed
2. While the PR was open, main commit `b522cc7d` renamed `PageWidth.svelte` → `SerpColumns.svelte`
3. The PR files API (GraphQL) diffs against the **current base branch head**, so the old path shows up as an addition
4. `action.cjs` wrote that stale path into `all_changed_files.txt`
5. The job checked out the **merge commit**, which correctly adopts main's rename — the file does not exist in the working tree
6. `scripttagextractor.py` `open()` → `FileNotFoundError` → sveltegrep runner failed with zero findings → Slack error notification

Not sveltegrep-specific: `safesvg` (xmllint) consumes the same list and would fail the same way on stale `.html`/`.svg` paths. Any PR forked before a base-branch rename/deletion hits this.

## Changes

**Commit 1 — drop stale paths from `all_changed_files.txt`** (root fix)

- New `src/filterExistingFiles.js`: pure helper dropping paths absent from the checkout (`GITHUB_WORKSPACE`), with an `onDropped` callback for debug logging
- `actions/main/action.cjs`: the scanner list is filtered against the working tree; the in-memory list used by codeowners/modelscan stays unfiltered (they reason about the PR, not the working tree)

**Commit 2 — scripttagextractor skips missing files** (defense in depth)

- A listed file missing from the working tree warns on stderr and is skipped instead of aborting the whole sveltegrep run, so the remaining files still get scanned

## Tests

BDD-first per repo convention:

- `features/all_changed_files.feature` (5 scenarios) + fast-check property suite (order-preserving subset, drop reporting, `GITHUB_WORKSPACE`/cwd fallback) — 100% coverage of the new module
- 2 new scenarios in `assets/tests/features/scripttagextractor.feature` (direct + CLI subprocess) reproducing the production failure red-first, plus a Hypothesis property (stale paths never raise, real files still extracted)

## Verification

- `pnpm test`: 74 unit + 345 BDD scenarios pass
- `pnpm run coverage`: 80/80 gate passes, new module at 100%
- `pnpm run coverage:py`: gate passes, `scripttagextractor.py` 99% branches
- `pnpm exec standard` clean
- Full suites re-run inside an Ubuntu VM (node 22, python 3.12): all green